### PR TITLE
Updated cardano node installation for Mac/Mac M1

### DIFF
--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -15,10 +15,10 @@ This guide will show you how to compile and install the `cardano-node` and `card
 If you want to avoid compiling the binaries yourself, you can download the latest versions of `cardano-node` and `cardano-cli` from the links below.
 
 <HydraBuildList
-    latest="8110794"
-    linux="8110920"
-    macos="8111097"
-    win64="8110999"/>
+    latest="9116257"
+    linux="9116140"
+    macos="9116041"
+    win64="9115926"/>
 
 The components can be built and run on **Windows** and **MacOS**, but we recommend that stake pool operators use **Linux** in production to take advantage of the associated performance advantages.
 :::
@@ -257,10 +257,6 @@ Next, we will talk about how to [run cardano-node](running-cardano.md).
 
 In this section, we will walk you through the process of downloading, compiling, and installing `cardano-node` and `cardano-cli` into your **MacOS-based** operating system. 
 
-:::note
-Please note that this guide only supports [Intel-based Apple MacOS](https://en.wikipedia.org/wiki/Mac_transition_to_Intel_processors) hardware. [Apple Silicon (M1)](https://en.wikipedia.org/wiki/Apple_M1) hardware guide is still in progress.
-:::
-
 #### Installing Operating System dependencies
 
 To download the source code and build it, you need the following packages and tools on your MacOS system:
@@ -281,6 +277,12 @@ brew install automake
 brew install pkg-config
 ```
 
+#### You will need to install llvm incase if you are using M1
+
+```
+brew install llvm
+```
+
 #### Installing GHC and Cabal
 
 The fastest way to install **GHC** (Glassglow Haskell Compiler) and **Cabal** (Common Architecture for Building Applications and Libraries) is to use [ghcup](https://www.haskell.org/ghcup).
@@ -289,7 +291,18 @@ Use the following command to install `ghcup`
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 ```
-Please follow the instructions and provide the necessary input to the installer. Once complete, you should have `ghc` and `cabal` installed on your system.
+Please follow the instructions and provide the necessary input to the installer.
+
+`Do you want ghcup to automatically add the required PATH variable to "/home/ubuntu/.bashrc"?` - (P or enter)
+
+`Do you want to install haskell-language-server (HLS)?` - (N or enter)
+
+`Do you want to install stack?` - (N or enter)
+
+`Press ENTER to proceed or ctrl-c to abort.` (enter)
+
+Once complete, you should have `ghc` and `cabal` installed to your system.
+
 
 :::note
 `ghcup` will try to detect your shell and will ask you to add it to the environment variables. Please restart your shell/terminal after installing `ghcup`
@@ -306,6 +319,13 @@ The GHCup Haskell installer, version v0.1.14.1
 ```bash
 ghcup install ghc 8.10.7
 ghcup set ghc 8.10.7
+```
+
+`ghcup` will install the latest stable version of `cabal`. However, as of the time of writing this, [Input-Output](https://iohk.io) recommends using `cabal 3.4.0.0`. So, we will use `ghcup` to install and switch to the required version.
+
+```bash
+ghcup install cabal 3.4.0.0
+ghcup set cabal 3.4.0.0
 ```
 
 Finally, we check if we have the correct `ghc` and `cabal` versions installed.

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -311,7 +311,7 @@ Once complete, you should have `ghc` and `cabal` installed to your system.
 You can check if `ghcup` has been installed properly by typing `ghcup --version` into the terminal. You should see something similar to the following: 
 
 ```
-The GHCup Haskell installer, version v0.1.14.1
+The GHCup Haskell installer, version v0.1.17.4
 ```
 
 `ghcup` will install the latest stable version of `ghc`. However, as of the time writing this, [Input-Output](https://iohk.io) recommends using `ghc 8.10.7`. So, we will use `ghcup` to install and switch to the required version. 

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -428,9 +428,8 @@ echo "  ghc-options: -Wwarn" >> cabal.project.local
 echo "" >> cabal.project.local
 ```
 
-
 :::note
-This commands might differs based how you installed llvm, if you used default installation, it should be ok. Please check screen after you installed llvm to see this info, if you forgot or lost it, you can just reinstall llvm and then you will see them again.
+First 2 commands might differs based how you installed llvm, if you used default installation, it should be ok. Please check screen after you installed llvm to see this info, if you forgot or lost it, you can just reinstall llvm and then you will see them again.
 :::
 
 ##### Configuring the build options

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -408,6 +408,19 @@ git checkout $(curl -s https://api.github.com/repos/input-output-hk/cardano-node
 If upgrading an existing node, please ensure that you have read the [release notes on GitHub](https://github.com/input-output-hk/cardano-node/releases) for any changes.
 :::
 
+#### You will need to run following commands on M1, so compiler can find llvm
+
+```
+export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
+export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+```
+
+
+:::note
+This commands might differs based how you installed llvm, if you used default installation, it should be ok. Please check screen after you installed llvm to see this info, if you forgot or lost it, you can just reinstall llvm and then you will see them again.
+:::
+
 ##### Configuring the build options
 
 We explicitly use the `ghc` version that we installed earlier. This avoids defaulting to a system version of `ghc` that might be newer or older than the one you have installed.

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -277,7 +277,7 @@ brew install automake
 brew install pkg-config
 ```
 
-#### You will need to install llvm incase you are using M1
+#### You will need to install llvm in case you are using M1
 
 ```
 brew install llvm

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -418,6 +418,14 @@ git checkout $(curl -s https://api.github.com/repos/input-output-hk/cardano-node
 If upgrading an existing node, please ensure that you have read the [release notes on GitHub](https://github.com/input-output-hk/cardano-node/releases) for any changes.
 :::
 
+##### Configuring the build options
+
+We explicitly use the `ghc` version that we installed earlier. This avoids defaulting to a system version of `ghc` that might be newer or older than the one you have installed.
+
+```bash
+cabal configure --with-compiler=ghc-8.10.7
+```
+
 #### You will need to run following commands on M1, so compiler can find llvm and some additional cabal magic
 
 ```
@@ -431,14 +439,6 @@ echo "" >> cabal.project.local
 :::note
 First 2 commands might differs based how you installed llvm, if you used default installation, it should be ok. Please check screen after you installed llvm to see this info, if you forgot or lost it, you can just reinstall llvm and then you will see them again.
 :::
-
-##### Configuring the build options
-
-We explicitly use the `ghc` version that we installed earlier. This avoids defaulting to a system version of `ghc` that might be newer or older than the one you have installed.
-
-```bash
-cabal configure --with-compiler=ghc-8.10.7
-```
 
 #### Building and installing the node
 ```bash

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -426,7 +426,7 @@ We explicitly use the `ghc` version that we installed earlier. This avoids defau
 cabal configure --with-compiler=ghc-8.10.7
 ```
 
-#### You will need to run following commands on M1, so compiler can find llvm and some additional cabal magic
+#### You will need to run following commands on M1, those commands will set some cabal related options before building
 
 ```
 echo "package trace-dispatcher" >> cabal.project.local

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -383,6 +383,16 @@ export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 ```
 
+If you installed llvm for M1, then you will need to add this too:
+
+```bash
+export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+```
+
+:::note
+llvm installation path might differs based on your installation, if you used default installation, it should be ok. Please check screen after you installed llvm to see this info, if you forgot or lost it, you can just reinstall llvm and then you will see them again.
+:::
+
 Once saved, we will then reload your shell profile to use the new variables. We can do that by typing `source $HOME/.bashrc` or `source $HOME/.zshrc` (***depending on the shell application you use***).
 
 Now we are ready to download, compile and install `cardano-node` and `cardano-cli`. But first, we have to make sure we are back at the root of our working directory:
@@ -411,7 +421,6 @@ If upgrading an existing node, please ensure that you have read the [release not
 #### You will need to run following commands on M1, so compiler can find llvm
 
 ```
-export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
 export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
 export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
 ```

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -429,16 +429,10 @@ cabal configure --with-compiler=ghc-8.10.7
 #### You will need to run following commands on M1, so compiler can find llvm and some additional cabal magic
 
 ```
-export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
-export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
 echo "package trace-dispatcher" >> cabal.project.local
 echo "  ghc-options: -Wwarn" >> cabal.project.local
 echo "" >> cabal.project.local
 ```
-
-:::note
-First 2 commands might differs based how you installed llvm, if you used default installation, it should be ok. Please check screen after you installed llvm to see this info, if you forgot or lost it, you can just reinstall llvm and then you will see them again.
-:::
 
 #### Building and installing the node
 ```bash

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -277,7 +277,7 @@ brew install automake
 brew install pkg-config
 ```
 
-#### You will need to install llvm incase if you are using M1
+#### You will need to install llvm incase you are using M1
 
 ```
 brew install llvm

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -418,11 +418,14 @@ git checkout $(curl -s https://api.github.com/repos/input-output-hk/cardano-node
 If upgrading an existing node, please ensure that you have read the [release notes on GitHub](https://github.com/input-output-hk/cardano-node/releases) for any changes.
 :::
 
-#### You will need to run following commands on M1, so compiler can find llvm
+#### You will need to run following commands on M1, so compiler can find llvm and some additional cabal magic
 
 ```
 export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
 export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+echo "package trace-dispatcher" >> cabal.project.local
+echo "  ghc-options: -Wwarn" >> cabal.project.local
+echo "" >> cabal.project.local
 ```
 
 


### PR DESCRIPTION
---

## Updating documentation

#### Description of the change

Updated cardano node installation page. Added details for Mac(added command that we need to switch to cabal 3.4.0.0, some additional comments) & added details that we need to install llvm for M1

---