### PR TITLE
Update docusaurus.config.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -62,6 +62,11 @@ module.exports = {
 
       items: [
         {
+          to: "docs/get-started/",
+          label: "Get Started",
+          position: "left",
+        },        
+        {
           to: "tools",
           label: "Builder Tools",
           position: "left",
@@ -69,11 +74,6 @@ module.exports = {
         {
           to: "showcase",
           label: "Showcase",
-          position: "left",
-        },
-        {
-          to: "docs/get-started/testnets-and-devnets",
-          label: "Testnets",
           position: "left",
         },
         {


### PR DESCRIPTION
## Updating documentation

#### Issue

Fixes #640

#### Description of the change

<!--
The Top Level Menu in my perspective does not match to the sidebar menu. I have removed "Testnets" which is subtopic of "Get Started" and replaced it with "Get Started" on the top menu instead. So, the user would have the option of navigating to one of the main topics from top menu or to one of the sub-topics from the boxes on page. 

-->

