### PR TITLE
Use stack install command to install cardano-wallet

### DIFF
--- a/docs/get-started/installing-cardano-wallet.md
+++ b/docs/get-started/installing-cardano-wallet.md
@@ -90,35 +90,15 @@ We can now build `cardano-wallet` code to produce executable binaries.
 ```bash
 stack build --test --no-run-tests
 ```
+
 Install the newly built `cardano-wallet` binary to the `$HOME/.local/bin` directory:
-<Tabs
-  defaultValue="macos"
-  values={[
-    {label: 'MacOS', value: 'macos' },
-    {label: 'Linux', value: 'linux' }
-  ]}>
-<TabItem value="macos">
 
-###### MacOS
 ```bash
-cp -p ./lib/shelley/.stack-work/dist/x86_64-osx/Cabal-*/build/cardano-wallet/cardano-wallet $HOME/.local/bin/
+stack install
 ```
-
-</TabItem>
-
-<TabItem value="linux">
-
-###### Linux
-```bash
-cp -p ./lib/shelley/.stack-work/dist/x86_64-linux-*/Cabal-*/build/cardano-wallet/cardano-wallet $HOME/.local/bin/
-```
-
-</TabItem>
-
-</Tabs>
-
 
 Check the version that has been installed:
+
 ```bash
 cardano-wallet version
 ```


### PR DESCRIPTION
This change updates the documentation section for the cardano-wallet.
As the build instruction is based on the `stack` tool then it makes
sense use the `stack install` sub command to install produced binaries.

`stack install` copies binaries into $HOME/.local/bin/.
As of now copied binaries are: cardano-wallet, local-cluser and
mock-token-metadata-server.

By effect this commit removes the need to have a macos / Linux tabs
and thus simplifies this documentation section.