### PR TITLE
Add careers on Cardano page

### DIFF
--- a/docs/careers.md
+++ b/docs/careers.md
@@ -1,0 +1,19 @@
+---
+id: careers
+title: Careers on Cardano
+sidebar_label: Careers on Cardano
+description: Are you passionate about Cardano and looking for a job working in the Cardano ecosystem?
+image: ./img/og-developer-portal.png
+hide_table_of_contents: false
+---
+
+Are you passionate about Cardano and looking for a job working in the Cardano ecosystem? There are several organizations which practically always have open vacancies and career opportunities.
+
+Most of these jobs are 100% remote. You can work from anywhere in the world with a flexible schedule.
+
+## Work on Cardano projects full-time
+
+- [Jobs at Cardano Foundation](https://cardanofoundation.org/careers)
+- [Jobs at dcSpark](https://careers.dcspark.io)
+- [Jobs at EMURGO](https://emurgo.io/career)
+- [Jobs at IOHK](https://apply.workable.com/io-global/)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -159,6 +159,10 @@ module.exports = {
           title: "More about Cardano",
           items: [
             {
+              label: "Careers on Cardano",
+              to: "docs/careers",
+            },
+            {
               label: "Cardano Enterprise",
               href: "https://cardano.org/enterprise",
             },


### PR DESCRIPTION
Add a "careers on Cardano"-page on the lower right with links to open jobs at Cardano Foundation, dcSpark, EMURGO, and IOHK.