### PR TITLE
Move CVM from showcase to builder tools

### DIFF
--- a/src/data/builder-tools.js
+++ b/src/data/builder-tools.js
@@ -563,6 +563,15 @@ const Showcases = [
     getstarted: "/docs/get-started/cscli",
     tags: ["getstarted", "cli"],
   },
+  {
+    title: "CVM",
+    description:
+      "Cardano Version Manager, manage the configuration and versions of your pool.",
+    preview: require("./builder-tools/cvm.png"),
+    website: "https://github.com/orelvis15/cvm",
+    getstarted:  null,
+    tags: ["operatortool"],
+  },
 ];
 
 export const TagList = Object.keys(Tags);

--- a/src/data/showcases.js
+++ b/src/data/showcases.js
@@ -1084,15 +1084,6 @@ const Showcases = [
     source: "https://github.com/nilscodes/hazelnet",
     tags: [ "nftsupport", "opensource", "token"],
   },
-  {
-    title: "CVM",
-    description:
-      "Cardano Version Manager, manage the configuration and versions of your pool.",
-    preview: require("./builder-tools/cvm.png"),
-    website: "https://sites.google.com/view/cvmcli/inicio",
-    source:  "https://github.com/orelvis15/cvm",
-    tags: ["operatortool"],
-  },
 ];
 
 export const TagList = Object.keys(Tags);


### PR DESCRIPTION
Move from showcase to builder tools. CVM builder tool was not fully moved to builder tool section in #682. 