### PR TITLE
Remove doubled favourite tag

### DIFF
--- a/src/data/showcases.js
+++ b/src/data/showcases.js
@@ -285,7 +285,7 @@ const Showcases = [
     preview: require("./showcase/poolpm.png"),
     website: "https://pool.pm",
     source: null,
-    tags: ["favorite", "favorite", "explorer"],
+    tags: ["favorite", "explorer"],
   },
   {
     title: "Adafolio",


### PR DESCRIPTION
## Bugfix

- Remove doubled `favourite` tag from Pool PM showcase
