### PR TITLE
Add explorer link and made them both English

### DIFF
--- a/docs/native-tokens/minting.md
+++ b/docs/native-tokens/minting.md
@@ -114,7 +114,7 @@ We will be using this technique of setting variables along the way to make it ea
 
 ### Check your node status
 
-We also want to check if our Node is up to date. To do that, we check the current epoch/block and compare it to the current value displayed in the [Cardano Explorer for the testnet](https://explorer.cardano-testnet.iohkdev.io/de.html).
+We also want to check if our Node is up to date. To do that, we check the current epoch/block and compare it to the current value displayed in the [Cardano Explorer for the testnet](https://explorer.cardano-testnet.iohkdev.io/en).
 
 ```bash
 cardano-cli query tip --$testnet
@@ -131,7 +131,7 @@ Should give you an output like this
 }
 ```
 
-Epoch and slot number should match when being compared to the Cardano Explorer for testnet.
+Epoch and slot number should match when being compared to the Cardano [Explorer for testnet](https://explorer.cardano-testnet.iohkdev.io/en)
 
 ![img](../../static/img/nfts/cardano_explorer_testnet.png)
 


### PR DESCRIPTION
There is a link to the explorer above, but not actually in the step where you need to access the explorer. Added a link to make it a bit easier for users to follow along in case they missed the link previously. Also, I switched both links to the English landing page vs German since the tutorial is in English.

## Updating documentation
Added additional explorer link and changed both to the English version

#### Description of the change
On the [minting main tutorial](https://developers.cardano.org/docs/native-tokens/minting) there is a link to the explorer at the start of the "Check Your Node Status" section, but not actually in the step where you need to access the explorer. Added a link there to make it a bit easier for users to follow along in case they missed the link previously. Also, I switched both links to the English landing page vs German since the tutorial is in English.

