### PR TITLE
Docusaurus beta 21 built with yarn 3.x depends on prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@popperjs/core": "^2.11.2",
     "clsx": "^1.1.1",
     "node-fetch": "^2.6.7",
+    "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-popper": "^2.2.5",


### PR DESCRIPTION
New dependency (`prop-types`) created by https://github.com/cardano-foundation/developer-portal/pull/686.  Without it one gets the errors listed in https://github.com/cardano-foundation/developer-portal/pull/686#pullrequestreview-1034678501.