### PR TITLE
Remove Legacy key from Creating keys and addresses

### DIFF
--- a/docs/stake-pool-course/handbook/keys-addresses.md
+++ b/docs/stake-pool-course/handbook/keys-addresses.md
@@ -26,20 +26,6 @@ cardano-cli address key-gen \
 ```
 This creates two files `payment.vkey` (the _public verification key_) and `payment.skey` (the _private signing key_).
 
-## Legacy key
-
-To generate Byron-era _payment key_:
-
-Payment key files use the following format:
-
-```json
-{
-    "type": "PaymentSigningKeyByron_ed25519_bip32",
-    "description": "Payment Signing Key",
-    "cborHex": "hex-here"
-}
-```
-
 Where the `hex-here` is generated as `0x5880 | xprv | pub | chaincode`
 
 ## Stake key pair


### PR DESCRIPTION
Remove Legacy key from Creating keys and addresses page



## Updating documentation

#### Issue

Fixes #375

#### Description of the change

This change will remove Legacy key from Creating keys and addresses page & Create Stake Pool Keys page from stake pool handbook
