### PR TITLE
Correct "Minting" Link  under Setup

### DIFF
--- a/docs/native-tokens/minting-nfts.md
+++ b/docs/native-tokens/minting-nfts.md
@@ -103,7 +103,7 @@ We recommend upload images to IPFS as it is the most common decentralized storag
 :::
 
 ## Setup
-Since the creation of native assets is documented extensively in the [minting](minting-nfts.md) chapter, we won't go into much detail here.
+Since the creation of native assets is documented extensively in the [minting](minting.md) chapter, we won't go into much detail here.
 Here's a little recap and needed setup
 
 ### Working directory


### PR DESCRIPTION
## Updating documentation

#### Description of the change
This "Minting" link in the setup section of the "minting NFTs " page currently just reloads that page, my guess is the author meant to link it back to the "minting native assets" page which is what I've done w/ this pull request. 

