### PR TITLE
Fix broken links in getting started section and remove one link from tangocrypto that requires a sign-in

### DIFF
--- a/docs/get-started/cardano-serialization-lib/overview.md
+++ b/docs/get-started/cardano-serialization-lib/overview.md
@@ -64,9 +64,9 @@ following:
 
 Here are the location of the original [CDDL](http://cbor.io/tools.html) specifications:
 
--  Byron: [link](https://github.com/input-output-hk/cardano-ledger-specs/tree/master/byron/cddl-spec)
--  Shelley: [link](https://github.com/input-output-hk/cardano-ledger-specs/tree/master/shelley/chain-and-ledger/shelley-spec-ledger-test/cddl-files)
--  Mary: [link](https://github.com/input-output-hk/cardano-ledger-specs/tree/master/shelley-ma/shelley-ma-test/cddl-files)
+-  Byron: [link](https://github.com/input-output-hk/cardano-ledger/tree/master/eras/byron/cddl-spec)
+-  Shelley: [link](https://github.com/input-output-hk/cardano-ledger/tree/master/eras/shelley/test-suite/cddl-files)
+-  Mary: [link](https://github.com/input-output-hk/cardano-ledger/tree/master/eras/shelley-ma/test-suite/cddl-files)
 
 ## Building
 

--- a/docs/get-started/cardano-wallet-js.md
+++ b/docs/get-started/cardano-wallet-js.md
@@ -539,7 +539,7 @@ let signed = Buffer.from(txBody.to_bytes()).toString('hex');
 let txId = await walletServer.submitTx(signed);
 ```    
 ### Key handling
-There ara a couple of methods you can use to derive and get private/public key pairs. For more info check [here](https://docs.cardano.org/projects/cardano-wallet/en/latest/About-Address-Derivation.html).
+There ara a couple of methods you can use to derive and get private/public key pairs. For more info check [here](https://github.com/input-output-hk/technical-docs/blob/main/cardano-components/cardano-wallet/doc/About-Address-Derivation.md).
 
 Get root key from recovery phrase
 ```js
@@ -571,7 +571,7 @@ Output:
 > "xprv..."
 ```
 
-All the method mentioned above return a `Bip32PrivateKey` which you can use to keep deriving and generating keys and addresses check [here](https://docs.cardano.org/projects/cardano-serialization-lib/en/latest/) for more info. For example, assuming you have `cardano-serialization-lib` installed, 
+All the method mentioned above return a `Bip32PrivateKey` which you can use to keep deriving and generating keys and addresses check [here](../get-started/cardano-serialization-lib/overview.md) for more info. For example, assuming you have `cardano-serialization-lib` installed, 
 you can get a stake address like this:
 ```js
 let rootKey = Seed.deriveRootKey(phrase);

--- a/docs/get-started/cscli.md
+++ b/docs/get-started/cscli.md
@@ -255,12 +255,10 @@ addr1qy5zuhh9685fup86syuzmu3e6eengzv8t46mfqxg086cvqzupvkzyt42349mnkhgu8ghqzgtsqv
 
 <details>
   <summary>Payment Base Address with Custom Indexes</summary>
-  
 ```console
 $ cscli wallet address payment derive --recovery-phrase "$(cat phrase.en.prv)" --payment-address-type base --network mainnet --account-index 1387 --address-index 12 --stake-account-index 968 --stake-address-index 83106 | tee pay_1387_12_968_83106.en.addr
 addr1qy3y89nnzdqs4fmqv49fmpqw24hjheen3ce7tch082hh6x7nwwgg06dngunf9ea4rd7mu9084sd3km6z56rqd7e04ylslhzn9h
 ```
-
 </details>
 <details>
   <summary>Payment Base Address from Spanish recovery-phrase with custom passphrase</summary>

--- a/docs/get-started/cscli.md
+++ b/docs/get-started/cscli.md
@@ -255,10 +255,12 @@ addr1qy5zuhh9685fup86syuzmu3e6eengzv8t46mfqxg086cvqzupvkzyt42349mnkhgu8ghqzgtsqv
 
 <details>
   <summary>Payment Base Address with Custom Indexes</summary>
+  
 ```console
 $ cscli wallet address payment derive --recovery-phrase "$(cat phrase.en.prv)" --payment-address-type base --network mainnet --account-index 1387 --address-index 12 --stake-account-index 968 --stake-address-index 83106 | tee pay_1387_12_968_83106.en.addr
 addr1qy3y89nnzdqs4fmqv49fmpqw24hjheen3ce7tch082hh6x7nwwgg06dngunf9ea4rd7mu9084sd3km6z56rqd7e04ylslhzn9h
 ```
+
 </details>
 <details>
   <summary>Payment Base Address from Spanish recovery-phrase with custom passphrase</summary>

--- a/docs/get-started/tangocrypto.md
+++ b/docs/get-started/tangocrypto.md
@@ -65,7 +65,7 @@ Check our API full reference documentation here https://www.tangocrypto.com/api-
 
 To use Tangocrypto's products, you need an API key to authenticate your requests.
 
-You can [create API keys from the dashboard](https://dashboard.tangocrypto.com/home/dashboard), just click on +Create App, name it and hit create:
+You can create API keys from the dashboard, just click on +Create App, name it and hit create:
 
 ![alt text](../../static/img/get-started/tangocrypto/app.png)
 


### PR DESCRIPTION
Hi,

I found some broken links in the get-started section.

I'm not entirely sure about the link from the tangocrypto file, but if you follow the link, you can only see the dashboard if you are logged in. As there is a screenshot right below, I thought we could remove the link.

Best,
Nicolas