### PR TITLE
Update installing-cardano-node.md

### DIFF
--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -168,6 +168,16 @@ git checkout 66f017f1
 make
 sudo make install
 ```
+Then, download and install libsecp256k1:
+```
+git clone https://github.com/bitcoin-core/secp256k1
+cd secp256k1
+git checkout ac83be33
+./autogen.sh
+./configure --enable-module-schnorrsig --enable-experimental
+make
+sudo make install
+```
 
 Then we will add the following environment variables to your shell profile. E.G `$HOME/.zshrc` or `$HOME/.bashrc` depending on what shell application you are using. Add the following to the bottom of your shell profile/config file so that the compiler can be aware that `libsodium` is installed on your system.
 


### PR DESCRIPTION
## Quickfix

The cardano-node 1.35.0 version and above needs and extra library to be installed. The quickfix is from the build documentation on the cardano-node repository.