### PR TITLE
Add truncate (shorten version of article) to blogs that don't have it

### DIFF
--- a/blog/2021-12-20-december.md
+++ b/blog/2021-12-20-december.md
@@ -26,7 +26,6 @@ So the goal was to create a feature-rich comparison tool, which, looking at it t
 
 <!-- truncate -->
 
-
 **_Could you please give us a rundown of the most important things about ADApools?_**
 
 We've created the biggest and most popular pool comparison site, which is great! 

--- a/blog/2022-01-24-january.md
+++ b/blog/2022-01-24-january.md
@@ -27,6 +27,8 @@
 
  3. **Decentralization problem:** We see centralized oracle solutions, where one party is the governing authority on who gets what data and from where. We see centralization as part of the current financial system’s problem. We hope to solve that problem by being as “hands-off” as possible with our ecosystem solution.
 
+<!-- truncate -->
+
  **_What are the most important things about Charli3?_**
 
  - **From a team perspective:** Most importantly, Charli3 is working towards our company vision, mission, and cultivating a culture that reflects our core values. It is critical that we internalize our core values and reflect them in our actions with the community and our partners.

--- a/blog/2022-02-28-february.md
+++ b/blog/2022-02-28-february.md
@@ -35,6 +35,7 @@ sources={{
 
  COTI will solve these challenges by introducing a new type of DAG-based base protocol and infrastructure that is scalable, fast, private, inclusive, low cost, and optimized for finance.
 
+<!-- truncate -->
 
  <br />
 

--- a/blog/2022-03-30-march.md
+++ b/blog/2022-03-30-march.md
@@ -22,6 +22,7 @@
 
  Lovelace Academy is a blockchain education platform that aims to make it easier for our learners to navigate the developer ecosystem, understand key concepts and learn best practices while building on Cardano. Currently, no platforms guide newcomers on the "Why" and "How" to build on Cardano. So we are trying to be a one-stop platform to onboard people on Cardano.
 
+<!-- truncate -->
 
  <br />
 

--- a/blog/2022-04-27-april.md
+++ b/blog/2022-04-27-april.md
@@ -31,6 +31,7 @@ sources={{
 
 Minswap is a community-centric decentralized exchange on Cardano. With no venture capital funding or private investment, we aim to become the best DEX for anyone to buy and sell their Cardano native tokens, and earn passive income via yield farming and staking.
 
+<!-- truncate -->
 
  <br />
 


### PR DESCRIPTION
Issue - Currently Dev Blog preview is too long since some of the blogs don't have a `truncate`.

Fix - Add truncate (shorten version of article) to blogs that don't have it 
