### PR TITLE
update application link for the third cohort

### DIFF
--- a/docs/smart-contracts/plutus.md
+++ b/docs/smart-contracts/plutus.md
@@ -63,4 +63,4 @@ The Plutus pioneer program was created in order to recruit and train developers 
 **This course is not for coding beginners.** You do not need to be an expert in formal methods, but programming experience and a general aptitude for logical and mathematical thinking are highly advisable. We recommend to [get started with Haskell](#get-started-with-haskell) before taking the course.
 
 Prior knowledge of Haskell or functional programming is also recommended, as Plutus is heavily based on Haskell and includes advanced features like Template Haskell, type-level programming, and effect systems.
-- [Apply for the Plutus Pioneer Program](https://input-output.typeform.com/to/fNd3RBX9)
+- [Apply for the Plutus Pioneer Program](https://testnets.cardano.org/en/plutus-pioneer-program/)


### PR DESCRIPTION

## Updating documentation

#### Description of the change

Replaced old Plutus Pioneer Program application URL with the new cohort 3 link

