### PR TITLE
rectified --mint= syntax to correct form --mint 

### DIFF
--- a/docs/native-tokens/minting.md
+++ b/docs/native-tokens/minting.md
@@ -300,7 +300,7 @@ cardano-cli transaction build-raw \
  --fee $fee \
  --tx-in $txhash#$txix \
  --tx-out $address+$output+"$tokenamount $policyid.$tokenname1 + $tokenamount $policyid.$tokenname2" \
- --mint="$tokenamount $policyid.$tokenname1 + $tokenamount $policyid.$tokenname2" \
+ --mint "$tokenamount $policyid.$tokenname1 + $tokenamount $policyid.$tokenname2" \
  --minting-script-file policy/policy.script \
  --out-file matx.raw
 ```
@@ -354,7 +354,7 @@ The syntax is very important, so here it is word for word. There are no spaces u
 :::
 
 ```bash
---mint="$tokenamount $policyid.$tokenname1 + $tokenamount $policyid.$tokenname2" \
+--mint "$tokenamount $policyid.$tokenname1 + $tokenamount $policyid.$tokenname2" \
 ```
 Again, the same syntax as specified in <i>--tx-out</i> but without the address and output.
 
@@ -384,7 +384,7 @@ cardano-cli transaction build-raw \
 --fee $fee  \
 --tx-in $txhash#$txix  \
 --tx-out $address+$output+"$tokenamount $policyid.$tokenname1 + $tokenamount $policyid.$tokenname2" \
---mint="$tokenamount $policyid.$tokenname1 + $tokenamount $policyid.$tokenname2" \
+--mint "$tokenamount $policyid.$tokenname1 + $tokenamount $policyid.$tokenname2" \
 --minting-script-file policy/policy.script \
 --out-file matx.raw
 ```


### PR DESCRIPTION
the cardano-cli help mentions clearly that --mint should be followed by a space. but the sample shows --mint="..." 
This should be rectified to be the same as the help documentation.

* Tags:
  
  * `nativetoken`
  * `nft`
  * `wallet`
## Updating documentation

#### Description of the change
the --mint subcommand does not require an '=' sign following it. the documentation of the cardano-cli help clearly shows this. I've removed the extraneous '=' character from the commandline options.

@katomm "Hi Tommy! I've got one more minor edit for you to review" :)
