### PR TITLE
Fixes documentation Stake Pool Course Handbook

### DIFF
--- a/docs/stake-pool-course/handbook/register-stake-keys.md
+++ b/docs/stake-pool-course/handbook/register-stake-keys.md
@@ -46,10 +46,10 @@ The output is the transaction fee in lovelace:
 
 Registering the stake address, not only pay transaction fees, but also includes a _deposit_ (which you get back when deregister the key) as stated in the protocol parameters:
 
-The deposit amount can be found in the `protocol.json` under `keyDeposit`, for example in Shelley Mainnet:
+The deposit amount can be found in the `protocol.json` under `stakeAddressDeposit`, for example in Shelley Mainnet:
 
     ...
-    "keyDeposit": 2000000,
+    "stakeAddressDeposit": 2000000,
     ...
 
 Query the UTXO of the address that pays for the transaction and deposit:


### PR DESCRIPTION
## Updating documentation

#### Description of the change

Fixes documentation Stake Pool Course Handbook "Register stake pool keys" chapter. Instead of keyDeposit it should be stakeAddressDeposit.

---