### PR TITLE
Update installing-cardano-node.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 
 # markdownlint
 .markdownlint.json
+
+# intellij
+.idea

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -103,6 +103,14 @@ ghcup install ghc 8.10.4
 ghcup set ghc 8.10.4
 ```
 
+`ghcup` will install the latest stable version of `cabal`. However, as of the time of writing this, [Input-Output](https://iohk.io) recommends using `cabal 3.4.0.0`. So, we will use `ghcup` to install and switch to the required version.
+
+```bash
+ghcup install cabal 3.4.0.0
+ghcup set cabal 3.4.0.0
+```
+
+
 Finally, we check if we have the correct `ghc` and `cabal` versions installed.
 
 Check `ghc` version: 
@@ -196,7 +204,7 @@ cabal configure --with-compiler=ghc-8.10.4
 We can now build the `Haskell-based` `cardano-node` to produce executable binaries.
 
 ```bash
-cabal build all
+cabal build cardano-node cardano-cli
 ```
 
 Install the newly built node and CLI commands to the $HOME/.local/bin directory:


### PR DESCRIPTION
## Updating documentation

#### Description of the change

Update the bash script code from 'cabal build all' to 'cabal build cardano-node cardano-cli'.  If you try to run `cabal build all` on latest tag of cardano-node code (i.e., 1.30.1), the build fails on tx-generator package with error message
```
cabal: Failed to build tx-generator-1.29 (which is required by
exe:tx-generator from tx-generator-1.29).
```
Since this documentation is specifically about building the cardano-node and cardano-cli, we can work around this by only building the specific executables needed.