### PR TITLE
minor bug

### DIFF
--- a/docs/transaction-metadata/overview.md
+++ b/docs/transaction-metadata/overview.md
@@ -62,7 +62,7 @@ However, according to your requirements, if your application uses floating-point
         "int": 14
     },
     "2": {
-        "bytes": "2512a00e9653fe49a44a5886202e24d77eeb998f"
+        "bytes": "0x2512a00e9653fe49a44a5886202e24d77eeb998f"
     },
     "3": {
         "list": [


### PR DESCRIPTION
added the 0x prefix, which is needed for the CLI to recognize the string as a byte array