### PR TITLE
Revert "Move CVM from showcase to builder tools"

### DIFF
--- a/src/data/builder-tools.js
+++ b/src/data/builder-tools.js
@@ -563,15 +563,6 @@ const Showcases = [
     getstarted: "/docs/get-started/cscli",
     tags: ["getstarted", "cli"],
   },
-  {
-    title: "CVM",
-    description:
-      "Cardano Version Manager, manage the configuration and versions of your pool.",
-    preview: require("./builder-tools/cvm.png"),
-    website: "https://github.com/orelvis15/cvm",
-    getstarted:  null,
-    tags: ["operatortool"],
-  },
 ];
 
 export const TagList = Object.keys(Tags);


### PR DESCRIPTION
Reverts cardano-foundation/developer-portal#716 as this breaks staging again and no time to fix this. Images needs to be moved as well.