### PR TITLE
Update installing-cardano-node.md MacOS update

### DIFF
--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -395,7 +395,7 @@ cp -p "$(./scripts/bin-path.sh cardano-cli)" ~/.local/bin/
 We have to add this line below our shell profile so that the shell/terminal can recognize that `cardano-node` and `cardano-cli` are global commands. (`~/.zshrc` or `~/.bashrc` ***depending on the shell application you use***)
 
 ```bash
-export PATH="~/.local/bin/:$PATH"
+export PATH="$HOME/.local/bin/:$PATH"
 ```
 
 Once saved, reload your shell profile by typing `source ~/.zshrc` or `source ~/.bashrc` (***depending on the shell application you use***).


### PR DESCRIPTION
## Updating documentation

#### Description of the change

`export PATH="~/.local/bin/:$PATH"` didn't work with me on Mac OSX 11.5.2 running zsh, since my .zshrc didn't recognize `~` as $HOME. Instead, it worked with `export PATH="$HOME/.local/bin/:$PATH"` which I believe should work for others as well.

An alternative update to instructions could be to specify that `export PATH="$HOME/.local/bin/:$PATH"` could work if `export PATH="~/.local/bin/:$PATH"` does not.

So it saves time for anyone debugging why running `cardano-cli --version` doesn't work.