### PR TITLE
Cardano node install - added libsecp256k1 details and more

### DIFF
--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -15,10 +15,10 @@ This guide will show you how to compile and install the `cardano-node` and `card
 If you want to avoid compiling the binaries yourself, you can download the latest versions of `cardano-node` and `cardano-cli` from the links below.
 
 <HydraBuildList
-    latest="9116257"
-    linux="9116140"
-    macos="9116041"
-    win64="9115926"/>
+    latest="16159682"
+    linux="16338142"
+    macos="16338141"
+    win64="16338127"/>
 
 The components can be built and run on **Windows** and **MacOS**, but we recommend that stake pool operators use **Linux** in production to take advantage of the associated performance advantages.
 :::

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -189,6 +189,7 @@ git checkout ac83be33
 ./autogen.sh
 ./configure --enable-module-schnorrsig --enable-experimental
 make
+make check
 sudo make install
 ```
 

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -29,7 +29,7 @@ To set up the components, you will need:
 
 * **Windows**, **MacOS**, or **Linux** for your operating system
 * An Intel or AMD x86 processor with **two or more cores, at 1.6GHz or faster** (2GHz or faster for a stake pool or relay)  
-* **12GB** of RAM and at least **30GB** of free disk space
+* **16GB** of RAM and at least **75GB** of free disk space
 
 :::note
 If intending to connect to mainnet instance, the requirements for RAM and storage would increase beyond baselines above.

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -103,7 +103,7 @@ Once complete, you should have `ghc` and `cabal` installed to your system.
 You can check if `ghcup` has been installed correctly by typing `ghcup --version` into the terminal. You should see something similar to the following: 
 
 ```
-The GHCup Haskell installer, version v0.1.17.4
+The GHCup Haskell installer, version v0.1.17.8
 ```
 
 `ghcup` will install the latest stable version of `ghc`. However, as of the time of writing this, [Input-Output](https://iohk.io) recommends using `ghc 8.10.7`. So, we will use `ghcup` to install and switch to the required version. 
@@ -177,6 +177,20 @@ export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 ```
 
 Once saved, we will then reload your shell profile to use the new variables. We can do that by typing `source $HOME/.bashrc` or `source $HOME/.zshrc` (***depending on the shell application you use***).
+
+We need to install Secp256k1 what is required for 1.35.0 cardano-node version
+
+Download and install libsecp256k1:
+```bash
+cd $HOME/cardano-src
+git clone https://github.com/bitcoin-core/secp256k1
+cd secp256k1
+git checkout ac83be33
+./autogen.sh
+./configure --enable-module-schnorrsig --enable-experimental
+make
+sudo make install
+```
 
 Now we are ready to download, compile and install `cardano-node` and `cardano-cli`. But first, we have to make sure we are back at the root of our working directory:
 
@@ -394,6 +408,20 @@ llvm installation path might differs based on your installation, if you used def
 :::
 
 Once saved, we will then reload your shell profile to use the new variables. We can do that by typing `source $HOME/.bashrc` or `source $HOME/.zshrc` (***depending on the shell application you use***).
+
+We need to install Secp256k1 what is required for 1.35.0 cardano-node version
+
+Download and install libsecp256k1:
+```bash
+cd $HOME/cardano-src
+git clone https://github.com/bitcoin-core/secp256k1
+cd secp256k1
+git checkout ac83be33
+./autogen.sh
+./configure --enable-module-schnorrsig --enable-experimental
+make
+sudo make install
+```
 
 Now we are ready to download, compile and install `cardano-node` and `cardano-cli`. But first, we have to make sure we are back at the root of our working directory:
 

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -421,6 +421,7 @@ git checkout ac83be33
 ./autogen.sh
 ./configure --enable-module-schnorrsig --enable-experimental
 make
+make check
 sudo make install
 ```
 


### PR DESCRIPTION
## Updating documentation

#### Description of the change

Updated cardano node installation page. Added details regarding new requirement - libsecp256k1 and how we can compile it. Added details regarding new system requirements. Updated links with latest binaries.