### PR TITLE
Use `HydraBuildList` to provide latest release binaries (with fallback)

### DIFF
--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -15,7 +15,7 @@ This guide will show you how to compile and install the `cardano-node` and `card
 If you want to avoid compiling the binaries yourself, you can download the latest versions of `cardano-node` and `cardano-cli` from the links below.
 
 <HydraBuildList
-    latest="740846"
+    latest="7408469"
     linux="7408438"
     macos="7408630"
     win64="7408538"/>

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -13,9 +13,9 @@ This guide will show you how to compile and install the `cardano-node` and `card
 :::note
 If you want to avoid compiling the binaries yourself, You can download the latest pre-built binaries of `cardano-node` and `cardano-cli` from the links below. 
 
-- [Linux](https://hydra.iohk.io/build/6263009)
-- [MacOS](https://hydra.iohk.io/build/6263000)
-- [Windows](https://hydra.iohk.io/build/6263143)
+- [Linux](https://hydra.iohk.io/job/Cardano/cardano-node/cardano-node-linux/latest-finished)
+- [MacOS](https://hydra.iohk.io/job/Cardano/cardano-node/cardano-node-macos/latest-finished)
+- [Windows](https://hydra.iohk.io/job/Cardano/cardano-node/cardano-node-win64/latest-finished)
 
 The components can be built and run on **Windows** and **MacOS**, but we recommend that stake pool operators use **Linux** in production to take advantage of the associated performance advantages.
 :::

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -5,17 +5,20 @@ sidebar_label: Installing cardano-node
 description: This guide shows how to build and install the cardano-node and cardano-cli from the source-code for all major Operating Systems
 image: ./img/og-developer-portal.png
 --- 
+import HydraBuildList from '@site/src/components/docs/HydraBuildList';
 
-### Overview 
+### Overview
 
 This guide will show you how to compile and install the `cardano-node` and `cardano-cli` into your operating system of choice, directly from the source-code. It will enable you to interact with the **Cardano** blockchain, including but not limited to sending/receiving **transactions**, creating **NFTs**, posting transaction **metadata** into the blockchain, minting/burning **native tokens**, creating a **stake pool**, executing **smart contracts**, and so much more!
 
 :::note
-If you want to avoid compiling the binaries yourself, You can download the latest pre-built binaries of `cardano-node` and `cardano-cli` from the links below. 
+If you want to avoid compiling the binaries yourself, you can download the latest versions of `cardano-node` and `cardano-cli` from the links below.
 
-- [Linux](https://hydra.iohk.io/job/Cardano/cardano-node/cardano-node-linux/latest-finished)
-- [MacOS](https://hydra.iohk.io/job/Cardano/cardano-node/cardano-node-macos/latest-finished)
-- [Windows](https://hydra.iohk.io/job/Cardano/cardano-node/cardano-node-win64/latest-finished)
+<HydraBuildList
+    latest="740846"
+    linux="7408438"
+    macos="7408630"
+    win64="7408538"/>
 
 The components can be built and run on **Windows** and **MacOS**, but we recommend that stake pool operators use **Linux** in production to take advantage of the associated performance advantages.
 :::

--- a/src/components/docs/HydraBuildList/index.js
+++ b/src/components/docs/HydraBuildList/index.js
@@ -32,6 +32,9 @@ class HydraBuildList extends React.Component {
                 let latest = link.match(/\d+.*/) + "#tabs-constituents"
                 this.setState({ ...this.state.latest, latest })
             })
+            .catch(err => {
+                this.setState({err,isLoading: false})
+            })
     }
     render() {
         return (

--- a/src/components/docs/HydraBuildList/index.js
+++ b/src/components/docs/HydraBuildList/index.js
@@ -13,6 +13,7 @@ class HydraBuildList extends React.Component {
         super()
         this.state = {
             isCurrent: false,
+            hasErrors: false,
             latest: latest,
             linux: linux,
             macos: macos,
@@ -33,7 +34,7 @@ class HydraBuildList extends React.Component {
                 this.setState({ ...this.state.latest, latest })
             })
             .catch(err => {
-                this.setState({err,isLoading: false})
+                this.setState({err, hasErrors: true})
             })
     }
     render() {

--- a/src/components/docs/HydraBuildList/index.js
+++ b/src/components/docs/HydraBuildList/index.js
@@ -1,0 +1,52 @@
+import React from "react";
+
+export const BuildLink = ({ children, id }) => (
+    <a href={"https://hydra.iohk.io/build/" + id}>{children}</a>
+);
+
+export const BuildListItem = ({ children, id }) => (
+    <li><BuildLink id={id}>{children}</BuildLink></li>
+);
+
+class HydraBuildList extends React.Component {
+    constructor({ latest, linux, macos, win64 }) {
+        super()
+        this.state = {
+            isCurrent: false,
+            latest: latest,
+            linux: linux,
+            macos: macos,
+            win64: win64
+        };
+    }
+    componentDidMount() {
+        fetch('https://api.github.com/repos/input-output-hk/cardano-node/releases/latest')
+            .then(resp => resp.json())
+            .then(json => json.body.match(/.*Hydra binaries]\((.*)#tabs-constituents\).*/)[1])
+            .then(link => {
+                let isCurrent = link.match(/\d+/) == this.state.latest
+                this.setState({ ...this.state.isCurrent, isCurrent })
+                return link
+            })
+            .then(link => {
+                let latest = link.match(/\d+.*/) + "#tabs-constituents"
+                this.setState({ ...this.state.latest, latest })
+            })
+    }
+    render() {
+        return (
+            <>
+                <ul>
+                    <BuildListItem id={this.state.linux}>Linux</BuildListItem>
+                    <BuildListItem id={this.state.macos}>MacOS</BuildListItem>
+                    <BuildListItem id={this.state.win64}>Windows</BuildListItem>
+                </ul>
+                {!this.state.isCurrent
+                    ? (<p>There are newer binaries available: <ul><BuildListItem id={this.state.latest}>latest release</BuildListItem></ul></p>) : (<></>)
+                }
+            </>
+        );
+    }
+}
+
+export default HydraBuildList;


### PR DESCRIPTION
## Updating documentation

#### Issue

Fixes #299 

#### Description of the change

I updated the links adding the `latest-finished` route to always use the latest pre-built binary (as stated in the NOTE)

These links resolve to the following `build ids` 

- [Linux](https://hydra.iohk.io/build/7630428): `https://hydra.iohk.io/build/7630428`
- [MacOS](https://hydra.iohk.io/build/7630460): `https://hydra.iohk.io/build/7630460`
- [Windows](https://hydra.iohk.io/build/7630442): `https://hydra.iohk.io/build/7630442`

Not sure if we should use them instead and *lock* the versions advertised in the admonition to v1.29... 

I'll update the links accordingly if you guys think the build ids are a better solution. 