### PR TITLE
Removing the random constraint for building wallet

### DIFF
--- a/docs/get-started/installing-cardano-wallet.md
+++ b/docs/get-started/installing-cardano-wallet.md
@@ -71,7 +71,7 @@ You can check the latest available version / tag by visiting the `cardano-wallet
 We explicitly use the `ghc` version that we installed earlier. This avoids defaulting to a system version of `ghc` that might be newer or older than the one you have installed.
 
 ```bash
-cabal configure --with-compiler=ghc-8.10.4 --constraint="random<1.2"
+cabal configure --with-compiler=ghc-8.10.4 
 ```
 
 #### Building and installing the node


### PR DESCRIPTION
## Updating documentation

#### Issue

Building the wallet with `--constraint="random<1.2"` results in:

```
Building library for cardano-wallet-core-2021.9.9..
[59 of 95] Compiling Cardano.Wallet.DB.Sqlite.Types ( src/Cardano/Wallet/DB/Sqlite/Types.hs, /home/cardano/cardano-src/cardano-wallet/dist-newstyle/build/x86_64-linux/ghc-8.10.7/cardano-wallet-core-2021.9.9/build/Cardano/Wallet/DB/Sqlite/Types.o, /home/cardano/cardano-src/cardano-wallet/dist-newstyle/build/x86_64-linux/ghc-8.10.7/cardano-wallet-core-2021.9.9/build/Cardano/Wallet/DB/Sqlite/Types.dyn_o )

src/Cardano/Wallet/DB/Sqlite/Types.hs:122:1: error:
    Could not load module ‘System.Random.Internal’
    It is a member of the hidden package ‘random-1.2.0’.
    Perhaps you need to add ‘random’ to the build-depends in your .cabal file.
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
    |
122 | import System.Random.Internal
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
cabal: Failed to build cardano-wallet-core-2021.9.9 (which is required by
exe:local-cluster from cardano-wallet-2021.9.9, test:integration from
cardano-wallet-2021.9.9 and others).
```



Issue here: https://github.com/input-output-hk/cardano-wallet/issues/2824
Raising this PR to discuss as I don't understand the significance of removing the constraint.

Versions:
* cardano-wallet tag v2021-09-09
* cabal-install version 3.4.0.0
* compiled using version 3.4.0.0 of the Cabal library
* The Glorious Glasgow Haskell Compilation System, version 8.10.7
* Ubuntu 20.04.3 LTS

#### Description of the change

Removing: `--constraint="random<1.2"`