### PR TITLE
iFrame is not big enough for Test Faucet

### DIFF
--- a/docs/integrate-cardano/testnet-faucet.md
+++ b/docs/integrate-cardano/testnet-faucet.md
@@ -16,7 +16,7 @@ The testnet faucet is a service that provides test ada (tAda) to users of the Ca
 1. Click on `Request` and the funds will be in the testnet account you specified within a few minutes. Use the [Cardano testnet explorer](https://explorer.cardano-testnet.iohkdev.io/) in case you want to check any transactions on the Cardano testnet.
 
 <div id="faucetcontainer">
-<iframe name="iframe" height="300" width="100%" scrolling="no" src="https://testnets.cardano.org/en/testnets/cardano/tools/faucet/" class="faucet"></iframe>
+<iframe name="iframe" height="750" width="100%" scrolling="yes" src="https://testnets.cardano.org/en/testnets/cardano/tools/faucet/" class="faucet"></iframe>
 </div>
 
 


### PR DESCRIPTION


## Updating documentation

#### Issue
Right now you cannot access the test faucet from https://developers.cardano.org/docs/integrate-cardano/testnet-faucet/ because the iframe isn't big enough. 

#### Description of the change
I've taken a guess at the correct size, and enable scrolling to address the issue (I can't fully test it because I don't know how to build the docs site locally).
