### PR TITLE
Modify build scripts: Replace fs.rmdir with fs.rm

### DIFF
--- a/scripts/cip.ts
+++ b/scripts/cip.ts
@@ -48,7 +48,7 @@ const processCIPContentAsync = async (cipName: string, content: string) => {
           );
 
           if (fs.existsSync(`.${CIPStaticResourcePath}${cipName}`)) {
-            fs.rmdirSync(`.${CIPStaticResourcePath}${cipName}`, {
+            fs.rmSync(`.${CIPStaticResourcePath}${cipName}`, {
               recursive: true,
             });
           }
@@ -131,7 +131,7 @@ const main = async () => {
   const cipUrlsUnique = [...new Set(cipUrls)];
 
   if (fs.existsSync(CIPDocsPath)) {
-    fs.rmdirSync(CIPDocsPath, { recursive: true });
+    fs.rmSync(CIPDocsPath, { recursive: true });
   }
   fs.mkdirSync(CIPDocsPath, { recursive: true });
 

--- a/scripts/token-registry.ts
+++ b/scripts/token-registry.ts
@@ -138,7 +138,7 @@ const main = async () => {
 
   // Create token registry folder to store markdown files locally
   if (fs.existsSync(TRDocsPath)) {
-    fs.rmdirSync(TRDocsPath, { recursive: true });
+    fs.rmSync(TRDocsPath, { recursive: true });
   }
   fs.mkdirSync(TRDocsPath, { recursive: true });
 


### PR DESCRIPTION
In future versions of `Node.js`, `fs.rmdir(path, { recursive: true })` will be removed.
