### PR TITLE
Update testnets-and-devnets.md

### DIFF
--- a/docs/get-started/testnets-and-devnets.md
+++ b/docs/get-started/testnets-and-devnets.md
@@ -36,6 +36,6 @@ The developer portal covers everything that you can do on Cardano Mainnet today.
 If you miss information about virtual machines like [KEVM](https://testnets.cardano.org/en/virtual-machines/kevm/overview/), [IELE](https://testnets.cardano.org/en/virtual-machines/iele/overview/), and [EVM](https://testnets.cardano.org/en/virtual-machines/evm/overview/) or programming languages like [Plutus](https://testnets.cardano.org/en/programming-languages/plutus/overview/), [Marlowe](https://testnets.cardano.org/en/programming-languages/marlowe/overview/) and [Glow](https://testnets.cardano.org/en/programming-languages/glow/overview/), visit [testnets.cardano.org](https://testnets.cardano.org).
 
 ### Smart Contracts
-To get you up to speed with the Smart Contract functionality coming to Cardano, we prepared [get started with smart contracts on Cardano](/docs/smart-contracts/overview).
+To get you up to speed with the Smart Contract functionality coming to Cardano, we prepared [get started with smart contracts on Cardano](/docs/smart-contracts/).
 
 

--- a/docs/get-started/testnets-and-devnets.md
+++ b/docs/get-started/testnets-and-devnets.md
@@ -36,6 +36,6 @@ The developer portal covers everything that you can do on Cardano Mainnet today.
 If you miss information about virtual machines like [KEVM](https://testnets.cardano.org/en/virtual-machines/kevm/overview/), [IELE](https://testnets.cardano.org/en/virtual-machines/iele/overview/), and [EVM](https://testnets.cardano.org/en/virtual-machines/evm/overview/) or programming languages like [Plutus](https://testnets.cardano.org/en/programming-languages/plutus/overview/), [Marlowe](https://testnets.cardano.org/en/programming-languages/marlowe/overview/) and [Glow](https://testnets.cardano.org/en/programming-languages/glow/overview/), visit [testnets.cardano.org](https://testnets.cardano.org).
 
 ### Smart Contracts
-To get you up to speed with the Smart Contract functionality coming to Cardano, we prepared [get started with smart contracts on Cardano](/docs/get-started/smart-contracts-signpost).
+To get you up to speed with the Smart Contract functionality coming to Cardano, we prepared [get started with smart contracts on Cardano](/docs/smart-contracts/overview).
 
 


### PR DESCRIPTION
## Updating documentation

#### Issue
There is a missing link on this page here under `Smart Contracts`:https://developers.cardano.org/docs/get-started/testnets-and-devnets/#smart-contracts
I think the correct link should be this here: https://developers.cardano.org/docs/smart-contracts/


#### Description of the change

I updated the path which should go to this markdown file here: https://github.com/cardano-foundation/developer-portal/blob/staging/docs/smart-contracts/overview.md
