### PR TITLE
Version update to 1.31.0 for binaries for "Installing cardano-node an…

### DIFF
--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -15,10 +15,10 @@ This guide will show you how to compile and install the `cardano-node` and `card
 If you want to avoid compiling the binaries yourself, you can download the latest versions of `cardano-node` and `cardano-cli` from the links below.
 
 <HydraBuildList
-    latest="7408469"
-    linux="7408438"
-    macos="7408630"
-    win64="7408538"/>
+    latest="8110794"
+    linux="8267131"
+    macos="8111097"
+    win64="8110999"/>
 
 The components can be built and run on **Windows** and **MacOS**, but we recommend that stake pool operators use **Linux** in production to take advantage of the associated performance advantages.
 :::


### PR DESCRIPTION
## Updating documentation

#### Description of the change

Updated links to binaries so it points to 1.31.0 for "Installing cardano-node and cardano-cli from source" page. Current manual contains links to 1.29.0 binaries, what are not supported at all at current point, so I think it is quite important to update at least till latest version for now.

---

