### PR TITLE
Fix spelling of 'metadata'

### DIFF
--- a/src/data/showcases.js
+++ b/src/data/showcases.js
@@ -137,7 +137,7 @@ const Showcases = [
   {
     title: "Cardano Wall",
     description:
-      "Demonstrates serveral use cases for transaction metdata. You can sign messages and create proof of existence for files.",
+      "Demonstrates serveral use cases for transaction metadata. You can sign messages and create proof of existence for files.",
     preview: require("./showcase/cardanowall.png"),
     website: "https://cardanowall.com/en/explore/",
     source: null,


### PR DESCRIPTION
Typo: changed "metdata" to "metadata"