### PR TITLE
Fix issue regarding broken links in Token Registry script

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ module.exports = {
   tagline: "let's build better",
   url: "https://developers.cardano.org",
   baseUrl: "/",
-  onBrokenLinks: "throw",
+  onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.ico",
   organizationName: "cardano-foundation",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ module.exports = {
   tagline: "let's build better",
   url: "https://developers.cardano.org",
   baseUrl: "/",
-  onBrokenLinks: "warn",
+  onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.ico",
   organizationName: "cardano-foundation",

--- a/scripts/token-registry.ts
+++ b/scripts/token-registry.ts
@@ -70,11 +70,18 @@ const stringManipulation = (content: string, fileName: string) => {
 
     // Remove `(` and `)` from relative links (temporariy not in use, using hardcoded solution for now)
     // content = content.replace(/(?<=\]\()(.*)(?=\))/g, (x) => x.replace(/[()]/g, ''));
-    
+                                  
+    // Replcae '_' with '-' from relative links to make sure they work correct 
+    content = content.match(/]\([^()]*\)/g) ? content.replace(/_/g, '-') : content;
+       
     // Remove `(` and `)` from relative links (temporariy solution focusing on specific link, in the future needs to be changed to work through all of the links)
     content = content.replace('How-to-prepare-an-entry-for-the-registry-(NA-policy-script)',
                                  'How-to-prepare-an-entry-for-the-registry-NA-policy-script');
-    
+
+    // Add '?' to a speficic relative link case (seems like it's a broken link that has been written badly in Token Registry repo)
+    content = content.replace('How-do-I-update-my-entry-in-the-registry)',
+                                 'How-do-I-update-my-entry-in-the-registry%3F)');
+
     content = injectTRnformation(content, fileName);
 
     return content;

--- a/scripts/token-registry.ts
+++ b/scripts/token-registry.ts
@@ -82,7 +82,7 @@ const stringManipulation = (content: string, fileName: string) => {
     content = content.replace('How-do-I-update-my-entry-in-the-registry)',
                                  'How-do-I-update-my-entry-in-the-registry%3F)');
 
-    content = injectTRnformation(content, fileName);
+    content = injectTRinformation(content, fileName);
 
     return content;
 }
@@ -134,7 +134,7 @@ const sidebar_positionForFilename = (fileName: string) => {
 }
 
 // Add Token Registry Info
-const injectTRnformation = (content: string, fileName: string) => {
+const injectTRinformation = (content: string, fileName: string) => {
 
     // Add to the end
     return content + '  \n## Token Registry Information  \nThis page was generated automatically from: ['+tokenRegistryWiki+']('+tokenRegistryWiki + '/' + fileName + ').';


### PR DESCRIPTION
Since some of the links in Token Registry repository are broken, I've modified the script to replace broken symbols and added an exception to one of the link that definitely should be changed in Token Registry repository.

