### PR TITLE
Add testnet faucet

### DIFF
--- a/docs/get-started/testnets-and-devnets.md
+++ b/docs/get-started/testnets-and-devnets.md
@@ -20,6 +20,9 @@ Test ada is worth nothing. With it you can safely perform all tests free of char
 
 To get free test ada, you need to visit the [Cardano testnet faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet/). 
 
+## Where to get a testnet wallet?
+- [Daedalus testnet](https://testnets.cardano.org/en/testnets/cardano/get-started/wallet/) is the testnet version of Daedalus wallet.
+
 ## What kind of monitoring tools are available for the testnet?
 - [Grafana dashboard](https://monitoring.cardano-testnet.iohkdev.io/grafana/d/Oe0reiHef/cardano-application-metrics-v2?orgId=1&refresh=1m&from=now-7d&to=now) provides many health metrics.
 - [tokentool.io](https://tokentool.io) lists all native tokens on mainnet and testnet.

--- a/docs/get-started/testnets-and-devnets.md
+++ b/docs/get-started/testnets-and-devnets.md
@@ -18,7 +18,7 @@ Because the Cardano testnet is an independent network, separate from the Cardano
 ## Where to get test ada?
 Test ada is worth nothing. With it you can safely perform all tests free of charge - the reason why you want to develop on the testnet. 
 
-To get free test ada, you need to visit the [Cardano testnet faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet/). 
+To get free test ada, you need to visit the [Cardano testnet faucet](../integrate-cardano/testnet-faucet). 
 
 ## Where to get a testnet wallet?
 - [Daedalus testnet](https://testnets.cardano.org/en/testnets/cardano/get-started/wallet/) is the testnet version of Daedalus wallet.

--- a/docs/integrate-cardano/creating-wallet-faucet.md
+++ b/docs/integrate-cardano/creating-wallet-faucet.md
@@ -201,9 +201,9 @@ You should see something like this:
 
 Now you might find it odd that there is not much information in the result that was returned the command, but that is totally normal as there are no available **UTXO** in the specific **wallet address** that we have queried just yet as it is a new wallet.
 
-Our next step is to request some `tADA` from the [Cardano Testnet Faucet](https://developers.cardano.org/en/testnets/cardano/tools/faucet).
+Our next step is to request some `tADA` from the [Cardano Testnet Faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet).
 
-Once you requested some `tADA` from the [Cardano Testnet Faucet](https://developers.cardano.org/en/testnets/cardano/tools/faucet) we can then run the query again and you should see something like this:
+Once you requested some `tADA` from the [Cardano Testnet Faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet) we can then run the query again and you should see something like this:
 
 ```
                            TxHash                                 TxIx        Amount
@@ -278,7 +278,7 @@ cardano-cli query utxo \
 
 Again, this is to be expected as the `payment2.addr` wallet address and keys has just recently been generated. So we expect that no one has sent any `tADA` to this wallet yet.
 
-In this example, we now have two wallets. We can call them `payment1` and `payment2`. Now remember that we requested some `tADA` from the [Cardano Testnet Faucet](https://developers.cardano.org/en/testnets/cardano/tools/faucet) for `payment1` wallet, and thats how we have the following:
+In this example, we now have two wallets. We can call them `payment1` and `payment2`. Now remember that we requested some `tADA` from the [Cardano Testnet Faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet) for `payment1` wallet, and thats how we have the following:
 
 `payment1` **wallet**: `1,000,000,000 lovelace`
 
@@ -756,9 +756,9 @@ It is important to note that the parameter of this request is the **wallet id** 
 
 We are basically querying the first wallet address that has not been used just yet, Indicated by `state: "unused"`. As we can see the wallet address value is: `addr_test1qpnjt8umuwr5f2y59avklhu8hd7h2uf4zfanxxr4nmqqsaw679hxgdmrtsjequ8ka27rm8366e6p7au9y89h6slmrjwskfmcef`
 
-Now we can finally request some `tADA` for the wallet address from the [Cardano Testnet Faucet](https://developers.cardano.org/en/testnets/cardano/tools/faucet).
+Now we can finally request some `tADA` for the wallet address from the [Cardano Testnet Faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet).
 
-Once you requested some `tADA` from the [Cardano Testnet Faucet](https://developers.cardano.org/en/testnets/cardano/tools/faucet), we can then check if it has arrived into our wallet like so:
+Once you requested some `tADA` from the [Cardano Testnet Faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet), we can then check if it has arrived into our wallet like so:
 
 ```bash
 curl --request GET \
@@ -784,7 +784,7 @@ You should see something like this:
 }
 ```
 
-As we can see here we have a total of `1,000,000,000 lovelace` available to spend that we received from the [Cardano Testnet Faucet](https://developers.cardano.org/en/testnets/cardano/tools/faucet).
+As we can see here we have a total of `1,000,000,000 lovelace` available to spend that we received from the [Cardano Testnet Faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet).
 
 #### Creating simple transactions
 

--- a/docs/integrate-cardano/creating-wallet-faucet.md
+++ b/docs/integrate-cardano/creating-wallet-faucet.md
@@ -201,9 +201,9 @@ You should see something like this:
 
 Now you might find it odd that there is not much information in the result that was returned the command, but that is totally normal as there are no available **UTXO** in the specific **wallet address** that we have queried just yet as it is a new wallet.
 
-Our next step is to request some `tADA` from the [Cardano Testnet Faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet).
+Our next step is to request some `tADA` from the [Cardano Testnet Faucet](../integrate-cardano/testnet-faucet).
 
-Once you requested some `tADA` from the [Cardano Testnet Faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet) we can then run the query again and you should see something like this:
+Once you requested some `tADA` from the [Cardano Testnet Faucet](../integrate-cardano/testnet-faucet) we can then run the query again and you should see something like this:
 
 ```
                            TxHash                                 TxIx        Amount
@@ -278,7 +278,7 @@ cardano-cli query utxo \
 
 Again, this is to be expected as the `payment2.addr` wallet address and keys has just recently been generated. So we expect that no one has sent any `tADA` to this wallet yet.
 
-In this example, we now have two wallets. We can call them `payment1` and `payment2`. Now remember that we requested some `tADA` from the [Cardano Testnet Faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet) for `payment1` wallet, and thats how we have the following:
+In this example, we now have two wallets. We can call them `payment1` and `payment2`. Now remember that we requested some `tADA` from the [Cardano Testnet Faucet](../integrate-cardano/testnet-faucet) for `payment1` wallet, and thats how we have the following:
 
 `payment1` **wallet**: `1,000,000,000 lovelace`
 
@@ -756,9 +756,9 @@ It is important to note that the parameter of this request is the **wallet id** 
 
 We are basically querying the first wallet address that has not been used just yet, Indicated by `state: "unused"`. As we can see the wallet address value is: `addr_test1qpnjt8umuwr5f2y59avklhu8hd7h2uf4zfanxxr4nmqqsaw679hxgdmrtsjequ8ka27rm8366e6p7au9y89h6slmrjwskfmcef`
 
-Now we can finally request some `tADA` for the wallet address from the [Cardano Testnet Faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet).
+Now we can finally request some `tADA` for the wallet address from the [Cardano Testnet Faucet](../integrate-cardano/testnet-faucet).
 
-Once you requested some `tADA` from the [Cardano Testnet Faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet), we can then check if it has arrived into our wallet like so:
+Once you requested some `tADA` from the [Cardano Testnet Faucet](../integrate-cardano/testnet-faucet), we can then check if it has arrived into our wallet like so:
 
 ```bash
 curl --request GET \
@@ -784,7 +784,7 @@ You should see something like this:
 }
 ```
 
-As we can see here we have a total of `1,000,000,000 lovelace` available to spend that we received from the [Cardano Testnet Faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet).
+As we can see here we have a total of `1,000,000,000 lovelace` available to spend that we received from the [Cardano Testnet Faucet](../integrate-cardano/testnet-faucet).
 
 #### Creating simple transactions
 

--- a/docs/integrate-cardano/listening-for-payments-cli.md
+++ b/docs/integrate-cardano/listening-for-payments-cli.md
@@ -784,7 +784,7 @@ You should see the **wallet address** value:
 addr_test1vpfkp665a6wn7nxvjql5vdn5g5a94tc22njf4lf98afk6tgnz5ge4
 ```
 
-Now simply send atleast `1,000,000 lovelace` to this **wallet address** or request some `test ADA` funds from the [Cardano Testnet Faucet](https://developers.cardano.org/en/testnets/cardano/tools/faucet). Once complete, we can now run the code again and we should see a succesful result this time.
+Now simply send atleast `1,000,000 lovelace` to this **wallet address** or request some `test ADA` funds from the [Cardano Testnet Faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet). Once complete, we can now run the code again and we should see a succesful result this time.
 
 <Tabs
   defaultValue="js"

--- a/docs/integrate-cardano/listening-for-payments-cli.md
+++ b/docs/integrate-cardano/listening-for-payments-cli.md
@@ -784,7 +784,7 @@ You should see the **wallet address** value:
 addr_test1vpfkp665a6wn7nxvjql5vdn5g5a94tc22njf4lf98afk6tgnz5ge4
 ```
 
-Now simply send atleast `1,000,000 lovelace` to this **wallet address** or request some `test ADA` funds from the [Cardano Testnet Faucet](https://testnets.cardano.org/en/testnets/cardano/tools/faucet). Once complete, we can now run the code again and we should see a succesful result this time.
+Now simply send atleast `1,000,000 lovelace` to this **wallet address** or request some `test ADA` funds from the [Cardano Testnet Faucet](../integrate-cardano/testnet-faucet). Once complete, we can now run the code again and we should see a succesful result this time.
 
 <Tabs
   defaultValue="js"

--- a/docs/integrate-cardano/listening-for-payments-wallet.md
+++ b/docs/integrate-cardano/listening-for-payments-wallet.md
@@ -197,7 +197,7 @@ var resp = await http.PostAsJsonAsync("wallets", new {
 
 #### Get unused wallet address to receive some payments
 
-We will get a **wallet address** to show to the customers and for them to send payments to the wallet. In this case we can use the address to request some `tADA` from the [Cardano Testnet Faucet](https://developers.cardano.org/en/testnets/cardano/tools/faucet) and simulate a payment:
+We will get a **wallet address** to show to the customers and for them to send payments to the wallet. In this case we can use the address to request some `tADA` from the [Cardano Testnet Faucet](../integrate-cardano/testnet-faucet) and simulate a payment:
 
 <Tabs
   defaultValue="js"
@@ -586,7 +586,7 @@ The code is telling us that our current wallet has received a total of `0 lovela
 
 What we can do to simulate a succesful payment is to send atleast `1,000,000 lovelace` into the **wallet address** that we have just generated for this project. We show how you can get the **wallet address** via code in the examples above.
 
-Now simply send atleast `1,000,000 lovelace` to this **wallet address** or request some `test ADA` funds from the [Cardano Testnet Faucet](https://developers.cardano.org/en/testnets/cardano/tools/faucet). Once complete, we can now run the code again and we should see a succesful result this time.
+Now simply send atleast `1,000,000 lovelace` to this **wallet address** or request some `test ADA` funds from the [Cardano Testnet Faucet](../integrate-cardano/testnet-faucet). Once complete, we can now run the code again and we should see a succesful result this time.
 
 <Tabs
   defaultValue="js"

--- a/docs/integrate-cardano/testnet-faucet.md
+++ b/docs/integrate-cardano/testnet-faucet.md
@@ -1,0 +1,26 @@
+---
+id: testnet-faucet
+title: Testnet Faucet
+sidebar_label: Testnet Faucet
+description: Request some test ada (tAda) from the Cardano testnet faucet.
+image: ./img/og-developer-portal.png
+--- 
+
+The testnet faucet is a service that provides test ada (tAda) to users of the Cardano testnet. These tokens have no value, but they enable users to experiment with Cardano testnet features without spending real ada on the mainnet. You can use test ada to [mint native tokens](../native-tokens/minting), to [play around with Cardano wallets](creating-wallet-faucet) or to [learn how to operate a stake pool](../operate-a-stake-pool/).
+
+## How to get test ada
+1. Default funds are in `tAda`. If you'd like to test the native token functionality, select `Testcoin` from the dropdown menu.
+1. Enter the address of the account where you want to top up funds.
+1. If you have been issued with an API key, please enter this to access any additional funds you may have been allocated.
+1. Confirm the `I'm not a robot` box and solve the captcha if needed.
+1. Click on `Request` and the funds will be in the testnet account you specified within a few minutes. Use the [Cardano testnet explorer](https://explorer.cardano-testnet.iohkdev.io/) in case you want to check any transactions on the Cardano testnet.
+
+<div id="faucetcontainer">
+<iframe name="iframe" height="300" width="100%" scrolling="no" src="https://testnets.cardano.org/en/testnets/cardano/tools/faucet/" class="faucet"></iframe>
+</div>
+
+
+
+:::note Return the test ada
+Please return your test ada once you are done with testing so that other members of the community can use them. Send your test tokens to this address: `addr_test1qqr585tvlc7ylnqvz8pyqwauzrdu0mxag3m7q56grgmgu7sxu2hyfhlkwuxupa9d5085eunq2qywy7hvmvej456flknswgndm3`
+:::

--- a/docs/native-tokens/minting.md
+++ b/docs/native-tokens/minting.md
@@ -169,7 +169,7 @@ address=$(cat payment.addr)
 Submitting transactions always require you to pay a fee. Sending native assets requires also requires sending at least 1 ada.  
 So make sure the address you are going to use as the input for the minting transaction has sufficient funds. 
 
-For the **testnet**, you can request funds through the [faucet](https://developers.cardano.org/en/testnets/cardano/tools/faucet/).
+For the **testnet**, you can request funds through the [testnet faucet](../integrate-cardano/testnet-faucet).
 
 ### Export protocol parameters
 

--- a/docs/transaction-metadata/how-to-create-a-metadata-transaction-cli.md
+++ b/docs/transaction-metadata/how-to-create-a-metadata-transaction-cli.md
@@ -55,7 +55,7 @@ cardano-cli address build \
 --testnet-magic 1097911063
 ```
 
-Now that you have a **wallet address**, you can now request some `tADA` funds from the **Testnet Faucet**. @TODO
+Now that you have a **wallet address**, you can now request some `tADA` funds from the [testnet faucet](../integrate-cardano/testnet-faucet). 
 
 Once you have some funds, we can now create the sample metadata that we want to store into the blockchain.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -44,7 +44,8 @@ module.exports = {
       "integrate-cardano/creating-wallet-faucet",
       "integrate-cardano/multi-witness-transactions-cli",
       "integrate-cardano/listening-for-payments-cli",
-      "integrate-cardano/listening-for-payments-wallet"
+      "integrate-cardano/listening-for-payments-wallet",
+      "integrate-cardano/testnet-faucet",
     ],
     "Build with Transaction Metadata": [
       "transaction-metadata/overview",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -85,3 +85,29 @@ html[data-theme='dark'] .header-github-link:before {
 .header-github-link:hover {
   opacity: 0.6;
 }
+
+div#faucetcontainer {
+  width:500px;  /* defines the visible width of the part */
+  height:500px; /* defines the visible height of the part */
+  overflow:hidden;     
+  overflow-x:hidden;   
+
+  /* resize and min-height are optional, allows user to resize viewable area */
+  -webkit-resize:vertical; 
+  -moz-resize:vertical;
+  resize:vertical;
+  min-height:317px;
+}
+
+.faucet {
+  border: 0px none; 
+  width:960px;        /* set to approximate width of the faucet page */
+  height:1750px;      /* determines where the bottom of the page cuts off */
+  margin-left:-300px; /* defines the left clipping of the faucet page */
+  margin-top:-1270px; /* defines the top clipping of the faucet page */
+  overflow:hidden;
+
+  -webkit-resize:none;
+  -moz-resize:none;
+  resize:none;
+}


### PR DESCRIPTION
## Testnet faucet

This PR integrates the testnet faucet in the developer portal for UX reasons. It seems a bit hacky as it has to do this with an iframe but is currently the only way to realize this.