### PR TITLE
Crypto-specific Haskell learning resource and typos

### DIFF
--- a/docs/get-started/smart-contracts-signpost.md
+++ b/docs/get-started/smart-contracts-signpost.md
@@ -12,7 +12,7 @@ The Cardano Developer Portal covers everything that is available on the mainnet.
 Marlowe is the domain-specific language for financial contracts on Cardano. 
 Take a look at the [Marlowe Tutorial](https://alpha.marlowe.iohkdev.io/doc/marlowe/tutorials/index.html) if you want to learn Marlowe from the beginning or dive straight into the [Marlowe Playground](https://alpha.marlowe.iohkdev.io/): 
 
-[![Marlowe Playground](../../static/img/get-started/smart-contracts/marlowe-playground.jpg)](https://alpha.marlowe.iohkdev.io/).
+[![Marlowe Playground](../../static/img/get-started/smart-contracts/marlowe-playground.jpg)](https://alpha.marlowe.iohkdev.io/)
 
 Talk to others about [Marlowe on the Cardano Forum](https://forum.cardano.org/c/developers/cardano-marlowe/149) or if you prefer Telegram there is a dedicated [Marlowe Telegram Group](https://t.me/IOHK_Marlowe).
 

--- a/docs/get-started/smart-contracts-signpost.md
+++ b/docs/get-started/smart-contracts-signpost.md
@@ -31,6 +31,8 @@ Haskell is the the programming language for Plutus contracts. If you are looking
 
 Learning Haskell is made easy with this illustrated guide, one of the most engaging ways to learn this fascinating programming language.
 
+Another great learning resource is the online course [Haskell and Crypto Mongolia 2020](https://www.youtube.com/watch?v=ctfZ6DwFiPg&list=PLJ3w5xyG4JWmBVIigNBytJhvSSfZZzfTm&index=4) lectured by [Andres Löh](https://kosmikus.org/), co-founder of the Well-Typed consultancy and [Dr. Lars Brünjes](https://iohk.io/en/team/lars-brunjes), Education Director at IOHK. The course is the suggested *starting point* for Plutus Pioneers at the beginning of the [Plutus Pioneer Program](#get-started-with-the-plutus-pioneer-program). It's a 10-week, 40 hours/week deep dive into Haskell and Cryptocurrencies.  
+
 ## Get started with the Plutus pioneer program
 The Plutus pioneer program was created in order to recruit and train developers in Plutus for the Cardano ecosystem. By entering the program, you will become part of a group with early access to a set of courses that teach you the core principles of how to code in both Haskell and Plutus. It will be highly interactive, with weekly videos, exercises, and Q&A sessions and exclusive access to the creators and key experts in the language. 
 

--- a/docs/portal-style-guide.md
+++ b/docs/portal-style-guide.md
@@ -227,7 +227,7 @@ In the developer portal you will often have to display code. You can display cod
 
     ```javascript
     var s = 'JavaScript syntax highlighting';
-    alert(s);```
+    alert(s);
     ```
 
 ```javascript


### PR DESCRIPTION
suggesting to add [this](https://www.youtube.com/watch?v=ctfZ6DwFiPg&list=PLJ3w5xyG4JWmBVIigNBytJhvSSfZZzfTm&index=2) Haskell course to the Getting Started with Haskell section.  A very challenging.course but more aimed at Blockchain Developers than Learn You A Haskell

...and two typos