### PR TITLE
Add sticky contribute button to home, showcases and builder tools

### DIFF
--- a/src/components/buttons/openStickyButton.js
+++ b/src/components/buttons/openStickyButton.js
@@ -1,0 +1,19 @@
+import React from "react";
+import styles from "./styles.module.css";
+
+export default function openStickyButton() {
+  return (
+    <div>
+      <button className={`${styles.iconBtn} ${styles.addBtn}`}>
+        <div className={styles.addIcon}></div>
+        <a
+          className={styles.btnText}
+          href="https://developers.cardano.org/docs/portal-contribute/"
+          target="_blank"
+        >
+          <span className={styles.btnSpan}>CONTRIBUTE NOW</span>
+        </a>
+      </button>
+    </div>
+  );
+}

--- a/src/components/buttons/styles.module.css
+++ b/src/components/buttons/styles.module.css
@@ -1,0 +1,108 @@
+html[data-theme=light] .iconBtn {
+  border: 1px solid #cdcdcd;
+  background-color: #383fd0;
+}
+
+html[data-theme=dark] .iconBtn {
+  border: 1px solid #000;
+  background-color: #2da48d;
+}
+
+  .iconBtn {
+    width: 50px;
+    height: 50px;
+    border-radius: 25px;
+    overflow: hidden;
+    transition: width 0.2s ease-in-out;
+
+
+    position: fixed;
+    bottom: 30px;
+    right: 30px;
+    z-index: 999;
+  }
+  .addBtn:hover {
+    width: 180px;
+  }
+  .addBtn::before,
+  .addBtn::after {
+    transition: width 0.2s ease-in-out, border-radius 0.2s ease-in-out;
+    content: "";
+    position: absolute;
+    height: 4px;
+    width: 10px;
+    top: calc(50% - 2px);
+    background: #fff;
+  }
+  .addBtn::after {
+    right: 14px;
+    overflow: hidden;
+    border-top-right-radius: 2px;
+    border-bottom-right-radius: 2px;
+  }
+  .addBtn::before {
+    left: 14px;
+    border-top-left-radius: 2px;
+    border-bottom-left-radius: 2px;
+  }
+  .iconBtn:focus {
+    outline: none;
+  }
+  .btnText {
+    opacity: 0;
+    transition: opacity 0.2s;
+    color: #ffff;
+    text-decoration: none;
+  }
+  .btnText:hover {
+    color: #ffff;
+    text-decoration: none;
+  }
+  .addBtn:hover::before,
+  .addBtn:hover::after {
+    width: 4px;
+    border-radius: 2px;
+  }
+  .addBtn:hover .btnText {
+    opacity: 1;
+    transition: opacity 1s;
+  }
+  .addIcon::after,
+  .addIcon::before {
+    transition: all 0.2s ease-in-out;
+    content: "";
+    position: absolute;
+    height: 20px;
+    width: 2px;
+    top: calc(50% - 10px);
+    background: #fff;
+    overflow: hidden;
+  }
+  .addIcon::before {
+    left: 22px;
+    border-top-left-radius: 2px;
+    border-bottom-left-radius: 2px;
+  }
+  .addIcon::after {
+    right: 22px;
+    border-top-right-radius: 2px;
+    border-bottom-right-radius: 2px;
+  }
+  .addBtn:hover .addIcon::before {
+    left: 15px;
+    height: 4px;
+    top: calc(50% - 2px);
+  }
+  .addBtn:hover .addIcon::after {
+    right: 15px;
+    height: 4px;
+    top: calc(50% - 2px);
+  }
+
+  .btnSpan {
+    font-weight: bold;
+  }
+  
+  
+  
+  

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,6 +6,7 @@ import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import styles from "./styles.module.css";
 import PortalHero from "./portalhero";
+import OpenStickyButton from "../components/buttons/openStickyButton";
 
 const features = [
   {
@@ -140,6 +141,7 @@ function Home() {
           </section>
         )}
       </main>
+      <OpenStickyButton/>
     </Layout>
   );
 }

--- a/src/pages/showcase/index.js
+++ b/src/pages/showcase/index.js
@@ -4,6 +4,7 @@ import Layout from "@theme/Layout";
 import ShowcaseTooltip from "@site/src/components/showcase/ShowcaseTooltip";
 import ShowcaseTagSelect from "@site/src/components/showcase/ShowcaseTagSelect";
 import ShowcaseCard from "@site/src/components/showcase/ShowcaseCard/";
+import OpenStickyButton from "../../components/buttons/openStickyButton";
 import ShowcaseFilterToggle, {
   readOperator,
 } from "@site/src/components/showcase/ShowcaseFilterToggle";
@@ -318,6 +319,7 @@ function Showcase() {
       <ShowcaseHeader />
       <ShowcaseFilters selectedTags={selectedTags} toggleTag={toggleTag} />
       <ShowcaseCards filteredProjects={filteredProjects} />
+      <OpenStickyButton/>
     </Layout>
   );
 }

--- a/src/pages/tools/index.js
+++ b/src/pages/tools/index.js
@@ -4,6 +4,7 @@ import Layout from "@theme/Layout";
 import ShowcaseTooltip from "@site/src/components/showcase/ShowcaseTooltip";
 import ShowcaseTagSelect from "@site/src/components/showcase/ShowcaseTagSelect";
 import ShowcaseCard from "@site/src/components/showcase/ShowcaseCard/";
+import OpenStickyButton from "../../components/buttons/openStickyButton";
 import ShowcaseFilterToggle, {
   readOperator,
 } from "@site/src/components/showcase/ShowcaseFilterToggle";
@@ -322,6 +323,7 @@ function Showcase() {
       <ShowcaseHeader />
       <ShowcaseFilters selectedTags={selectedTags} toggleTag={toggleTag} />
       <ShowcaseCards filteredProjects={filteredProjects} />
+      <OpenStickyButton/>
     </Layout>
   );
 }


### PR DESCRIPTION
Add a sticky CONTRIBUTE button that redirects to [How to contribute to the developer portal
](https://developers.cardano.org/docs/portal-contribute/)

Screenshots for button preview: 

<img width="64" alt="Screenshot 2022-05-13 at 14 52 23" src="https://user-images.githubusercontent.com/60065019/168277690-bc3bacbe-e3df-4dd8-ba21-ab44e9b4875f.png">

<img width="218" alt="Screenshot 2022-05-13 at 14 51 18" src="https://user-images.githubusercontent.com/60065019/168277619-45692942-f68e-4922-9aa3-c145b71d3214.png">

