### PR TITLE
Update node checkout references, replace home directory references

### DIFF
--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -31,6 +31,10 @@ To set up the components, you will need:
 * A **CPU** with at least **two** cores
 * **8GB** of RAM and at least **10GB** of free disk space
 
+:::note
+If intending to connect to mainnet instance, the requirements for RAM and storage would increase beyond baselines above.
+:::
+
 ### Choose your Platform
 
 * [Linux](#linux)
@@ -132,8 +136,8 @@ Please confirm that the versions you have installed match the recommended versio
 Let's create a working directory to store the source-code and builds for the components.
 
 ```bash
-mkdir -p ~/cardano-src
-cd ~/cardano-src
+mkdir -p $HOME/cardano-src
+cd $HOME/cardano-src
 ```
 Next, we will download, compile and install `libsodium`.
 
@@ -147,19 +151,19 @@ make
 sudo make install
 ```
 
-Then we will add the following environment variables to your shell profile. E.G `~/.zshrc` or `~/.bashrc` depending on what shell application you are using. Add the following to the bottom of your shell profile/config file so that the compiler can be aware that `libsodium` is installed on your system.
+Then we will add the following environment variables to your shell profile. E.G `$HOME/.zshrc` or `$HOME/.bashrc` depending on what shell application you are using. Add the following to the bottom of your shell profile/config file so that the compiler can be aware that `libsodium` is installed on your system.
 
 ```bash
 export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 ```
 
-Once saved, we will then reload your shell profile to use the new variables. We can do that by typing `source ~/.bashrc` or `source ~/.zshrc` (***depending on the shell application you use***).
+Once saved, we will then reload your shell profile to use the new variables. We can do that by typing `source $HOME/.bashrc` or `source $HOME/.zshrc` (***depending on the shell application you use***).
 
 Now we are ready to download, compile and install `cardano-node` and `cardano-cli`. But first, we have to make sure we are back at the root of our working directory:
 
 ```bash
-cd ~/cardano-src
+cd $HOME/cardano-src
 ```
 
 Download the `cardano-node` repository: 
@@ -172,11 +176,11 @@ git fetch --all --recurse-submodules --tags
 Switch the repository to the latest tagged commit: 
 
 ```bash
-git checkout tags/1.27.0
+git checkout $(curl -s https://api.github.com/repos/input-output-hk/cardano-node/releases/latest | jq -r .tag_name)
 ```
 
 :::important
-You can check the latest available version/tag by visiting the `cardano-node` [Github Release](https://github.com/input-output-hk/cardano-node/releases) page. At the time of writing this, the current version is `1.27.0`.
+If upgrading an existing node, please ensure that you have read the [release notes on GitHub](https://github.com/input-output-hk/cardano-node/releases) for any changes.
 :::
 
 #### Configuring the build options
@@ -187,13 +191,6 @@ We explicitly use the `ghc` version that we installed earlier. This avoids defau
 cabal configure --with-compiler=ghc-8.10.4
 ```
 
-Update the local project file to use `libsodium` that you installed earlier.
-
-```bash
-echo "package cardano-crypto-praos" >>  cabal.project.local
-echo "  flags: -external-libsodium-vrf" >>  cabal.project.local
-```
-
 #### Building and installing the node
 
 We can now build the `Haskell-based` `cardano-node` to produce executable binaries.
@@ -202,21 +199,21 @@ We can now build the `Haskell-based` `cardano-node` to produce executable binari
 cabal build all
 ```
 
-Install the newly built node and CLI commands to the ~/.local/bin directory:
+Install the newly built node and CLI commands to the $HOME/.local/bin directory:
 
 ```bash
-mkdir -p ~/.local/bin
-cp -p "$(./scripts/bin-path.sh cardano-node)" ~/.local/bin/
-cp -p "$(./scripts/bin-path.sh cardano-cli)" ~/.local/bin/
+mkdir -p $HOME/.local/bin
+cp -p "$(./scripts/bin-path.sh cardano-node)" $HOME/.local/bin/
+cp -p "$(./scripts/bin-path.sh cardano-cli)" $HOME/.local/bin/
 ```
 
-We have to add this line below our shell profile so that the shell/terminal can recognize that `cardano-node` and `cardano-cli` are global commands. (`~/.zshrc` or `~/.bashrc` ***depending on the shell application you use***)
+We have to add this line below our shell profile so that the shell/terminal can recognize that `cardano-node` and `cardano-cli` are global commands. (`$HOME/.zshrc` or `$HOME/.bashrc` ***depending on the shell application you use***)
 
 ```bash
-export PATH="~/.local/bin/:$PATH"
+export PATH="$HOME/.local/bin/:$PATH"
 ```
 
-Once saved, reload your shell profile by typing `source ~/.zshrc` or `source ~/.bashrc` (***depending on the shell application you use***).
+Once saved, reload your shell profile by typing `source $HOME/.zshrc` or `source $HOME/.bashrc` (***depending on the shell application you use***).
 
 Check the version that has been installed:
 ```
@@ -265,7 +262,6 @@ Use the following command to install `ghcup`
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 ```
 Please follow the instructions and provide the necessary input to the installer. Once complete, you should have `ghc` and `cabal` installed on your system.
-
 
 :::note
 `ghcup` will try to detect your shell and will ask you to add it to the environment variables. Please restart your shell/terminal after installing `ghcup`
@@ -317,8 +313,8 @@ Please confirm that the versions you have installed matches the recommended vers
 Let's create a working directory to store the source-code and builds for the components.
 
 ```bash
-mkdir -p ~/cardano-src
-cd ~/cardano-src
+mkdir -p $HOME/cardano-src
+cd $HOME/cardano-src
 ```
 Next, we will download, compile and install `libsodium`.
 
@@ -332,19 +328,19 @@ make
 sudo make install
 ```
 
-Then we will add the following environment variables to your shell profile. E.G `~/.zshrc` or `~/.bashrc` depending on what shell application you are using. Add the following to the bottom of your shell profile/config file so the compiler can be aware that `libsodium` is installed on your system.
+Then we will add the following environment variables to your shell profile. E.G `$HOME/.zshrc` or `$HOME/.bashrc` depending on what shell application you are using. Add the following to the bottom of your shell profile/config file so the compiler can be aware that `libsodium` is installed on your system.
 
 ```bash
 export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 ```
 
-Once saved, we will then reload your shell profile to use the new variables. We can do that by typing `source ~/.bashrc` or `source ~/.zshrc` (***depending on the shell application you use***).
+Once saved, we will then reload your shell profile to use the new variables. We can do that by typing `source $HOME/.bashrc` or `source $HOME/.zshrc` (***depending on the shell application you use***).
 
 Now we are ready to download, compile and install `cardano-node` and `cardano-cli`. But first, we have to make sure we are back at the root of our working directory:
 
 ```bash
-cd ~/cardano-src
+cd $HOME/cardano-src
 ```
 
 Download the `cardano-node` repository: 
@@ -357,11 +353,11 @@ git fetch --all --recurse-submodules --tags
 Switch the repository to the latest tagged commit: 
 
 ```bash
-git checkout tags/1.27.0
+git checkout $(curl -s https://api.github.com/repos/input-output-hk/cardano-node/releases/latest | jq -r .tag_name)
 ```
 
 :::important
-You can check the latest available version / tag by visiting the `cardano-node` [Github Release](https://github.com/input-output-hk/cardano-node/releases) page. At the time of writing this, the current version is `1.27.0`.
+If upgrading an existing node, please ensure that you have read the [release notes on GitHub](https://github.com/input-output-hk/cardano-node/releases) for any changes.
 :::
 
 ##### Configuring the build options
@@ -372,33 +368,26 @@ We explicitly use the `ghc` version that we installed earlier. This avoids defau
 cabal configure --with-compiler=ghc-8.10.4
 ```
 
-Update the local project file to use `libsodium` that you installed earlier.
-
-```bash
-echo "package cardano-crypto-praos" >>  cabal.project.local
-echo "  flags: -external-libsodium-vrf" >>  cabal.project.local
-```
-
 #### Building and installing the node
 ```bash
 cabal build all
 ```
 
-Install the newly built node and CLI to the ~/.local/bin directory:
+Install the newly built node and CLI to the $HOME/.local/bin directory:
 
 ```bash
-mkdir -p ~/.local/bin
-cp -p "$(./scripts/bin-path.sh cardano-node)" ~/.local/bin/
-cp -p "$(./scripts/bin-path.sh cardano-cli)" ~/.local/bin/
+mkdir -p $HOME/.local/bin
+cp -p "$(./scripts/bin-path.sh cardano-node)" $HOME/.local/bin/
+cp -p "$(./scripts/bin-path.sh cardano-cli)" $HOME/.local/bin/
 ```
 
-We have to add this line below our shell profile so that the shell/terminal can recognize that `cardano-node` and `cardano-cli` are global commands. (`~/.zshrc` or `~/.bashrc` ***depending on the shell application you use***)
+We have to add this line below our shell profile so that the shell/terminal can recognize that `cardano-node` and `cardano-cli` are global commands. (`$HOME/.zshrc` or `$HOME/.bashrc` ***depending on the shell application you use***)
 
 ```bash
-export PATH="~/.local/bin/:$PATH"
+export PATH="$HOME/.local/bin/:$PATH"
 ```
 
-Once saved, reload your shell profile by typing `source ~/.zshrc` or `source ~/.bashrc` (***depending on the shell application you use***).
+Once saved, reload your shell profile by typing `source $HOME/.zshrc` or `source $HOME/.bashrc` (***depending on the shell application you use***).
 
 Check the version that has been installed:
 ```

--- a/docs/get-started/installing-cardano-wallet.md
+++ b/docs/get-started/installing-cardano-wallet.md
@@ -41,11 +41,11 @@ In this section, we will walk you through the process of downloading, compiling 
 
 #### Downloading & Compiling
 
-If you have followed the [Installing cardano-node](/docs/get-started/installing-cardano-node) guide, You should have the `~/cardano-src` directory. If not, let's create a working directory to store the source-code and build for `cardano-wallet`.
+If you have followed the [Installing cardano-node](/docs/get-started/installing-cardano-node) guide, You should have the `$HOME/cardano-src` directory. If not, let's create a working directory to store the source-code and build for `cardano-wallet`.
 
 ```bash
-mkdir -p ~/cardano-src
-cd ~/cardano-src
+mkdir -p $HOME/cardano-src
+cd $HOME/cardano-src
 ```
 
 Next we download the `cardano-wallet` source-code: 
@@ -81,7 +81,7 @@ We can now build `cardano-wallet` code to produce executable binaries.
 ```bash
 cabal build all
 ```
-Install the newly built `cardano-wallet` binary to the `~/.local/bin` directory:
+Install the newly built `cardano-wallet` binary to the `$HOME/.local/bin` directory:
 <Tabs
   defaultValue="macos"
   values={[
@@ -92,7 +92,7 @@ Install the newly built `cardano-wallet` binary to the `~/.local/bin` directory:
 
 ###### MacOS
 ```bash
-cp -p "dist-newstyle/build/x86_64-osx/ghc-8.10.4/cardano-wallet-2021.5.26/x/cardano-wallet/build/cardano-wallet/cardano-wallet" ~/.local/bin/
+cp -p "dist-newstyle/build/x86_64-osx/ghc-8.10.4/cardano-wallet-2021.5.26/x/cardano-wallet/build/cardano-wallet/cardano-wallet" $HOME/.local/bin/
 ```
 
 </TabItem>
@@ -101,7 +101,7 @@ cp -p "dist-newstyle/build/x86_64-osx/ghc-8.10.4/cardano-wallet-2021.5.26/x/card
 
 ###### Linux
 ```bash
-cp -p "dist-newstyle/build/x86_64-linux/ghc-8.10.4/cardano-wallet-2021.5.26/x/cardano-wallet/build/cardano-wallet/cardano-wallet" ~/.local/bin/
+cp -p "dist-newstyle/build/x86_64-linux/ghc-8.10.4/cardano-wallet-2021.5.26/x/cardano-wallet/build/cardano-wallet/cardano-wallet" $HOME/.local/bin/
 ```
 
 </TabItem>

--- a/docs/get-started/running-cardano.md
+++ b/docs/get-started/running-cardano.md
@@ -132,23 +132,23 @@ Available options:
 ### cardano-node parameters
 
 :::note
-In this section, we will use the path `/home/user/cardano` to store all the `cardano-node` related files as an example, and please replace it with the directory you have chosen to store the files.
+In this section, we will use the path `$HOME/cardano` to store all the `cardano-node` related files as an example, and please replace it with the directory you have chosen to store the files.
 :::
 We will focus on six key command-line parameters for running a node: 
 
 **`--topology`**: This requires the path of the `topology.json` file that you have downloaded as instructed [above](/docs/get-started/running-cardano#configuration-files).
 
-> For example, If you have downloaded the `topology.json` file to the path `/home/user/cardano/topology.json`, then the argument would be something like this:
+> For example, If you have downloaded the `topology.json` file to the path `$HOME/cardano/topology.json`, then the argument would be something like this:
 ```
---topology /home/user/cardano/topology.json
+--topology $HOME/cardano/topology.json
 ```
 
 **`--database-path`**: This expects the path to a directory where we will store the actual blockchain data like **blocks**, **transactions**, **metadata**, and other data type that people stored in the **Cardano** blockchain. We explore how we can query those kinds of data in the cardano-db-sync section. ***@TODO: link to the cardano-db-sync section.***
 
-> For example, if we decide that all files required by `cardano-node` will be in the path `/home/user/cardano/`. Then we could create a database directory like this, `mkdir -p /home/user/cardano/db`.
+> For example, if we decide that all files required by `cardano-node` will be in the path `$HOME/cardano/`. Then we could create a database directory like this, `mkdir -p $HOME/cardano/db`.
 > The directory structure would then be something like this:
 ```
-/home/user/cardano/
+$HOME/cardano/
 ├── db
 ├── testnet-alonzo-genesis.json
 ├── testnet-byron-genesis.json
@@ -157,9 +157,9 @@ We will focus on six key command-line parameters for running a node:
 └── testnet-topology.json
 1 directory, 4 files
 ```
-> As you may have noticed, we are planning to run a `testnet` node in this example and have downloaded the configuration files into the `/home/user/cardano/` directory. We also see that we have created the `db` directory inside `/home/user/cardano/` successfully. The argument would look something like this: 
+> As you may have noticed, we are planning to run a `testnet` node in this example and have downloaded the configuration files into the `$HOME/cardano/` directory. We also see that we have created the `db` directory inside `$HOME/cardano/` successfully. The argument would look something like this: 
 ```
---database-path /home/user/cardano/db
+--database-path $HOME/cardano/db
 ```
 > Please download and move the configuration files to your Cardano directory as shown above to continue following this guide.
 
@@ -169,7 +169,7 @@ We will focus on six key command-line parameters for running a node:
 > 
 > Here is an example `--socket-path` argument for **Linux**:
 ```
---socket-path /home/user/cardano/db/node.socket
+--socket-path $HOME/cardano/db/node.socket
 ```
 > As you can see, the argument points to a file since **unix sockets** are represented as files (like everything else in **Linux**). In this case, we put the socket file in the `db` directory that we have just created before.
 > 
@@ -197,7 +197,7 @@ We will focus on six key command-line parameters for running a node:
 **`--config`**: This expects the path to the main configuration file that we have downloaded previously.
 > Here is an example `--config` argument:
 ```
---config /home/user/cardano/testnet-config.json
+--config $HOME/cardano/testnet-config.json
 ```
 > Please make sure that the `alonzo-genesis.json`, `byron-genesis.json` and `shelley-genesis.json` are in the same directory as the `config.json`.
 
@@ -205,12 +205,12 @@ Here is a realistic example for running `cardano-node`:
 
 ```bash
 cardano-node run \
---config /home/user/cardano/testnet-config.json \
---database-path /home/user/cardano/db/ \
---socket-path /home/user/cardano/db/node.socket \
+--config $HOME/cardano/testnet-config.json \
+--database-path $HOME/cardano/db/ \
+--socket-path $HOME/cardano/db/node.socket \
 --host-addr 127.0.0.1 \
 --port 1337 \
---topology /home/user/cardano/testnet-topology.json
+--topology $HOME/cardano/testnet-topology.json
 ```
 
 If you have everything set correctly, you should see something like this:
@@ -219,7 +219,7 @@ If you have everything set correctly, you should see something like this:
 Listening on http://127.0.0.1:12798
 [cardano.node.networkMagic:Notice:5] [2021-05-20 12:17:10.02 UTC] NetworkMagic 1097911063
 [cardano.node.basicInfo.protocol:Notice:5] [2021-05-20 12:17:10.02 UTC] Byron; Shelley
-[cardano.node.basicInfo.version:Notice:5] [2021-05-20 12:17:10.02 UTC] 1.27.0
+[cardano.node.basicInfo.version:Notice:5] [2021-05-20 12:17:10.02 UTC] 1.XX.X
 [cardano.node.basicInfo.commit:Notice:5] [2021-05-20 12:17:10.02 UTC] 9a7331cce5e8bc0ea9c6bfa1c28773f4c5a7000f
 [cardano.node.basicInfo.nodeStartTime:Notice:5] [2021-05-20 12:17:10.02 UTC] 2021-05-20 12:17:10.024924 UTC
 [cardano.node.basicInfo.systemStartTime:Notice:5] [2021-05-20 12:17:10.02 UTC] 2019-07-24 20:20:16 UTC
@@ -252,13 +252,13 @@ Syncing the blockchain from zero can take a while. Please be patient. If you wan
 
 Now that we have `cardano-node` running and syncing, we can test it out by querying the blockchain tip data; which is the current point your local node is synced. To do this, we use the `cardano-cli` command-line application.
 
-But before we can do that, `cardano-cli` and other **Cardano** software components need to know where the node socket file is located. We saved it to the path `/home/user/cardano/db/node.socket` in the previous example. The components read the shell environment variable `CARDANO_NODE_SOCKET_PATH` to find this.
+But before we can do that, `cardano-cli` and other **Cardano** software components need to know where the node socket file is located. We saved it to the path `$HOME/cardano/db/node.socket` in the previous example. The components read the shell environment variable `CARDANO_NODE_SOCKET_PATH` to find this.
 
-So we will set that in `~/.bashrc` or `~/.zshrc`, depending on which shell application that you use. In Windows, you can follow this guide: [How to Set Environment Variable in Windows](https://phoenixnap.com/kb/windows-set-environment-variable).
+So we will set that in `$HOME/.bashrc` or `$HOME/.zshrc`, depending on which shell application that you use. In Windows, you can follow this guide: [How to Set Environment Variable in Windows](https://phoenixnap.com/kb/windows-set-environment-variable).
 
 Add this line to the bottom of your shell profile (**MacOS** and **Linux**):
 ```
-export CARDANO_NODE_SOCKET_PATH="/home/user/cardano/db/node.socket"
+export CARDANO_NODE_SOCKET_PATH="$HOME/cardano/db/node.socket"
 ```
 
 Once saved, reload your shell/terminal for changes to take effect.

--- a/docs/integrate-cardano/creating-wallet-faucet.md
+++ b/docs/integrate-cardano/creating-wallet-faucet.md
@@ -58,7 +58,7 @@ As mentioned before, in this guide we will only be focusing on the `cardano-cli`
 #### Creating a wallet with `cardano-cli`
 
 :::note
-In this section, We will use the path `/home/user/cardano` to store all the `cardano-cli` related files as an example, please replace it with the directory you have choosen to store the files.
+In this section, We will use the path `$HOME/cardano` to store all the `cardano-cli` related files as an example, please replace it with the directory you have choosen to store the files.
 :::
 
 :::important
@@ -72,17 +72,17 @@ In a production environment, it might not be a good idea to store wallets / keys
 First, lets create a directory to store all our `keys` like so:
 
 ```bash
-mkdir -p /home/user/cardano/keys
+mkdir -p $HOME/cardano/keys
 ```
 
-Make sure we are inside the `keys` directory like so: `cd /home/user/cardano/keys`
+Make sure we are inside the `keys` directory like so: `cd $HOME/cardano/keys`
 
 Next, we generate our **payment key-pair** using `cardano-cli`:
 
 ```bash
 cardano-cli address key-gen \
---verification-key-file /home/user/cardano/keys/payment1.vkey \
---signing-key-file /home/user/cardano/keys/payment1.skey
+--verification-key-file $HOME/cardano/keys/payment1.vkey \
+--signing-key-file $HOME/cardano/keys/payment1.skey
 ```
 
 `cardano-cli address key-gen` : generates a **payment key-pair**.
@@ -94,7 +94,7 @@ cardano-cli address key-gen \
 You should now have two files in your `keys` directory like so: 
 
 ```bash
-/home/user/cardano/keys/
+$HOME/cardano/keys/
 ├── payment1.skey
 └── payment1.vkey
 
@@ -129,8 +129,8 @@ Since we now have our **payment key-pair**, the next step would be to generate a
 
 ```bash
 cardano-cli address build \
---payment-verification-key-file /home/user/cardano/keys/payment1.vkey \
---out-file /home/user/cardano/keys/payment1.addr \
+--payment-verification-key-file $HOME/cardano/keys/payment1.vkey \
+--out-file $HOME/cardano/keys/payment1.addr \
 --testnet-magic 1097911063
 ```
 
@@ -145,7 +145,7 @@ cardano-cli address build \
 You should now have `payment1.vkey`, `payment1.skey` and `payment1.addr` in your `keys` directory. It should look something like this:
 
 ```bash
-/home/user/cardano/keys/
+$HOME/cardano/keys/
 ├── payment1.addr
 ├── payment1.skey
 └── payment1.vkey
@@ -176,14 +176,14 @@ Now that we have a **wallet address**, we can then query the **UTXO** of the add
 ```bash
 cardano-cli query utxo \
 --testnet-magic 1097911063 \
---address $(cat /home/user/cardano/keys/payment1.addr)
+--address $(cat $HOME/cardano/keys/payment1.addr)
 ```
 
 - `cardano-cli query utxo` : Queries the wallet address **UTXO**.
 
 - `--testnet-magic 1097911063` : Specifies that we want to query the `testnet` **Cardano** network.
 
-- `--address $(cat /home/user/cardano/keys/payment1.addr)` : The **wallet address** string value that we want to query, In this case we read the contents of `/home/user/cardano/keys/payment1.addr` using the `cat` command and we pass that value to the `--address` flag. That means you could also directly paste the **wallet address** value like so: 
+- `--address $(cat $HOME/cardano/keys/payment1.addr)` : The **wallet address** string value that we want to query, In this case we read the contents of `$HOME/cardano/keys/payment1.addr` using the `cat` command and we pass that value to the `--address` flag. That means you could also directly paste the **wallet address** value like so: 
 ```
 --address addr_test1vz95zjvtwm9u9mc83uzsfj55tzwf99fgeyt3gmwm9gdw2xgwrvsa5
 ```
@@ -232,22 +232,22 @@ To have a clearer understanding of how sending transactions work using `cardano-
 **Generate payment key-pair**
 ```bash
 cardano-cli address key-gen \
---verification-key-file /home/user/cardano/keys/payment2.vkey \
---signing-key-file /home/user/cardano/keys/payment2.skey 
+--verification-key-file $HOME/cardano/keys/payment2.vkey \
+--signing-key-file $HOME/cardano/keys/payment2.skey 
 ```
 
 **Generate wallet address**
 ```bash
 cardano-cli address build \
---payment-verification-key-file /home/user/cardano/keys/payment2.vkey \
---out-file /home/user/cardano/keys/payment2.addr \
+--payment-verification-key-file $HOME/cardano/keys/payment2.vkey \
+--out-file $HOME/cardano/keys/payment2.addr \
 --testnet-magic 1097911063
 ```
 
 Once complete you should have the following directory structure:
 
 ```bash
-/home/user/cardano/keys
+$HOME/cardano/keys
 ├── payment1.addr
 ├── payment1.skey
 ├── payment1.vkey
@@ -263,7 +263,7 @@ Querying the **UTXO** for the second wallet `payment2.addr` should give you a fa
 ```bash
 cardano-cli query utxo \
 --testnet-magic 1097911063 \
---address $(cat /home/user/cardano/keys/payment2.addr)
+--address $(cat $HOME/cardano/keys/payment2.addr)
 ```
 
 **UTXO Result**
@@ -300,7 +300,7 @@ We start by storing the current on-chain protocol parameters to a **JSON** file:
 ```bash
 cardano-cli query protocol-parameters \
   --testnet-magic 1097911063 \
-  --out-file /home/user/cardano/protocol.json
+  --out-file $HOME/cardano/protocol.json
 ```
 This will produce a **JSON** file that looks something like this:
 ```json
@@ -338,10 +338,10 @@ Next, we create a draft transaction like so:
 ```bash
 cardano-cli transaction build-raw \
 --tx-in cf3cf4850c8862f2d698b2ece926578b3815795c9e38d2f907280f02f577cf85#0 \
---tx-out $(cat /home/user/cardano/keys/payment2.addr)+0 \
---tx-out $(cat /home/user/cardano/keys/payment1.addr)+0 \
+--tx-out $(cat $HOME/cardano/keys/payment2.addr)+0 \
+--tx-out $(cat $HOME/cardano/keys/payment1.addr)+0 \
 --fee 0 \
---out-file /home/user/cardano/tx.draft
+--out-file $HOME/cardano/tx.draft
 ```
 
 `cardano-cli transaction build-raw` : This tells `cardano-cli` to build a raw transaction.
@@ -358,12 +358,12 @@ In this case, we are just building a draft transaction to calculate how much fee
 
 ```bash
 cardano-cli transaction calculate-min-fee \
---tx-body-file /home/user/cardano/tx.draft \
+--tx-body-file $HOME/cardano/tx.draft \
 --tx-in-count 1 \
 --tx-out-count 2 \
 --witness-count 1 \
 --testnet-magic 1097911063 \
---protocol-params-file /home/user/cardano/protocol.json
+--protocol-params-file $HOME/cardano/protocol.json
 ```
 
 You should see something like this for the output: 
@@ -374,7 +374,7 @@ You should see something like this for the output:
 
 You will notice that we use the `protocol.json` we queried awhile ago to calculate the transaction fee:
 ```
---protocol-params-file /home/user/cardano/protocol.json
+--protocol-params-file $HOME/cardano/protocol.json
 ```
 
 That is because the transaction fee calculation results changes depending on the on-chain protocol parameters.
@@ -386,10 +386,10 @@ We can then finally build the real transaction like so:
 ```bash
 cardano-cli transaction build-raw \
 --tx-in cf3cf4850c8862f2d698b2ece926578b3815795c9e38d2f907280f02f577cf85#0 \
---tx-out $(cat /home/user/cardano/keys/payment2.addr)+250000000 \
---tx-out $(cat /home/user/cardano/keys/payment1.addr)+749825831 \
+--tx-out $(cat $HOME/cardano/keys/payment2.addr)+250000000 \
+--tx-out $(cat $HOME/cardano/keys/payment1.addr)+749825831 \
 --fee 174169 \
---out-file /home/user/cardano/tx.draft
+--out-file $HOME/cardano/tx.draft
 ```
 
 To recap, We want to send `250,000,000 lovelace` from `payment1` wallet to `payment2` wallet. Our `payment1` wallet had the following **UTXO**:
@@ -409,13 +409,13 @@ So we will use the `TxHash` `cf3cf4850c8862f2d698b2ece926578b3815795c9e38d2f9072
 We then tell `cardano-cli` that the destination of the `250,000,000 lovelace` is the **wallet address** of `payment2`.
 
 ```bash
---tx-out $(cat /home/user/cardano/keys/payment2.addr)+250000000
+--tx-out $(cat $HOME/cardano/keys/payment2.addr)+250000000
 ```
 
 Now, we still have `750000000 lovelace` as the change amount, so we will simply send it back to ourselves like so:
 
 ```bash
---tx-out $(cat /home/user/cardano/keys/payment1.addr)+749825831
+--tx-out $(cat $HOME/cardano/keys/payment1.addr)+749825831
 ```
 
 Now an important question you might ask here is that, why is the amount `749825831 lovelace`? Well remember that we calculated the fee to be `174169 lovelace` and someone has to shoulder the transaction fee, so we decide that `payment` should pay for the fee with the change `lovelace` amount. So we calculate that `750000000 - 174169 = 749825831` and so the total change would be `749825831 lovelace`.
@@ -429,26 +429,26 @@ We then specify the transaction fee like so:
 And then we specify where we will save the transaction file:
 
 ```
---out-file /home/user/cardano/tx.draft
+--out-file $HOME/cardano/tx.draft
 ```
 
 Now that we have the transaction file, we must sign the transaction in-order to prove that we are the owner of the input **UTXO** that was used.
 
 ```bash
 cardano-cli transaction sign \
---tx-body-file /home/user/cardano/tx.draft \
---signing-key-file /home/user/cardano/keys/payment1.skey \
+--tx-body-file $HOME/cardano/tx.draft \
+--signing-key-file $HOME/cardano/keys/payment1.skey \
 --testnet-magic 1097911063 \
---out-file /home/user/cardano/tx.signed
+--out-file $HOME/cardano/tx.signed
 ```
 
-`--signing-key-file /home/user/cardano/keys/payment1.skey` : This argument tells the `cardano-cli` that we will use `payment1.skey` to sign the transaction.
+`--signing-key-file $HOME/cardano/keys/payment1.skey` : This argument tells the `cardano-cli` that we will use `payment1.skey` to sign the transaction.
 
 Finally, we submit the transaction to the blockchain!
 
 ```bash
 cardano-cli transaction submit \
---tx-file /home/user/cardano/tx.signed \
+--tx-file $HOME/cardano/tx.signed \
 --testnet-magic 1097911063 
 ```
 :::important
@@ -459,14 +459,14 @@ Checking the balances of both wallets `payment1` and `payment2`:
 
 ```bash
 # payment1 wallet UTXO
-❯ cardano-cli query utxo --testnet-magic 1097911063 --address $(cat ~/cardano/keys/payment1.addr)
+❯ cardano-cli query utxo --testnet-magic 1097911063 --address $(cat $HOME/cardano/keys/payment1.addr)
 
                            TxHash                                 TxIx        Amount
 --------------------------------------------------------------------------------------
 63eeeb7e43171aeea0b3d53c5a36236cf9af92d5ee39e99bfadfe0237c46bd91     1        749825303 lovelace
 
 # payment2 wallet UTXO
-❯ cardano-cli query utxo --testnet-magic 1097911063 --address $(cat ~/cardano/keys/payment2.addr)
+❯ cardano-cli query utxo --testnet-magic 1097911063 --address $(cat $HOME/cardano/keys/payment2.addr)
                            TxHash                                 TxIx        Amount
 --------------------------------------------------------------------------------------
 63eeeb7e43171aeea0b3d53c5a36236cf9af92d5ee39e99bfadfe0237c46bd91     0        250000000 lovelace
@@ -481,7 +481,7 @@ Congratulations, You have created and sent your first **Cardano** transaction us
 :::note
 This guide assumes you have installed `cardano-wallet` into your system. If not you can refer to [Installing cardano-wallet](/docs/get-started/installing-cardano-wallet) guide for instructions on how to do that.
 
-We will use the path `/home/user/cardano/wallets` to store all the `cardano-wallet` related files as an example, please replace it with the directory you have choosen to store the files.
+We will use the path `$HOME/cardano/wallets` to store all the `cardano-wallet` related files as an example, please replace it with the directory you have choosen to store the files.
 :::
 
 :::important
@@ -495,7 +495,7 @@ In a production environment, it might not be a good idea to store wallets / keys
 First, lets create a directory to store all our `wallets` like so:
 
 ```bash
-mkdir -p /home/user/cardano/wallets
+mkdir -p $HOME/cardano/wallets
 ```
 
 **Starting cardano-wallet as a REST API server**
@@ -505,8 +505,8 @@ We will be focusing on the [REST API](https://en.wikipedia.org/wiki/Representati
 ```bash
 cardano-wallet serve \
 --port 1337 \
---testnet /home/user/cardano/testnet-byron-genesis.json \
---database /home/user/cardano/wallets/db \
+--testnet $HOME/cardano/testnet-byron-genesis.json \
+--database $HOME/cardano/wallets/db \
 --node-socket $CARDANO_NODE_SOCKET_PATH
 ```
 
@@ -530,7 +530,7 @@ cardano-wallet serve \
 > 
 > Here is an example `--socket-path` argument for **Linux**:
 ```
---socket-path /home/user/cardano/db/node.socket
+--socket-path $HOME/cardano/db/node.socket
 ```
 > As you can see the argument points to a file since **unix sockets** are represented as files (like everything else in **Linux**). In this case we put the socket file in the `db` directory that we have just created before.
 > 

--- a/docs/integrate-cardano/listening-for-payments-cli.md
+++ b/docs/integrate-cardano/listening-for-payments-cli.md
@@ -39,7 +39,7 @@ In the meantime the transaction is then being processed and settled within the *
 Now let's get our hands dirty and see how we can implement something like this in actual code.
 
 :::note
-In this section, We will use the path `/home/user/receive-ada-sample` to store all the related files as an example, please replace it with the directory you have choosen to store the files.
+In this section, We will use the path `$HOME/receive-ada-sample` to store all the related files as an example, please replace it with the directory you have choosen to store the files.
 All the code examples in this article assumes that you will save all the source-code-files under the root of this directory.
 :::
 
@@ -48,30 +48,30 @@ All the code examples in this article assumes that you will save all the source-
 First, lets create a directory to store our sample project:
 
 ```bash
-mkdir -p /home/user/receive-ada-sample/keys
+mkdir -p $HOME/receive-ada-sample/keys
 ```
 
 Next, we generate our **payment key-pair** using `cardano-cli`:
 
 ```bash
 cardano-cli address key-gen \
---verification-key-file /home/user/receive-ada-sample/keys/payment.vkey \
---signing-key-file /home/user/receive-ada-sample/keys/payment.skey
+--verification-key-file $HOME/receive-ada-sample/keys/payment.vkey \
+--signing-key-file $HOME/receive-ada-sample/keys/payment.skey
 ```
 
 Since we now have our **payment key-pair**, the next step would be to generate a **wallet address** for the `testnet` network like so:
 
 ```bash
 cardano-cli address build \
---payment-verification-key-file /home/user/receive-ada-sample/keys/payment.vkey \
---out-file /home/user/receive-ada-sample/keys/payment.addr \
+--payment-verification-key-file $HOME/receive-ada-sample/keys/payment.vkey \
+--out-file $HOME/receive-ada-sample/keys/payment.addr \
 --testnet-magic 1097911063
 ```
 
 Your directory structure should now look like this:
 
 ```bash
-/home/user/receive-ada-sample/receive-ada-sample
+$HOME/receive-ada-sample/receive-ada-sample
 └── keys
     ├── payment.addr
     ├── payment.skey
@@ -106,7 +106,7 @@ const CARDANO_CLI_PATH = "cardano-cli";
 // The `testnet` identifier number
 const CARDANO_NETWORK_MAGIC = 1097911063;
 // The directory where we store our payment keys
-// assuming our current directory context is /home/user/receive-ada-sample
+// assuming our current directory context is $HOME/receive-ada-sample
 const CARDANO_KEYS_DIR = "keys";
 // The total payment we expect in lovelace unit
 const TOTAL_EXPECTED_LOVELACE = 1000000;
@@ -125,7 +125,7 @@ const CARDANO_CLI_PATH: string = "cardano-cli";
 // The `testnet` identifier number
 const CARDANO_NETWORK_MAGIC: number = 1097911063;
 // The directory where we store our payment keys
-// assuming our current directory context is /home/user/receive-ada-sample/receive-ada-sample
+// assuming our current directory context is $HOME/receive-ada-sample/receive-ada-sample
 const CARDANO_KEYS_DIR: string = "keys";
 // The total payment we expect in lovelace unit
 const TOTAL_EXPECTED_LOVELACE: number = 1000000;
@@ -143,7 +143,7 @@ CARDANO_CLI_PATH = "cardano-cli"
 # The `testnet` identifier number
 CARDANO_NETWORK_MAGIC = 1097911063
 # The directory where we store our payment keys
-# assuming our current directory context is /home/user/receive-ada-sample
+# assuming our current directory context is $HOME/receive-ada-sample
 CARDANO_KEYS_DIR = "keys"
 # The total payment we expect in lovelace unit
 TOTAL_EXPECTED_LOVELACE = 1000000
@@ -161,7 +161,7 @@ const string CARDANO_CLI_PATH = "cardano-cli";
 // The `testnet` identifier number
 const int CARDANO_NETWORK_MAGIC = 1097911063;
 // The directory where we store our payment keys
-// assuming our current directory context is /home/user/receive-ada-sample
+// assuming our current directory context is $HOME/user/receive-ada-sample
 const string CARDANO_KEYS_DIR = "keys";
 // The total payment we expect in lovelace unit
 const long TOTAL_EXPECTED_LOVELACE = 1000000;
@@ -453,7 +453,7 @@ const CARDANO_CLI_PATH = "cardano-cli";
 // The `testnet` identifier number
 const CARDANO_NETWORK_MAGIC = 1097911063;
 // The directory where we store our payment keys
-// assuming our current directory context is /home/user/receive-ada-sample/receive-ada-sample
+// assuming our current directory context is $HOME/receive-ada-sample/receive-ada-sample
 const CARDANO_KEYS_DIR = "keys";
 // The imaginary total payment we expect in lovelace unit
 const TOTAL_EXPECTED_LOVELACE = 1000000;
@@ -501,7 +501,7 @@ const CARDANO_CLI_PATH: string = "cardano-cli";
 // The `testnet` identifier number
 const CARDANO_NETWORK_MAGIC: number = 1097911063;
 // The directory where we store our payment keys
-// assuming our current directory context is /home/user/receive-ada-sample/receive-ada-sample
+// assuming our current directory context is $HOME/receive-ada-sample/receive-ada-sample
 const CARDANO_KEYS_DIR: string = "keys";
 // The imaginary total payment we expect in lovelace unit
 const TOTAL_EXPECTED_LOVELACE: number = 1000000;
@@ -552,7 +552,7 @@ const string CARDANO_CLI_PATH = "cardano-cli";
 // The `testnet` identifier number
 const int CARDANO_NETWORK_MAGIC = 1097911063;
 // The directory where we store our payment keys
-// assuming our current directory context is /home/user/receive-ada-sample
+// assuming our current directory context is $HOME/receive-ada-sample
 const string CARDANO_KEYS_DIR = "keys";
 // The total payment we expect in lovelace unit
 const long TOTAL_EXPECTED_LOVELACE = 1000000;
@@ -598,7 +598,7 @@ CARDANO_CLI_PATH = "cardano-cli"
 # The `testnet` identifier number
 CARDANO_NETWORK_MAGIC = 1097911063
 # The directory where we store our payment keys
-# assuming our current directory context is /home/user/receive-ada-sample
+# assuming our current directory context is $HOME/receive-ada-sample
 CARDANO_KEYS_DIR = "keys"
 # The total payment we expect in lovelace unit
 TOTAL_EXPECTED_LOVELACE = 1000000
@@ -651,7 +651,7 @@ Your project directory should look something like this:
 ```bash
 # Excluding node_modules directory
 
-/home/user/receive-ada-sample/receive-ada-sample
+$HOME/receive-ada-sample/receive-ada-sample
 ├── checkPayment.js
 ├── keys
 │   ├── payment.addr
@@ -669,7 +669,7 @@ Your project directory should look something like this:
 ```bash
 # Excluding node_modules directory
 
-/home/user/receive-ada-sample/receive-ada-sample
+$HOME/receive-ada-sample/receive-ada-sample
 ├── checkPayment.ts
 ├── keys
 │   ├── payment.addr
@@ -687,7 +687,7 @@ Your project directory should look something like this:
 ```bash
 # Excluding bin and obj directories
 
-/home/user/receive-ada-sample/receive-ada-sample
+$HOME/receive-ada-sample/receive-ada-sample
 ├── Program.cs
 ├── dotnet.csproj
 ├── keys
@@ -702,7 +702,7 @@ Your project directory should look something like this:
   <TabItem value="py">
 
 ```bash
-/home/user/receive-ada-sample/receive-ada-sample
+$HOME/receive-ada-sample/receive-ada-sample
 ├── checkPayment.py
 └── keys
     ├── payment.addr
@@ -775,7 +775,7 @@ The code is telling us that our current wallet has received a total of `0 lovela
 What we can do to simulate a succesful payment is to send atleast `1,000,000 lovelace` into the **wallet address** that we have just generated for this project. We can get the **wallet address** by reading the contents of the `payment.addr` file like so:
 
 ```bash
-cat /home/user/receive-ada-sample/receive-ada-sample/keys/payment.addr
+cat $HOME/receive-ada-sample/receive-ada-sample/keys/payment.addr
 ```
 
 You should see the **wallet address** value:

--- a/docs/integrate-cardano/multi-witness-transactions-cli.md
+++ b/docs/integrate-cardano/multi-witness-transactions-cli.md
@@ -26,7 +26,7 @@ Make sure we are in the correct folder.
 
 ```bash
 $ pwd
-/home/user/cardano
+$HOME/cardano
 ```
 
 <Tabs
@@ -205,29 +205,29 @@ We also assume you paid `174169 Lovelace` in transaction fees and that your curr
 
 If you don't already have a third wallet to use for this guide, let's create one where we can transfer all our funds to.
 
-Make sure you are inside the `keys` directory like so: `cd /home/user/cardano/keys`
+Make sure you are inside the `keys` directory like so: `cd $HOME/cardano/keys`
 
 Generate a **payment key-pair** using `cardano-cli`:
 
 ```bash
 cardano-cli address key-gen \
---verification-key-file /home/user/cardano/keys/store-owner.vkey \
---signing-key-file /home/user/cardano/keys/store-owner.skey
+--verification-key-file $HOME/cardano/keys/store-owner.vkey \
+--signing-key-file $HOME/cardano/keys/store-owner.skey
 ```
 
 Then generate a **wallet address** for the `testnet` network:
 
 ```bash
 cardano-cli address build \
---payment-verification-key-file /home/user/cardano/keys/store-owner.vkey \
---out-file /home/user/cardano/keys/store-owner.addr \
+--payment-verification-key-file $HOME/cardano/keys/store-owner.vkey \
+--out-file $HOME/cardano/keys/store-owner.addr \
 --testnet-magic 1097911063
 ```
 
 Check your `keys` directory. It should look something like this:
 
 ```bash
-/home/user/cardano/keys/
+$HOME/cardano/keys/
 ├── payment1.addr
 ├── payment1.skey
 ├── payment1.vkey
@@ -246,7 +246,7 @@ Check your `keys` directory. It should look something like this:
 Lets create a directory to store our transactions for this guide and enter it:
 
 ```bash
-mkdir -p /home/user/cardano/multi-witness-sample && cd $_;
+mkdir -p $HOME/cardano/multi-witness-sample && cd $_;
 ```
 
 We want to send **all our tAda** sitting at the two UTxO we verified [before](#recap) and send it to the `store-owner.addr`. That means we will have **two inputs**.
@@ -324,7 +324,7 @@ The devious store-owner will now verify that everything went according to his pl
 ```bash
 cardano-cli query utxo \
 --testnet-magic 1097911063 \
---address $(cat /home/user/cardano/keys/store-owner.addr)
+--address $(cat $HOME/cardano/keys/store-owner.addr)
                            TxHash                                 TxIx        Amount
 --------------------------------------------------------------------------------------
 258abd628eef7d6ff0f7b4e6866b4f7c21065f4d6b5e49b51e2ac4ff035ad06f     0        999646250 lovelace
@@ -349,36 +349,36 @@ For that we draft two transactions
 ```sh
 cardano-cli transaction build-raw \
 --tx-in 258abd628eef7d6ff0f7b4e6866b4f7c21065f4d6b5e49b51e2ac4ff035ad06f#0 \
---tx-out $(cat ~/cardano/keys/payment1.addr)+0 \
+--tx-out $(cat $HOME/cardano/keys/payment1.addr)+0 \
 --fee 0 \
---out-file ~/cardano/multi-witness-sample/tx-single1.draft
+--out-file $HOME/cardano/multi-witness-sample/tx-single1.draft
 
 cardano-cli transaction build-raw \
 --tx-in 258abd628eef7d6ff0f7b4e6866b4f7c21065f4d6b5e49b51e2ac4ff035ad06f#0 \
---tx-out $(cat ~/cardano/keys/payment2.addr)+0 \
+--tx-out $(cat $HOME/cardano/keys/payment2.addr)+0 \
 --fee 0 \
---out-file ~/cardano/multi-witness-sample/tx-single2.draft
+--out-file $HOME/cardano/multi-witness-sample/tx-single2.draft
 ```
 
 And invoke the calculate-min-fees endpoint on `cardano-cli` for both of them:
 
 ```bash {8,17}
 cardano-cli transaction calculate-min-fee \
---tx-body-file ~/cardano/multi-witness-sample/tx-single1.draft \
+--tx-body-file $HOME/cardano/multi-witness-sample/tx-single1.draft \
 --tx-in-count 1 \
 --tx-out-count 1 \
 --witness-count 1 \
 --testnet-magic 1097911063 \
---protocol-params-file ~/cardano/protocol.json 
+--protocol-params-file $HOME/cardano/protocol.json 
 169857 Lovelace
 
 cardano-cli transaction calculate-min-fee \
---tx-body-file ~/cardano/multi-witness-sample/tx-single2.draft \
+--tx-body-file $HOME/cardano/multi-witness-sample/tx-single2.draft \
 --tx-in-count 1 \
 --tx-out-count 1 \
 --witness-count 1 \
 --testnet-magic 1097911063 \
---protocol-params-file ~/cardano/protocol.json 
+--protocol-params-file $HOME/cardano/protocol.json 
 169857 Lovelace
 ```
 

--- a/docs/native-tokens/minting.md
+++ b/docs/native-tokens/minting.md
@@ -83,17 +83,17 @@ The variable needs to hold the absolute path to the socket file of your running 
 If you're unsure or do not know where to find your socket path, please check the command on how you start/run your Cardano node.  
 For example - if you start your node with this command
 ```bash
-/home/user/.local/bin/cardano-node run \
+$HOME/.local/bin/cardano-node run \
  --topology config/testnet-topology.json \
  --database-path db \
- --socket-path /home/user/TESTNET_NODE/socket/node.socket \
+ --socket-path $HOME/TESTNET_NODE/socket/node.socket \
  --port 3001 \
  --config config/testnet-config.json
 ```
 You need to set the variable to the corresponding path of the `--socket-path` parameter:
 
 ```bash
-export CARDANO_NODE_SOCKET_PATH="/home/user/TESTNET_NODE/socket/node.socket"
+export CARDANO_NODE_SOCKET_PATH="$HOME/TESTNET_NODE/socket/node.socket"
 ```
 You need to adjust the path on your setup and your socket path accordingly.
 

--- a/docs/operate-a-stake-pool/guild-ops-suite.md
+++ b/docs/operate-a-stake-pool/guild-ops-suite.md
@@ -47,12 +47,12 @@ mkdir "$HOME/tmp";cd "$HOME/tmp"
 curl -sS -o prereqs.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/prereqs.sh
 chmod 755 prereqs.sh
 ./prereqs.sh
-. ~/.bashrc
+. "$HOME"/.bashrc
 ```
 
 ### Build of Node/DBSync components
 
-We assume you'd have already seen te guide [here](../../docs/get-started/installing-cardano-node.md). There are similar build scripts/instructions available for building different cardano-node, cardano-db-sync, offline-metadata-tools and setting up postgres+postgREST with dbsync) on guild documentations. You can navigate instructions for each of them [here](https://cardano-community.github.io/guild-operators/build/). The instructions will also deploy these as a systemd service, which is recommended to avoid manually managing services.  
+We assume you'd have already seen the guide [here](../../docs/get-started/installing-cardano-node.md). There are similar build scripts/instructions available for building different cardano-node, cardano-db-sync, offline-metadata-tools and setting up postgres+postgREST with dbsync) on guild documentations. You can navigate instructions for each of them [here](https://cardano-community.github.io/guild-operators/build/). The instructions will also deploy these as a systemd service, which is recommended to avoid manually managing services.  
 
 ### Customise configuration
 

--- a/docs/stake-pool-course/assignments/kes_period.md
+++ b/docs/stake-pool-course/assignments/kes_period.md
@@ -23,10 +23,10 @@ cat shelley_testnet-genesis.json | grep KES
 
 and we see that in this example, the key will evolve after each period of 3600 slots and that it can evolve 120 times before it needs to be renewed.
 
-Before we can create an operational certificate for our node, we need to figure out the start of the KES validity period, i.e. which KES evolution period we are in. We check the current slot \(assuming our relay node socket file is at `~/cardano-node/relay/db/node.socket`\):
+Before we can create an operational certificate for our node, we need to figure out the start of the KES validity period, i.e. which KES evolution period we are in. We check the current slot \(assuming our relay node socket file is at `$HOME/cardano-node/relay/db/node.socket`\):
 
 ```
-export CARDANO_NODE_SOCKET_PATH=~/cardano-node/relay/db/node.socket
+export CARDANO_NODE_SOCKET_PATH=$HOME/cardano-node/relay/db/node.socket
 cardano-cli shelley query tip --testnet-magic 1097911063
 
 {

--- a/docs/stake-pool-course/handbook/install-cardano-node-written.md
+++ b/docs/stake-pool-course/handbook/install-cardano-node-written.md
@@ -57,8 +57,8 @@ If you are using a different flavor of Linux, you will need to use the package m
 wget https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz
 tar -xf cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz
 rm cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz cabal.sig
-mkdir -p ~/.local/bin
-mv cabal ~/.local/bin/
+mkdir -p $HOME/.local/bin
+mv cabal $HOME/.local/bin/
 ```
 
 Verify that .local/bin is in your PATH
@@ -84,7 +84,7 @@ nano .bashrc
 Go to the bottom of the file and add the following lines
 
 ```sh
-export PATH="~/.local/bin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 You need to restart your server or source your .bashrc file
@@ -190,10 +190,10 @@ cd cardano-node
 
 For reproducible builds, we should check out a specific release, a specific "tag". For the Shelley Testnet, we will use tag `1.24.2`, which we can check out as follows:
 
-```sh
+```bash
 git fetch --all --tags
 git tag
-git checkout tags/1.24.2
+git checkout $(curl -s https://api.github.com/repos/input-output-hk/cardano-node/releases/latest | jq -r .tag_name)
 ```
 
 ## Build and install the node
@@ -209,11 +209,11 @@ cabal build all
 Now we can copy the executables files to the .local/bin directory
 
 ```sh
-cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-node-1.24.2/x/cardano-node/build/cardano-node/cardano-node ~/.local/bin/
+cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-node-1.24.2/x/cardano-node/build/cardano-node/cardano-node $HOME/.local/bin/
 ```
 
 ```sh
-cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-cli-1.24.2/x/cardano-cli/build/cardano-cli/cardano-cli ~/.local/bin/
+cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-cli-1.24.2/x/cardano-cli/build/cardano-cli/cardano-cli $HOME/.local/bin/
 ```
 
 ```sh
@@ -234,15 +234,15 @@ cabal build cardano-node cardano-cli
 
 This is a good time to backup your current binaries (in case you have to revert to an earlier version). Something like this will work:
 ```sh
-cd ~/.local/bin
+cd $HOME/.local/bin
 mv cardano-cli cardano-cli-backup
 mv cardano-node cardano-node-backup
 ```
 Now copy your newly built binaries to the appropriate directory, with:
 ```sh
-cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-node-<NEW VERSION>/x/cardano-node/build/cardano-node/cardano-node ~/.local/bin/
+cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-node-<NEW VERSION>/x/cardano-node/build/cardano-node/cardano-node $HOME/.local/bin/
 
-cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-cli-<NEW VERSION>/x/cardano-cli/build/cardano-cli/cardano-cli ~/.local/bin/
+cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-cli-<NEW VERSION>/x/cardano-cli/build/cardano-cli/cardano-cli $HOME/.local/bin/
 ```
 
 :::note


### PR DESCRIPTION
👋👋 Hello there! Welcome. Please follow the steps below to tell us about your contribution.

---

## Updating documentation

#### Description of the change

- Exclude specific version info in node compilation instructions
- Remove libsodium flag addition to cabal.project.local (it should only be required when falling back on system libsodium instead of fork, which as per the instructions in place - should not)
- Specify mainnet resource consumption may be higher than minimum specified
- Replace mentions of `~` and `/home/user` with $HOME across entire docs (replaces #317 and #290, but also includes other pages)

(PS: While stakepool handbook is entirely stale, references were only updated in those due to sed conditions 🙂 )