### PR TITLE
Add jq to the list of needed packages for CentOS

### DIFF
--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -64,7 +64,7 @@ To download the source code and build it, you need the following packages and to
 In Redhat, Fedora, and Centos:
 ```bash
 sudo yum update -y
-sudo yum install git gcc gcc-c++ tmux gmp-devel make tar xz wget zlib-devel libtool autoconf -y
+sudo yum install git gcc gcc-c++ tmux gmp-devel make tar xz wget zlib-devel libtool autoconf jq -y
 sudo yum install systemd-devel ncurses-devel ncurses-compat-libs -y
 ```
 

--- a/docs/stake-pool-course/handbook/install-cardano-node-written.md
+++ b/docs/stake-pool-course/handbook/install-cardano-node-written.md
@@ -35,7 +35,7 @@ If we are using an AWS instance running Amazon Linux AMI 2 \(see the [AWS walk-t
 
 ```sh
 sudo yum update -y
-sudo yum install git gcc gcc-c++ tmux gmp-devel make tar wget -y
+sudo yum install git gcc gcc-c++ tmux gmp-devel make tar wget jq -y
 sudo yum install zlib-devel libtool autoconf -y
 sudo yum install systemd-devel ncurses-devel ncurses-compat-libs -y
 ```


### PR DESCRIPTION
Some parts of the documentation relies on the jq command that must
be installed. This package was missing on CentOS Stream 8.
