### PR TITLE
Update minting-nfts.md

### DIFF
--- a/docs/native-tokens/minting-nfts.md
+++ b/docs/native-tokens/minting-nfts.md
@@ -464,7 +464,7 @@ txix="Insert your txix"
 The transaction looks like this:
 
 ```bash
-cardano-cli transaction build-raw --fee $burnfee --tx-in $txhash#$txix --tx-out $address+$burnoutput --mint="-1 $policyid.$tokenname" --minting-script-file $script --invalid-hereafter $slot --out-file burning.raw
+cardano-cli transaction build-raw --fee $burnfee --tx-in $txhash#$txix --tx-out $address+$burnoutput --mint="-1 $policyid.$tokenname" --minting-script-file $script --invalid-hereafter $slotnumber --out-file burning.raw
 ```
 
 :::note


### PR DESCRIPTION
## Updating documentation

#### Issue

There is a wrong variable used in bash command in the "Burn your token" section - "The transaction looks like this:" - not a $slot, but a $slotnumber as defined after a policy.script is created.

#### Description of the change

Changed to correct variable.