### PR TITLE
Standardize code block formatting in Stake Pool Course handhook

### DIFF
--- a/docs/stake-pool-course/handbook/apply-logging-prometheus.md
+++ b/docs/stake-pool-course/handbook/apply-logging-prometheus.md
@@ -19,21 +19,22 @@ You can get the best out of prometheus if you have both Prometheus on your local
 ## Setup Prometheus in your local machine or monitoring server
 Prometheus needs to be configured to monitor your Cardano Node. A minimalistic configuration file doing this could look like this:
 
-        global:
-          scrape_interval:     15s
-          external_labels:
-            monitor: 'codelab-monitor'
+```yaml
+global:
+  scrape_interval:     15s
+  external_labels:
+    monitor: 'codelab-monitor'
 
-        scrape_configs:
-          - job_name: 'cardano' # To scrape data from the cardano node
-            scrape_interval: 5s
-            static_configs:
-              - targets: ['a.b.c.d:12798']
-          - job_name: 'node' # To scrape data from a node exporter to monitor your linux host metrics.
-            scrape_interval: 5s
-            static_configs:
-              - targets: ['a.b.c.d:9100']
-
+scrape_configs:
+  - job_name: 'cardano' # To scrape data from the cardano node
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['a.b.c.d:12798']
+  - job_name: 'node' # To scrape data from a node exporter to monitor your linux host metrics.
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['a.b.c.d:9100']
+```
 
 You have to replace `a.b.c.d` with the public IP-address of your Cardano Node server, which you can find on the dashboard under _IPv4 Public IP_.
 

--- a/docs/stake-pool-course/handbook/configure-topology-files.md
+++ b/docs/stake-pool-course/handbook/configure-topology-files.md
@@ -14,15 +14,17 @@ Make the __block-producing__ node to "talk" only to __YOUR__ relay node. Do not 
 
     nano mainnet-topology.json
 
+```json
+{
+  "Producers": [
     {
-      "Producers": [
-        {
-          "addr": "<RELAY IP ADDRESS>",
-          "port": <PORT>,
-          "valency": 1
-        }
-      ]
+      "addr": "<RELAY IP ADDRESS>",
+      "port": <PORT>,
+      "valency": 1
     }
+  ]
+}
+```
 
 ## Configure the relay node:
 
@@ -31,25 +33,28 @@ Make your __relay node__ `talk` to your __block-producing__ node and __other rel
 
     nano mainnet-topology.json
 
+```json
+{
+  "Producers": [
     {
-      "Producers": [
-        {
-          "addr": "<BLOCK-PRODUCING IP ADDRESS>",
-          "port": <PORT>,
-          "valency": 1
-        },
-        {
-          "addr": "<IP ADDRESS>",
-          "port": <PORT>,
-          "valency": 1
-        },
-        {
-          "addr": "<IP ADDRESS>",
-          "port": <PORT>,
-          "valency": 1
-        }
-      ]
+      "addr": "<BLOCK-PRODUCING IP ADDRESS>",
+      "port": <PORT>,
+      "valency": 1
+    },
+    {
+      "addr": "<IP ADDRESS>",
+      "port": <PORT>,
+      "valency": 1
+    },
+    {
+      "addr": "<IP ADDRESS>",
+      "port": <PORT>,
+      "valency": 1
     }
+  ]
+}
+```
+
 ## Optionally you can use `topologyUpdater.sh` on your relay nodes from Guild Operators
 
 Until fully P2P is live we need to put peers manually in `topology.json` file on relays, to automatize this you can run `topologyUpdater.sh` script from Guild Operators. With this script help, you can speed up your relays registrations too, currently registration is done twice per day based on your pool registration. If you run `topologyUpdater.sh` every 60 minutes on your relays using cron then after 3 hours(or 4 runs) your relays will be registered. And most importnat you can generate `topology.json` which will contain remote peers. Find more details [here](https://cardano-community.github.io/guild-operators/Scripts/topologyupdater/). 

--- a/docs/stake-pool-course/handbook/create-simple-transaction.md
+++ b/docs/stake-pool-course/handbook/create-simple-transaction.md
@@ -21,16 +21,16 @@ Get the protocol parameters and save them to `protocol.json` with:
 
 ```sh
 cardano-cli query protocol-parameters \
-  --mainnet \
-  --out-file protocol.json
+    --mainnet \
+    --out-file protocol.json
 ```
 
 ## Get the transaction hash and index of the **UTXO** to spend:
 
 ```sh
 cardano-cli query utxo \
-  --address $(cat payment.addr) \
-  --mainnet
+    --address $(cat payment.addr) \
+    --mainnet
 ```
 
 ## Draft the transaction
@@ -41,13 +41,15 @@ Create a draft for the transaction and save it in tx.draft
 For `--tx-in` we use the following syntax: `TxHash#TxIx` where `TxHash` is the transaction hash and `TxIx` is the index; for `--tx-out` we use: `TxOut+Lovelace` where `TxOut` is the hex encoded address followed by the amount in `Lovelace`. For the transaction draft --tx-out, --invalid-hereafter and --fee can be set to zero.
 :::note
 
-    cardano-cli transaction build-raw \
+```sh
+cardano-cli transaction build-raw \
     --tx-in 4e3a6e7fdcb0d0efa17bf79c13aed2b4cb9baf37fb1aa2e39553d5bd720c5c99#4 \
     --tx-out $(cat payment2.addr)+0 \
     --tx-out $(cat payment.addr)+0 \
     --invalid-hereafter 0 \
     --fee 0 \
     --out-file tx.draft
+```
 
 ## Calculate the fee
 
@@ -57,8 +59,9 @@ A simple transaction needs one input, a valid UTXO from `payment.addr`, and two 
 * Output2: The address that receives the change of the transaction.
 
 Note that to calculate the fee you need to include the draft transaction
+
 ```sh
-    cardano-cli transaction calculate-min-fee \
+cardano-cli transaction calculate-min-fee \
     --tx-body-file tx.draft \
     --tx-in-count 1 \
     --tx-out-count 2 \
@@ -75,6 +78,7 @@ all amounts must be in Lovelace:
     expr <UTXO BALANCE> - <AMOUNT TO SEND> - <TRANSACTION FEE>
 
 For example, if we send 10 ada from a UTxO containing 20 ada, the change to send back to `payment.addr` after paying the fee is: 9.832035 ada
+
 ```sh
 expr 20000000 - 10000000 - 167965
 9832035
@@ -86,9 +90,12 @@ To build the transaction we need to specify the **TTL (Time to live)**, this is 
 
 Query the tip of the blockchain:
 
-    cardano-cli query tip --mainnet
+```sh
+cardano-cli query tip --mainnet
+```
 
 Look for the value of `slotNo`
+
 ```json
     {
         "blockNo": 16829,
@@ -96,13 +103,15 @@ Look for the value of `slotNo`
         "slotNo": 369200
     }
 ```
+
 Calculate your TTL, for example:  369200 + 200 slots = 369400
 
 ## Build the transaction
 
 We write the transaction in a file, we will name it `tx.raw`.
+
 ```sh
-    cardano-cli transaction build-raw \
+cardano-cli transaction build-raw \
     --tx-in 4e3a6e7fdcb0d0efa17bf79c13aed2b4cb9baf37fb1aa2e39553d5bd720c5c99#4 \
     --tx-out $(cat payment2.addr)+10000000 \
     --tx-out $(cat payment.addr)+9832035 \
@@ -114,8 +123,9 @@ We write the transaction in a file, we will name it `tx.raw`.
 ## Sign the transaction
 
 Sign the transaction with the signing key **payment.skey** and save the signed transaction in **tx.signed**
+
 ```sh
-    cardano-cli transaction sign \
+cardano-cli transaction sign \
     --tx-body-file tx.raw \
     --signing-key-file payment.skey \
     --mainnet \
@@ -123,8 +133,9 @@ Sign the transaction with the signing key **payment.skey** and save the signed t
 ```
 
 ## Submit the transaction
+
 ```sh
-    cardano-cli transaction submit \
+cardano-cli transaction submit \
     --tx-file tx.signed \
     --mainnet
 ```
@@ -132,18 +143,21 @@ Sign the transaction with the signing key **payment.skey** and save the signed t
 ## Check the balances
 
 We must give it some time to get incorporated into the blockchain, but eventually, we will see the effect:
+
 ```sh
 cardano-cli query utxo \
---address $(cat payment.addr) \
---mainnet
+    --address $(cat payment.addr) \
+    --mainnet
 
     >                            TxHash                                 TxIx         Amount
     > ----------------------------------------------------------------------------------------
     > b64ae44e1195b04663ab863b62337e626c65b0c9855a9fbb9ef4458f81a6f5ee     1         9832035 lovelace
+```
 
+```sh
 cardano-cli query utxo \
---address $(cat payment2.addr) \
---mainnet
+    --address $(cat payment2.addr) \
+    --mainnet
 
     >                            TxHash                                 TxIx         Amount
     > ----------------------------------------------------------------------------------------

--- a/docs/stake-pool-course/handbook/create-stake-pool-keys.md
+++ b/docs/stake-pool-course/handbook/create-stake-pool-keys.md
@@ -17,9 +17,10 @@ To generate a _payment key pair_:
 
 ```sh
 cardano-cli address key-gen \
---verification-key-file payment.vkey \
---signing-key-file payment.skey
+    --verification-key-file payment.vkey \
+    --signing-key-file payment.skey
 ```
+
 This creates two files `payment.vkey` (the _public verification key_) and `payment.skey` (the _private signing key_).
 
 ## Legacy key
@@ -27,6 +28,7 @@ This creates two files `payment.vkey` (the _public verification key_) and `payme
 To generate Byron-era _payment key_:
 
 Payment key files use the following format:
+
 ```json
 {
     "type": "PaymentSigningKeyByron_ed25519_bip32",
@@ -42,29 +44,32 @@ To generate a _stake key pair_ :
 
 ```sh
 cardano-cli stake-address key-gen \
---verification-key-file stake.vkey \
---signing-key-file stake.skey
+    --verification-key-file stake.vkey \
+    --signing-key-file stake.skey
 ```
+
 ## Payment address
 Both verification keys (`payment.vkey` and `stake.vkey`) are used to build the address and the resulting `payment address` is associated with these keys.
 
 ```sh
 cardano-cli address build \
---payment-verification-key-file payment.vkey \
---stake-verification-key-file stake.vkey \
---out-file payment.addr \
---mainnet
+    --payment-verification-key-file payment.vkey \
+    --stake-verification-key-file stake.vkey \
+    --out-file payment.addr \
+    --mainnet
 ```
+
 ## Stake address
 
 To generate a `stake address`:
 
 ```sh
 cardano-cli stake-address build \
---stake-verification-key-file stake.vkey \
---out-file stake.addr \
---mainnet
+    --stake-verification-key-file stake.vkey \
+    --out-file stake.addr \
+    --mainnet
 ```
+
 This address __CAN'T__ receive payments but will receive the rewards from participating in the protocol.
 
 
@@ -78,8 +83,8 @@ To query the balance of an address we need a running node and the environment va
 
 ```sh
 cardano-cli query utxo \
---address $(cat payment.addr) \
---mainnet
+    --address $(cat payment.addr) \
+    --mainnet
 ```
 
 :::note

--- a/docs/stake-pool-course/handbook/generate-stake-pool-keys.md
+++ b/docs/stake-pool-course/handbook/generate-stake-pool-keys.md
@@ -11,9 +11,9 @@ image: ./img/og-developer-portal.png
 Now let us create our _stake key pair_ :
 
 ```sh
- cardano-cli stake-address key-gen \
- --verification-key-file stake.vkey \
- --signing-key-file stake.skey
+cardano-cli stake-address key-gen \
+    --verification-key-file stake.vkey \
+    --signing-key-file stake.skey
 ```
 
 ## Stake address
@@ -21,10 +21,10 @@ Now let us create our _stake key pair_ :
 Finally, we can create our stake address. This address **CAN'T** receive payments but will receive the rewards from participating in the protocol. We will save this address in the file `stake.addr`
 
 ```sh
- cardano-cli stake-address build \
- --stake-verification-key-file stake.vkey \
- --out-file stake.addr \
- --testnet-magic 1097911063
+cardano-cli stake-address build \
+    --stake-verification-key-file stake.vkey \
+    --out-file stake.addr \
+    --testnet-magic 1097911063
 ```
 
 This created the file stake.addr, let's check its content:
@@ -39,9 +39,9 @@ cat stake.addr
 Now that we have a stake address, it is time to regenerate a payment address. This time we use both the stake verification key and payment verification key to build the address. With this, both addresses will be linked together and associated with one another.
 
 ```sh
- cardano-cli address build \
- --payment-verification-key-file payment.vkey \
- --stake-verification-key-file stake.vkey \
- --out-file paymentwithstake.addr \
- --testnet-magic 1097911063
+cardano-cli address build \
+    --payment-verification-key-file payment.vkey \
+    --stake-verification-key-file stake.vkey \
+    --out-file paymentwithstake.addr \
+    --testnet-magic 1097911063
 ```

--- a/docs/stake-pool-course/handbook/install-cardano-node-written.md
+++ b/docs/stake-pool-course/handbook/install-cardano-node-written.md
@@ -139,18 +139,18 @@ ghcup upgrade
 ghcup install <VERSION>
 ghcup set <VERSION>
 ```
+
 `<VERSION>` here could be for example 8.10.2
 
 You can check that your default GHC version has been properly set:
 
 ```sh
-
 ghc --version
 ```
 
 ## Install Libsodium
 
-```
+```sh
 export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 
@@ -165,14 +165,10 @@ sudo make install
 
 ## Download the source code for cardano-node
 
-
 ```sh
-
 cd
 git clone https://github.com/input-output-hk/cardano-node.git
-
 ```
-
 
 This creates the folder `cardano-node` and downloads the latest source code.
 
@@ -190,7 +186,7 @@ cd cardano-node
 
 For reproducible builds, we should check out a specific release, a specific "tag". For the Shelley Testnet, we will use tag `1.24.2`, which we can check out as follows:
 
-```bash
+```sh
 git fetch --all --tags
 git tag
 git checkout $(curl -s https://api.github.com/repos/input-output-hk/cardano-node/releases/latest | jq -r .tag_name)
@@ -220,7 +216,6 @@ cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-cli-1.24.2/x/cardano-c
 cardano-cli --version
 ```
 
-
 ## If you need to update to a newer version follow the steps below:
 
 ```sh
@@ -233,12 +228,15 @@ cabal build cardano-node cardano-cli
 ```
 
 This is a good time to backup your current binaries (in case you have to revert to an earlier version). Something like this will work:
+
 ```sh
 cd $HOME/.local/bin
 mv cardano-cli cardano-cli-backup
 mv cardano-node cardano-node-backup
 ```
+
 Now copy your newly built binaries to the appropriate directory, with:
+
 ```sh
 cp -p dist-newstyle/build/x86_64-linux/ghc-8.10.2/cardano-node-<NEW VERSION>/x/cardano-node/build/cardano-node/cardano-node $HOME/.local/bin/
 

--- a/docs/stake-pool-course/handbook/keys-addresses.md
+++ b/docs/stake-pool-course/handbook/keys-addresses.md
@@ -21,8 +21,8 @@ To generate a _payment key pair_:
 
 ```sh
 cardano-cli address key-gen \
---verification-key-file payment.vkey \
---signing-key-file payment.skey
+    --verification-key-file payment.vkey \
+    --signing-key-file payment.skey
 ```
 This creates two files `payment.vkey` (the _public verification key_) and `payment.skey` (the _private signing key_).
 
@@ -31,6 +31,7 @@ This creates two files `payment.vkey` (the _public verification key_) and `payme
 To generate Byron-era _payment key_:
 
 Payment key files use the following format:
+
 ```json
 {
     "type": "PaymentSigningKeyByron_ed25519_bip32",
@@ -46,28 +47,29 @@ To generate a _stake key pair_ :
 
 ```sh
 cardano-cli stake-address key-gen \
---verification-key-file stake.vkey \
---signing-key-file stake.skey
+    --verification-key-file stake.vkey \
+    --signing-key-file stake.skey
 ```
 ## Payment address
 Both verification keys (`payment.vkey` and `stake.vkey`) are used to build the address and the resulting `payment address` is associated with these keys.
 
 ```sh
 cardano-cli address build \
---payment-verification-key-file payment.vkey \
---stake-verification-key-file stake.vkey \
---out-file payment.addr \
---mainnet
+    --payment-verification-key-file payment.vkey \
+    --stake-verification-key-file stake.vkey \
+    --out-file payment.addr \
+    --mainnet
 ```
+
 ## Stake address
 
 To generate a `stake address`:
 
 ```sh
 cardano-cli stake-address build \
---stake-verification-key-file stake.vkey \
---out-file stake.addr \
---mainnet
+    --stake-verification-key-file stake.vkey \
+    --out-file stake.addr \
+    --mainnet
 ```
 This address __CAN'T__ receive payments but will receive the rewards from participating in the protocol.
 
@@ -82,6 +84,6 @@ To query the balance of an address we need a running node and the environment va
 
 ```sh
 cardano-cli query utxo \
---address $(cat payment.addr) \
---mainnet
+    --address $(cat payment.addr) \
+    --mainnet
 ```

--- a/docs/stake-pool-course/handbook/register-stake-keys.md
+++ b/docs/stake-pool-course/handbook/register-stake-keys.md
@@ -13,25 +13,30 @@ Stake address needs to be registered on the blockchain to be useful. Registering
 
 ## Create a registration certificate
 
-    cardano-cli stake-address registration-certificate \
+```sh
+cardano-cli stake-address registration-certificate \
     --stake-verification-key-file stake.vkey \
     --out-file stake.cert
+```
 
 ## Draft transaction
 
 For the transaction draft, --tx.out, --invalid-hereafter and --fee can be set to zero.
 
-    cardano-cli transaction build-raw \
+```sh
+cardano-cli transaction build-raw \
     --tx-in b64ae44e1195b04663ab863b62337e626c65b0c9855a9fbb9ef4458f81a6f5ee#1 \
     --tx-out $(cat payment.addr)+0 \
     --invalid-hereafter 0 \
     --fee 0 \
     --out-file tx.draft \
     --certificate-file stake.cert
+```
 
 ## Calculate fees
 
-    cardano-cli transaction calculate-min-fee \
+```sh
+cardano-cli transaction calculate-min-fee \
     --tx-body-file tx.draft \
     --tx-in-count 1 \
     --tx-out-count 1 \
@@ -39,6 +44,7 @@ For the transaction draft, --tx.out, --invalid-hereafter and --fee can be set to
     --byron-witness-count 0 \
     --mainnet \
     --protocol-params-file protocol.json
+```
 
 The output is the transaction fee in lovelace:
 
@@ -48,15 +54,17 @@ Registering the stake address, not only pay transaction fees, but also includes 
 
 The deposit amount can be found in the `protocol.json` under `stakeAddressDeposit`, for example in Shelley Mainnet:
 
-    ...
-    "stakeAddressDeposit": 2000000,
-    ...
+```json
+"stakeAddressDeposit": 2000000,
+```
 
 Query the UTXO of the address that pays for the transaction and deposit:
 
-    cardano-cli query utxo \
-        --address $(cat payment.addr) \
-        --mainnet
+```sh
+cardano-cli query utxo \
+    --address $(cat payment.addr) \
+    --mainnet
+```
 
     >                            TxHash                                 TxIx      Amount
     > ----------------------------------------------------------------------------------------
@@ -72,28 +80,34 @@ Query the UTXO of the address that pays for the transaction and deposit:
 
 Build the transaction, this time include  --invalid-hereafter and --fee
 
-    cardano-cli transaction build-raw \
+```sh
+cardano-cli transaction build-raw \
     --tx-in b64ae44e1195b04663ab863b62337e626c65b0c9855a9fbb9ef4458f81a6f5ee#1 \
     --tx-out $(cat payment.addr)+997828515 \
     --invalid-hereafter 987654 \
     --fee 171485 \
     --out-file tx.raw \
     --certificate-file stake.cert
+```
 
 Sign it:
 
-    cardano-cli transaction sign \
+```sh
+cardano-cli transaction sign \
     --tx-body-file tx.raw \
     --signing-key-file payment.skey \
     --signing-key-file stake.skey \
     --mainnet \
     --out-file tx.signed
+```
 
 And submit it:
 
-    cardano-cli transaction submit \
+```sh
+cardano-cli transaction submit \
     --tx-file tx.signed \
     --mainnet
+```
 
 Your stake key is now registered on the blockchain.
 

--- a/docs/stake-pool-course/handbook/register-stake-pool-metadata.md
+++ b/docs/stake-pool-course/handbook/register-stake-pool-metadata.md
@@ -39,10 +39,10 @@ Registering your stake pool requires:
 
 ```json
 {
-"name": "TestPool",
-"description": "The pool that tests all the pools",
-"ticker": "TEST",
-"homepage": "https://teststakepool.com"
+	"name": "TestPool",
+	"description": "The pool that tests all the pools",
+	"ticker": "TEST",
+	"homepage": "https://teststakepool.com"
 }
 ```
 
@@ -66,19 +66,19 @@ cardano-cli stake-pool metadata-hash --pool-metadata-file pool_Metadata.json
 
 ```sh
 cardano-cli stake-pool registration-certificate \
-	--cold-verification-key-file cold.vkey \
-	--vrf-verification-key-file vrf.vkey \
-	--pool-pledge <AMOUNT TO PLEDGE IN LOVELACE> \
-	--pool-cost <POOL COST PER EPOCH IN LOVELACE> \
-	--pool-margin <POOL COST PER EPOCH IN PERCENTAGE> \
-	--pool-reward-account-verification-key-file stake.vkey \
-	--pool-owner-stake-verification-key-file stake.vkey \
-	--mainnet \
-	--pool-relay-ipv4 <RELAY NODE PUBLIC IP> \
-	--pool-relay-port <RELAY NODE PORT> \
-	--metadata-url https://git.io/JJWdJ \
-	--metadata-hash <POOL METADATA HASH> \
-	--out-file pool-registration.cert
+    --cold-verification-key-file cold.vkey \
+    --vrf-verification-key-file vrf.vkey \
+    --pool-pledge <AMOUNT TO PLEDGE IN LOVELACE> \
+    --pool-cost <POOL COST PER EPOCH IN LOVELACE> \
+    --pool-margin <POOL COST PER EPOCH IN PERCENTAGE> \
+    --pool-reward-account-verification-key-file stake.vkey \
+    --pool-owner-stake-verification-key-file stake.vkey \
+    --mainnet \
+    --pool-relay-ipv4 <RELAY NODE PUBLIC IP> \
+    --pool-relay-port <RELAY NODE PORT> \
+    --metadata-url https://git.io/JJWdJ \
+    --metadata-hash <POOL METADATA HASH> \
+    --out-file pool-registration.cert
 ```
 
 | Parameter | Explanation |
@@ -117,9 +117,9 @@ To honor your pledge, create a _delegation certificate_:
 
 ```sh
 cardano-cli stake-address delegation-certificate \
-	--stake-verification-key-file stake.vkey \
-	--cold-verification-key-file cold.vkey \
-	--out-file delegation.cert
+    --stake-verification-key-file stake.vkey \
+    --cold-verification-key-file cold.vkey \
+    --out-file delegation.cert
 ```
 
 This creates a delegation certificate which delegates funds from all stake addresses associated with key `stake.vkey` to the pool belonging to cold key `cold.vkey`. If there are many staking keys as pool owners in the first step, we need delegation certificates for all of them.
@@ -132,26 +132,26 @@ To submit the `pool registration certificate` and the `delegation certificates` 
 
 ```sh
 cardano-cli transaction build-raw \
-	--tx-in <TxHash>#<TxIx> \
-	--tx-out $(cat payment.addr)+0 \
-	--invalid-hereafter 0 \
-	--fee 0 \
-	--out-file tx.draft \
-	--certificate-file pool-registration.cert \
-	--certificate-file delegation.cert
+    --tx-in <TxHash>#<TxIx> \
+    --tx-out $(cat payment.addr)+0 \
+    --invalid-hereafter 0 \
+    --fee 0 \
+    --out-file tx.draft \
+    --certificate-file pool-registration.cert \
+    --certificate-file delegation.cert
 ```
 
 #### Calculate the fees
 
 ```sh
 cardano-cli transaction calculate-min-fee \
-	--tx-body-file tx.draft \
-	--tx-in-count 1 \
-	--tx-out-count 1 \
-	--witness-count 3 \
-	--byron-witness-count 0 \
-	--mainnet \
-	--protocol-params-file protocol.json
+    --tx-body-file tx.draft \
+    --tx-in-count 1 \
+    --tx-out-count 1 \
+    --witness-count 3 \
+    --byron-witness-count 0 \
+    --mainnet \
+    --protocol-params-file protocol.json
 ```
 
 For example:
@@ -177,33 +177,33 @@ expr <UTxO BALANCE> - <poolDeposit> - <TRANSACTION FEE>
 
 ```sh
 cardano-cli transaction build-raw \
-	--tx-in <TxHash>#<TxIx> \
-	--tx-out $(cat payment.addr)+<CHANGE IN LOVELACE> \
-	--invalid-hereafter <TTL> \
-	--fee <TRANSACTION FEE> \
-	--out-file tx.raw \
-	--certificate-file pool-registration.cert \
-	--certificate-file delegation.cert
+    --tx-in <TxHash>#<TxIx> \
+    --tx-out $(cat payment.addr)+<CHANGE IN LOVELACE> \
+    --invalid-hereafter <TTL> \
+    --fee <TRANSACTION FEE> \
+    --out-file tx.raw \
+    --certificate-file pool-registration.cert \
+    --certificate-file delegation.cert
 ```
 
 #### Sign the transaction:
 
 ```sh
 cardano-cli transaction sign \
-	--tx-body-file tx.raw \
-	--signing-key-file payment.skey \
-	--signing-key-file stake.skey \
-	--signing-key-file cold.skey \
-	--mainnet \
-	--out-file tx.signed
+    --tx-body-file tx.raw \
+    --signing-key-file payment.skey \
+    --signing-key-file stake.skey \
+    --signing-key-file cold.skey \
+    --mainnet \
+    --out-file tx.signed
 ```
 
 #### Submit the transaction:
 
 ```sh
 cardano-cli transaction submit \
-	--tx-file tx.signed \
-	--mainnet
+    --tx-file tx.signed \
+    --mainnet
 ```
 
 #### Verify that your stake pool registration was successful.

--- a/docs/stake-pool-course/handbook/register-stake-pool-metadata.md
+++ b/docs/stake-pool-course/handbook/register-stake-pool-metadata.md
@@ -39,10 +39,10 @@ Registering your stake pool requires:
 
 ```json
 {
-	"name": "TestPool",
-	"description": "The pool that tests all the pools",
-	"ticker": "TEST",
-	"homepage": "https://teststakepool.com"
+    "name": "TestPool",
+    "description": "The pool that tests all the pools",
+    "ticker": "TEST",
+    "homepage": "https://teststakepool.com"
 }
 ```
 

--- a/docs/stake-pool-course/handbook/register-stake-pool-metadata.md
+++ b/docs/stake-pool-course/handbook/register-stake-pool-metadata.md
@@ -36,6 +36,7 @@ Registering your stake pool requires:
 **WARNING:** Generating the **stake pool registration certificate** and the **delegation certificate** requires the **cold keys**. So, when doing this on mainnet you may want to generate these certificates in your local machine taking the proper security measures to avoid exposing your cold keys to the internet.
 
 #### Create a JSON file with your pool's metadata
+
 ```json
 {
 "name": "TestPool",
@@ -54,31 +55,31 @@ Git.IO-URL https://git.io/JJWdJ
 #### Get the hash of your metadata JSON file:
 
 This validates that the JSON fits the required schema, if it does, you will get the hash of your file.
+
 ```sh
 cardano-cli stake-pool metadata-hash --pool-metadata-file pool_Metadata.json
 
 >6bf124f217d0e5a0a8adb1dbd8540e1334280d49ab861127868339f43b3948af
 ```
 
-
 #### Generate Stake pool registration certificate
+
 ```sh
 cardano-cli stake-pool registration-certificate \
---cold-verification-key-file cold.vkey \
---vrf-verification-key-file vrf.vkey \
---pool-pledge <AMOUNT TO PLEDGE IN LOVELACE> \
---pool-cost <POOL COST PER EPOCH IN LOVELACE> \
---pool-margin <POOL COST PER EPOCH IN PERCENTAGE> \
---pool-reward-account-verification-key-file stake.vkey \
---pool-owner-stake-verification-key-file stake.vkey \
---mainnet \
---pool-relay-ipv4 <RELAY NODE PUBLIC IP> \
---pool-relay-port <RELAY NODE PORT> \
---metadata-url https://git.io/JJWdJ \
---metadata-hash <POOL METADATA HASH> \
---out-file pool-registration.cert
+	--cold-verification-key-file cold.vkey \
+	--vrf-verification-key-file vrf.vkey \
+	--pool-pledge <AMOUNT TO PLEDGE IN LOVELACE> \
+	--pool-cost <POOL COST PER EPOCH IN LOVELACE> \
+	--pool-margin <POOL COST PER EPOCH IN PERCENTAGE> \
+	--pool-reward-account-verification-key-file stake.vkey \
+	--pool-owner-stake-verification-key-file stake.vkey \
+	--mainnet \
+	--pool-relay-ipv4 <RELAY NODE PUBLIC IP> \
+	--pool-relay-port <RELAY NODE PORT> \
+	--metadata-url https://git.io/JJWdJ \
+	--metadata-hash <POOL METADATA HASH> \
+	--out-file pool-registration.cert
 ```
-
 
 | Parameter | Explanation |
 | :--- | :--- |
@@ -98,7 +99,8 @@ cardano-cli stake-pool registration-certificate \
 **You can use a different key for the rewards, and can provide more than one owner key if there were multiple owners who share the pledge.**
 
 The **pool-registration.cert** file should look like this:
-```sh
+
+```
 type: CertificateShelley
 description: Stake Pool Registration Certificate
 cborHex:
@@ -112,11 +114,12 @@ cborHex:
 #### Generate delegation certificate pledge
 
 To honor your pledge, create a _delegation certificate_:
+
 ```sh
 cardano-cli stake-address delegation-certificate \
---stake-verification-key-file stake.vkey \
---cold-verification-key-file cold.vkey \
---out-file delegation.cert
+	--stake-verification-key-file stake.vkey \
+	--cold-verification-key-file cold.vkey \
+	--out-file delegation.cert
 ```
 
 This creates a delegation certificate which delegates funds from all stake addresses associated with key `stake.vkey` to the pool belonging to cold key `cold.vkey`. If there are many staking keys as pool owners in the first step, we need delegation certificates for all of them.
@@ -126,84 +129,93 @@ This creates a delegation certificate which delegates funds from all stake addre
 To submit the `pool registration certificate` and the `delegation certificates` to the blockchain by including them in one or more transactions. We can use one transaction for multiple certificates, the certificates will be applied in order.
 
 #### Draft the transaction
+
 ```sh
 cardano-cli transaction build-raw \
---tx-in <TxHash>#<TxIx> \
---tx-out $(cat payment.addr)+0 \
---invalid-hereafter 0 \
---fee 0 \
---out-file tx.draft \
---certificate-file pool-registration.cert \
---certificate-file delegation.cert
+	--tx-in <TxHash>#<TxIx> \
+	--tx-out $(cat payment.addr)+0 \
+	--invalid-hereafter 0 \
+	--fee 0 \
+	--out-file tx.draft \
+	--certificate-file pool-registration.cert \
+	--certificate-file delegation.cert
 ```
 
 #### Calculate the fees
+
 ```sh
 cardano-cli transaction calculate-min-fee \
---tx-body-file tx.draft \
---tx-in-count 1 \
---tx-out-count 1 \
---witness-count 3 \
---byron-witness-count 0 \
---mainnet \
---protocol-params-file protocol.json
+	--tx-body-file tx.draft \
+	--tx-in-count 1 \
+	--tx-out-count 1 \
+	--witness-count 3 \
+	--byron-witness-count 0 \
+	--mainnet \
+	--protocol-params-file protocol.json
 ```
 
 For example:
+
 ```sh
 > 184685
 ```
 
 Registering a stake pool requires a deposit. This amount is specified in `protocol.json`. For example, for Shelley Mainnet we have:
+
 ```json
 "poolDeposit": 500000000
 ```
 
 #### Calculate the change for --tx-out
 All amounts in Lovelace
+
 ```sh
 expr <UTxO BALANCE> - <poolDeposit> - <TRANSACTION FEE>
 ```
 
 #### Build the transaction:
+
 ```sh
 cardano-cli transaction build-raw \
---tx-in <TxHash>#<TxIx> \
---tx-out $(cat payment.addr)+<CHANGE IN LOVELACE> \
---invalid-hereafter <TTL> \
---fee <TRANSACTION FEE> \
---out-file tx.raw \
---certificate-file pool-registration.cert \
---certificate-file delegation.cert
+	--tx-in <TxHash>#<TxIx> \
+	--tx-out $(cat payment.addr)+<CHANGE IN LOVELACE> \
+	--invalid-hereafter <TTL> \
+	--fee <TRANSACTION FEE> \
+	--out-file tx.raw \
+	--certificate-file pool-registration.cert \
+	--certificate-file delegation.cert
 ```
 
 #### Sign the transaction:
+
 ```sh
 cardano-cli transaction sign \
---tx-body-file tx.raw \
---signing-key-file payment.skey \
---signing-key-file stake.skey \
---signing-key-file cold.skey \
---mainnet \
---out-file tx.signed
+	--tx-body-file tx.raw \
+	--signing-key-file payment.skey \
+	--signing-key-file stake.skey \
+	--signing-key-file cold.skey \
+	--mainnet \
+	--out-file tx.signed
 ```
 
 #### Submit the transaction:
+
 ```sh
 cardano-cli transaction submit \
---tx-file tx.signed \
---mainnet
+	--tx-file tx.signed \
+	--mainnet
 ```
-
 
 #### Verify that your stake pool registration was successful.
 
 Get Pool ID
+
 ```sh
 cardano-cli stake-pool id --cold-verification-key-file cold.vkey --output-format "hex"
 ```
 
 Check for the presence of your poolID in the network ledger state, with:
+
 ```sh
 cardano-cli query ledger-state --mainnet | grep publicKey | grep <poolId>
 ```

--- a/docs/stake-pool-course/handbook/setup-a-server-on-aws-written.md
+++ b/docs/stake-pool-course/handbook/setup-a-server-on-aws-written.md
@@ -55,10 +55,7 @@ If you do not have access to a computer running Linux \(or VirtualBox\), you can
 
 ![img](../../../static/img/stake-pool-course/setup-aws-11-connect-2.png)
 
-
 Congratulations! You have now access to a machine running Linux.
-
-
 
 :::tip questions or suggestions?
 

--- a/docs/stake-pool-course/handbook/setup-virtual-box-written.md
+++ b/docs/stake-pool-course/handbook/setup-virtual-box-written.md
@@ -22,11 +22,9 @@ Follow this tutorial to setup a virtual machine with ubuntu 20.04 Desktop:
 
 When you have finished creating your virtual Machine, open a terminal and run to install Install VirtualBox Guest Additions on Ubuntu VirtualBox VM.
 
-
 ```sh
 sudo apt install virtualbox-guest-dkms virtualbox-guest-x11 virtualbox-guest-utils
 ```
-
 
 :::tip questions or suggestions?
 

--- a/docs/stake-pool-course/handbook/use-cli.md
+++ b/docs/stake-pool-course/handbook/use-cli.md
@@ -32,7 +32,7 @@ will inform us about the parameters this command takes, so we can for example ge
 
 ```sh
 cardano-cli node key-gen \
---cold-verification-key-file cold.vkey \
---cold-signing-key-file cold.skey \
---operational-certificate-issue-counter-file cold.counter
+	--cold-verification-key-file cold.vkey \
+	--cold-signing-key-file cold.skey \
+	--operational-certificate-issue-counter-file cold.counter
 ```

--- a/docs/stake-pool-course/handbook/use-cli.md
+++ b/docs/stake-pool-course/handbook/use-cli.md
@@ -32,7 +32,7 @@ will inform us about the parameters this command takes, so we can for example ge
 
 ```sh
 cardano-cli node key-gen \
-	--cold-verification-key-file cold.vkey \
-	--cold-signing-key-file cold.skey \
-	--operational-certificate-issue-counter-file cold.counter
+    --cold-verification-key-file cold.vkey \
+    --cold-signing-key-file cold.skey \
+    --operational-certificate-issue-counter-file cold.counter
 ```


### PR DESCRIPTION
## Updating documentation

#### Description of the change

This diff updates the code blocks in the stake pool course to use a consistent format:

* All code blocks now use 3 backticks to indicate the start of a block. In some cases, a lexer was specified to improve readability.
* Command-line invocations were inconsistently indented; some had CLI flags indented by 2 spaces, some weren't indented at all. Now, all lines following the first one are indented by 4 spaces to make it clear that subsequent lines are not new commands.
* Extraneous newlines prior to and after code blocks have been removed. If there was no newline prior to or after a block, one was added to improve legibility.
