### PR TITLE
Fix broken code consoles in CSCLI markdown file

### DIFF
--- a/docs/get-started/cscli.md
+++ b/docs/get-started/cscli.md
@@ -239,12 +239,11 @@ addr1vy5zuhh9685fup86syuzmu3e6eengzv8t46mfqxg086cvqqrukl6w
 
 <details>
   <summary>Payment Enterprise Address with Custom Indexes</summary>
-  
+
 ```console
 $ cscli wallet address payment derive --recovery-phrase "$(cat phrase.en.prv)" --payment-address-type enterprise --network mainnet --account-index 1387 --address-index 12 | tee pay_1387_12.en.addr
 addr1vy3y89nnzdqs4fmqv49fmpqw24hjheen3ce7tch082hh6xcc8pzd9
 ```
-
 </details>
 
 ### Derive Payment Base Address
@@ -255,6 +254,7 @@ addr1qy5zuhh9685fup86syuzmu3e6eengzv8t46mfqxg086cvqzupvkzyt42349mnkhgu8ghqzgtsqv
 
 <details>
   <summary>Payment Base Address with Custom Indexes</summary>
+
 ```console
 $ cscli wallet address payment derive --recovery-phrase "$(cat phrase.en.prv)" --payment-address-type base --network mainnet --account-index 1387 --address-index 12 --stake-account-index 968 --stake-address-index 83106 | tee pay_1387_12_968_83106.en.addr
 addr1qy3y89nnzdqs4fmqv49fmpqw24hjheen3ce7tch082hh6x7nwwgg06dngunf9ea4rd7mu9084sd3km6z56rqd7e04ylslhzn9h


### PR DESCRIPTION
Thanks to [thenic95](https://github.com/thenic95) who found a bug related to code console in CSCLI markdown file, it's now fixed and properly displayed.