### PR TITLE
Change witness count to 2 for minting transactions

### DIFF
--- a/docs/native-tokens/minting-nfts.md
+++ b/docs/native-tokens/minting-nfts.md
@@ -388,7 +388,7 @@ As with every other transaction, we need to calculate the fee and the output and
 
 Use this command to set the <i>$fee</i> variable.
 ```bash
-fee=$(cardano-cli transaction calculate-min-fee --tx-body-file matx.raw --tx-in-count 1 --tx-out-count 1 --witness-count 1 --mainnet --protocol-params-file protocol.json | cut -d " " -f1)
+fee=$(cardano-cli transaction calculate-min-fee --tx-body-file matx.raw --tx-in-count 1 --tx-out-count 1 --witness-count 2 --mainnet --protocol-params-file protocol.json | cut -d " " -f1)
 ```
 
 And this command calculates the correct value for <i>$output</i>.
@@ -474,7 +474,7 @@ The minting parameter is now called with a negative value, therefore destroying 
 Calculate the fee to burn the token.
 
 ```bash
-burnfee=$(cardano-cli transaction calculate-min-fee --tx-body-file burning.raw --tx-in-count 1 --tx-out-count 1 --witness-count 1 --mainnet --protocol-params-file protocol.json | cut -d " " -f1)
+burnfee=$(cardano-cli transaction calculate-min-fee --tx-body-file burning.raw --tx-in-count 1 --tx-out-count 1 --witness-count 2 --mainnet --protocol-params-file protocol.json | cut -d " " -f1)
 ```
 
 Calculate the leftovers/output.


### PR DESCRIPTION
You sign with payment key and policy key, so I guess the witness count should be 2 for those transactions instead of 1?