### PR TITLE
Explain base16 encoding of token names

### DIFF
--- a/docs/native-tokens/minting.md
+++ b/docs/native-tokens/minting.md
@@ -300,6 +300,22 @@ cardano-cli transaction build-raw \
  --minting-script-file policy/policy.script \
  --out-file matx.raw
 ```
+
+:::note 
+In later versions of cardano-cli (at least from >1.31.0) the tokennames must be base16 encoded or you will receive an error
+```bash
+option --tx-out: 
+unexpected 'T'
+expecting alphanumeric asset name, white space, "+" or end of input
+```
+
+You can easily fix this by redefining the tokennames. In this tutorial the equivilant base16 token names are:
+```bash
+tokenname1="54657374746F6B656E"
+tokenname2="5365636F6E6454657374746F6B656E"
+```
+:::
+
 #### Syntax breakdown 
 Here's a breakdown of the syntax as to which parameters we define in our minting transaction:
 ```bash


### PR DESCRIPTION
## Updating documentation

#### Description of the change

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

In more recent versions of cardano-cli  the token names must be encoded in base16 for you to be able to create a transaction (I encountered this problem myself). With this PR the solution is made immediately available to the reader.

