### PR TITLE
Update CardanoSharp build statuses for developers

### DIFF
--- a/docs/get-started/cardanosharp-wallet.md
+++ b/docs/get-started/cardanosharp-wallet.md
@@ -7,7 +7,7 @@ image: ./img/og-developer-portal.png
 --- 
 
 # CardanoSharp.Wallet 
-[![Build status](https://ci.appveyor.com/api/projects/status/knh87k86mf7gbxyo?svg=true)](https://ci.appveyor.com/project/nothingalike/cardanosharp-wallet) [![Test status](https://img.shields.io/appveyor/tests/nothingalike/cardanosharp-wallet)](https://ci.appveyor.com/project/nothingalike/cardanosharp-wallet) [![NuGet Version](https://img.shields.io/nuget/v/CardanoSharp.Wallet.svg?style=flat)](https://www.nuget.org/packages/CardanoSharp.Wallet/) ![NuGet Downloads](https://img.shields.io/nuget/dt/CardanoSharp.Wallet.svg)
+[![Build status](https://ci.appveyor.com/api/projects/status/knh87k86mf7gbxyo?svg=true)](https://ci.appveyor.com/project/nothingalike/cardanosharp-wallet/branch/main) [![Test status](https://img.shields.io/appveyor/tests/nothingalike/cardanosharp-wallet)](https://ci.appveyor.com/project/nothingalike/cardanosharp-wallet/branch/main) [![NuGet Version](https://img.shields.io/nuget/v/CardanoSharp.Wallet.svg?style=flat)](https://www.nuget.org/packages/CardanoSharp.Wallet/) ![NuGet Downloads](https://img.shields.io/nuget/dt/CardanoSharp.Wallet.svg)
 
 CardanoSharp Wallet is a .NET library for Creating/Managing Wallets and Building/Signing Transactions.
 


### PR DESCRIPTION
## Quickfix

Build statuses were misleading. I don't want developers thinking the project is failing. Updated indicators to point to main branch where packages are being built. This will be more accurate. 