### PR TITLE
Update setting ~/.local/bin/ in PATH

### DIFF
--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -210,7 +210,7 @@ cp -p "$(./scripts/bin-path.sh cardano-cli)" ~/.local/bin/
 We have to add this line below our shell profile so that the shell/terminal can recognize that `cardano-node` and `cardano-cli` are global commands. (`~/.zshrc` or `~/.bashrc` ***depending on the shell application you use***)
 
 ```bash
-export PATH="~/.local/bin/:$PATH"
+export PATH="$HOME/.local/bin/:$PATH"
 ```
 
 Once saved, reload your shell profile by typing `source ~/.zshrc` or `source ~/.bashrc` (***depending on the shell application you use***).


### PR DESCRIPTION
---

## Updating documentation

#### Description of the change

When using WSL on Windows (with ZSH), following the [installation guide](https://developers.cardano.org/docs/get-started/installing-cardano-node/) leaves me unable to run the `cardano-cli` or `cardano-node` commands from the shell unless I am inside the `~/.local/bin` folder. Despite the `$PATH `appearing to include  the `~/.local/bin` folder from my home directory, I receive an error from ZSH that the command was not found. 

```
echo $PATH | grep /.local/bin
~/.local/bin/:...
```

I can successfully run the command inside the directory using:

```
cd ~/.local/bin
./cardano-cli --version
```

I believe the use of the `~` expansion in the export command in my shell profile is causing issues, and the fix is to replace `~/` with the `$HOME`. This produces the following output in the `$PATH` (where peteski is my username):

```
echo $PATH | grep /.local/bin
/home/peteski/.local/bin/:...
```

After restarting WSL or running `source ~/.zshrc` I am now able to reference the commands anywhere.

[Related information on tilde expansion](https://unix.stackexchange.com/questions/146671/does-always-equal-home/146697#146697)

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->


#### Description

Changed reference to using `~/` to using `$HOME` for `$PATH` export of `~/.local/bin`

---

## Quickfix