### PR TITLE
Add notes about the transaction era need to match

### DIFF
--- a/docs/stake-pool-course/handbook/register-stake-keys.md
+++ b/docs/stake-pool-course/handbook/register-stake-keys.md
@@ -72,9 +72,12 @@ It is either possible to simply keep the transaction as prepared above and send 
     > 997828515
 
 Herefore you would need to calculate the expression above and then build the transaction (as stated above) again, but adding the result calculated in the tx-out parameter:
-Note: In Babbage era the Babbage-era transaction is used by default and doesn't need to be specified on command line.
+
+:::note
+In Babbage era the Babbage-era transaction is used by default and doesn't need to be specified on command line.
 
 The transaction build command works only when transaction era is the same as network era. It cannot build e.g. Mary-era transaction on Babbage-era network. In that sense the --babbage-era, --alonzo-era, etc. options are redundant. The transaction build should figure out what the network era is and build same era transaction.
+:::
 
 ```sh
 cardano-cli transaction build \

--- a/docs/stake-pool-course/handbook/register-stake-keys.md
+++ b/docs/stake-pool-course/handbook/register-stake-keys.md
@@ -72,6 +72,9 @@ It is either possible to simply keep the transaction as prepared above and send 
     > 997828515
 
 Herefore you would need to calculate the expression above and then build the transaction (as stated above) again, but adding the result calculated in the tx-out parameter:
+Note: In Babbage era the Babbage-era transaction is used by default and doesn't need to be specified on command line.
+
+The transaction build command works only when transaction era is the same as network era. It cannot build e.g. Mary-era transaction on Babbage-era network. In that sense the --babbage-era, --alonzo-era, etc. options are redundant. The transaction build should figure out what the network era is and build same era transaction.
 
 ```sh
 cardano-cli transaction build \


### PR DESCRIPTION
## Updating documentation


<!--

If there is no issue for your PR, (i.e. typos or new article), remove the *issue* section and just provide the description.

-->

#### Description of the change

I added notes about the transaction era must match. I was following the current documentation to learn the staking pool but since I am on the test-net the alonzo-era was giving an error when trying to submit the transaction build. I change the transaction build to use the --babbage-era and it was successful. So I just wanted to add notes in the documentation to help others as they take the stake pool course. 

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

## Quickfix

<!--

Leave the ##Quickfix header.  

Don't provide any structure to your description or let the title of the PR speak for itself.

Be advised. PRs with no structure have the lowest priority for maintainers to review / merge and might not make it into the next release of the developer portal.

-->
