### PR TITLE
doc fix: add missing backslash from code example

### DIFF
--- a/docs/get-started/running-cardano.md
+++ b/docs/get-started/running-cardano.md
@@ -78,7 +78,7 @@ To run `cardano-node` you enter something like this into the terminal:
    --database-path path/to/db \
    --socket-path path/to/db/node.socket \
    --host-addr x.x.x.x \
-   --port 3001 
+   --port 3001 \
    --config path/to/mainnet-config.json
 ```
 


### PR DESCRIPTION
## Updating documentation

Added `\` to example code block in `docs/get-started/running-cardano.md`.
