### PR TITLE
Add new filter to check latest showcases and builder tools 

### DIFF
--- a/src/components/showcase/ShowcaseFilterToggle/index.js
+++ b/src/components/showcase/ShowcaseFilterToggle/index.js
@@ -25,7 +25,7 @@ export default function ShowcaseFilterToggle() {
   const id = "showcase_filter_toggle";
   const location = useLocation();
   const history = useHistory();
-  const [operator, setOperator] = useState(true);
+  const [operator, setOperator] = useState(false);
 
   useEffect(() => {
     setOperator(readOperator(location.search) === "OR");

--- a/src/components/showcase/ShowcaseLatestToggle/index.js
+++ b/src/components/showcase/ShowcaseLatestToggle/index.js
@@ -25,7 +25,7 @@ export default function ShowcaseLatestToggle() {
   const id = "showcase_filter_toggle_latest";
   const location = useLocation();
   const history = useHistory();
-  const [operator, setOperator] = useState(true);
+  const [operator, setOperator] = useState(false);
 
   useEffect(() => {
     setOperator(readLatestOperator(location.search) === "LAST");

--- a/src/components/showcase/ShowcaseLatestToggle/index.js
+++ b/src/components/showcase/ShowcaseLatestToggle/index.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState, useEffect, useCallback } from "react";
+import { useHistory, useLocation } from "@docusaurus/router";
+
+import {prepareUserState} from '../../../pages/tools/index';
+
+import styles from "./styles.module.css";
+import clsx from "clsx";
+
+export const Operator = "ALL" | "LATEST";
+
+export const OperatorQueryKey = "projects";
+
+export function readLatestOperator(search) {
+  return new URLSearchParams(search).get(OperatorQueryKey) ?? "ALL";
+}
+
+export default function ShowcaseLatestToggle() {
+  const id = "showcase_filter_toggle_latest";
+  const location = useLocation();
+  const history = useHistory();
+  const [operator, setOperator] = useState(true);
+
+  useEffect(() => {
+    setOperator(readLatestOperator(location.search) === "LAST");
+  }, [location]);
+
+  const toggleOperator = useCallback(() => {
+    setOperator((o) => !o);
+    const searchParams = new URLSearchParams(location.search);
+    searchParams.delete(OperatorQueryKey);
+    if (!operator) {
+      searchParams.append(OperatorQueryKey, operator ? "ALL" : "LAST");
+    }
+    history.push({
+      ...location,
+      search: searchParams.toString(),
+      state: prepareUserState(),
+    });
+  }, [operator, location, history]);
+
+  return (
+    <div>
+      <input
+        type="checkbox"
+        id={id}
+        className={styles.screenReader}
+        onChange={toggleOperator}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            toggleOperator();
+          }
+        }}
+        checked={!operator}
+      />
+      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+      <label htmlFor={id} className={clsx(styles.checkboxLabel, "shadow--md")}>
+        <span className={styles.checkboxLabelOr}>LAST</span>
+        <span className={styles.checkboxLabelALL}>ALL</span>
+      </label>
+    </div>
+  );
+}

--- a/src/components/showcase/ShowcaseLatestToggle/styles.module.css
+++ b/src/components/showcase/ShowcaseLatestToggle/styles.module.css
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ .screenReader {
+    border: 0;
+    clip: rect(0 0 0 0);
+    clip-path: polygon(0 0, 0 0, 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 10px;
+    white-space: nowrap;
+  }
+  
+  .checkboxLabel {
+    --height: 25px;
+    --width: 80px;
+    --border: 2px;
+    display: flex;
+    width: var(--width);
+    height: var(--height);
+    position: relative;
+    border-radius: var(--height);
+    border: var(--border) solid var(--ifm-color-primary-darkest);
+    cursor: pointer;
+    justify-content: space-around;
+    opacity: 0.75;
+    transition: opacity var(--ifm-transition-fast)
+      var(--ifm-transition-timing-default);
+    box-shadow: var(--ifm-global-shadow-md);
+  }
+  
+  .checkboxLabel:hover {
+    opacity: 1;
+    box-shadow: var(--ifm-global-shadow-md),
+      0 0 2px 1px var(--ifm-color-primary-dark);
+  }
+  
+  .checkboxLabel::after {
+    position: absolute;
+    content: '';
+    inset: 0;
+    width: calc(var(--width) / 2);
+    height: 100%;
+    border-radius: var(--height);
+    background-color: var(--ifm-color-primary-darkest);
+    transition: transform var(--ifm-transition-fast)
+      var(--ifm-transition-timing-default);
+    transform: translateX(calc(var(--width) / 2 - var(--border)));
+  }
+  
+  input:focus-visible ~ .checkboxLabel::after {
+    outline: 2px solid currentColor;
+  }
+  
+  .checkboxLabel > * {
+    font-size: 0.8rem;
+    color: inherit;
+    transition: opacity 150ms ease-in 50ms;
+  }
+  
+  input:checked ~ .checkboxLabel::after {
+    transform: translateX(calc(-1 * var(--border)));
+  }

--- a/src/pages/showcase/index.js
+++ b/src/pages/showcase/index.js
@@ -10,6 +10,10 @@ import ShowcaseFilterToggle, {
 } from "@site/src/components/showcase/ShowcaseFilterToggle";
 import clsx from "clsx";
 
+import ShowcaseLatestToggle, {
+  readLatestOperator,
+} from "@site/src/components/showcase/ShowcaseLatestToggle";
+
 import PortalHero from "../portalhero";
 import { toggleListItem } from "../../utils/jsUtils";
 import { SortedShowcases, Tags, TagList } from "../../data/showcases";
@@ -66,7 +70,13 @@ function replaceSearchTags(search, newTags) {
 }
 
 // Filter projects based on chosen project tags, toggle operator or searchbar value
-function filterProjects(projects, selectedTags, operator, searchName) {
+function filterProjects(projects, selectedTags, latest, operator, searchName) {
+  
+  // Check if "LAST" filter is applied to decide if to filter through all projects or only last ones
+  if (latest === "LAST") {
+    var projects = projects.slice(-10);
+  }
+
   if (searchName) {
     projects = projects.filter((project) =>
       project.title.toLowerCase().includes(searchName.toLowerCase())
@@ -75,11 +85,11 @@ function filterProjects(projects, selectedTags, operator, searchName) {
   if (selectedTags.length === 0) {
     return projects;
   }
+
   return projects.filter((project) => {
     if (project.tags.length === 0) {
       return false;
-    }
-    if (operator === "AND") {
+    } else if (operator === "AND") {
       return selectedTags.every((tag) => project.tags.includes(tag));
     } else {
       return selectedTags.some((tag) => project.tags.includes(tag));
@@ -90,6 +100,7 @@ function filterProjects(projects, selectedTags, operator, searchName) {
 function useFilteredProjects() {
   const location = useLocation();
   const [operator, setOperator] = useState("OR");
+  const [latest, setLatest] = useState("LAST");
 
   // On SSR / first mount (hydration) no tag is selected
   const [selectedTags, setSelectedTags] = useState([]);
@@ -99,13 +110,21 @@ function useFilteredProjects() {
   useEffect(() => {
     setSelectedTags(readSearchTags(location.search));
     setOperator(readOperator(location.search));
+    setLatest(readLatestOperator(location.search));
     setSearchName(readSearchName(location.search));
     restoreUserState(location.state);
   }, [location]);
 
   return useMemo(
-    () => filterProjects(SortedShowcases, selectedTags, operator, searchName),
-    [selectedTags, operator, searchName]
+    () =>
+      filterProjects(
+        SortedShowcases,
+        selectedTags,
+        latest,
+        operator,
+        searchName
+      ),
+    [selectedTags, latest, operator, searchName]
   );
 }
 
@@ -143,7 +162,6 @@ function ShowcaseHeader() {
 }
 
 function ShowcaseFilters() {
-
   const filteredProjects = useFilteredProjects();
 
   return (
@@ -155,6 +173,7 @@ function ShowcaseFilters() {
             filteredProjects.length === 1 ? '' : 's'
           }`}</span>
         </div>
+        <ShowcaseLatestToggle />
         <ShowcaseFilterToggle />
       </div>
       <div className={styles.checkboxList}>
@@ -180,7 +199,11 @@ function ShowcaseFilters() {
                             marginLeft: 8,
                           }}
                         >
-                      <Fav svgClass={styles.svgIconFavorite} size="small" style={{display: 'grid'}}/>
+                          <Fav
+                            svgClass={styles.svgIconFavorite}
+                            size="small"
+                            style={{ display: "grid" }}
+                          />
                         </span>
                       ) : (
                         <span
@@ -253,10 +276,8 @@ function ShowcaseCards() {
       ) : (
         <div className="container">
           <div
-            className={clsx(
-              'margin-bottom--md',
-              styles.showcaseFavoriteHeader,
-            )}>
+            className={clsx("margin-bottom--md", styles.showcaseFavoriteHeader)}
+          >
             <SearchBar />
           </div>
           <ul className={styles.showcaseList}>

--- a/src/pages/showcase/index.js
+++ b/src/pages/showcase/index.js
@@ -21,7 +21,7 @@ import { useHistory, useLocation } from "@docusaurus/router";
 import styles from "./styles.module.css";
 
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
-import Fav from "../../svg/fav.svg"
+import Fav from "../../svg/fav.svg";
 
 const TITLE = "Showcase";
 const DESCRIPTION = "See the awesome projects people are building with Cardano";
@@ -40,10 +40,10 @@ export function prepareUserState() {
 }
 
 const favoriteShowcases = SortedShowcases.filter((showcase) =>
-  showcase.tags.includes('favorite'),
+  showcase.tags.includes("favorite")
 );
 const otherShowcases = SortedShowcases.filter(
-  (showcase) => !showcase.tags.includes('favorite'),
+  (showcase) => !showcase.tags.includes("favorite")
 );
 
 function restoreUserState(userState) {
@@ -71,7 +71,6 @@ function replaceSearchTags(search, newTags) {
 
 // Filter projects based on chosen project tags, toggle operator or searchbar value
 function filterProjects(projects, selectedTags, latest, operator, searchName) {
-  
   // Check if "LAST" filter is applied to decide if to filter through all projects or only last ones
   if (latest === "LAST") {
     var projects = projects.slice(-10);
@@ -170,7 +169,7 @@ function ShowcaseFilters() {
         <div>
           <h2>Filters</h2>
           <span>{`${filteredProjects.length} project${
-            filteredProjects.length === 1 ? '' : 's'
+            filteredProjects.length === 1 ? "" : "s"
           }`}</span>
         </div>
         <ShowcaseLatestToggle />
@@ -250,14 +249,15 @@ function ShowcaseCards() {
             <div className="container">
               <div
                 className={clsx(
-                  'margin-bottom--md',
-                  styles.showcaseFavoriteHeader,
-                )}>
+                  "margin-bottom--md",
+                  styles.showcaseFavoriteHeader
+                )}
+              >
                 <h2 className={styles.ourFavorites}>Our favorites</h2>
-                <Fav svgClass={styles.svgIconFavorite} size="small"/>
+                <Fav svgClass={styles.svgIconFavorite} size="small" />
                 <SearchBar />
               </div>
-              <ul className={clsx('container', styles.showcaseList)}>
+              <ul className={clsx("container", styles.showcaseList)}>
                 {favoriteShowcases.map((showcase) => (
                   <ShowcaseCard key={showcase.title} showcase={showcase} />
                 ))}
@@ -340,7 +340,7 @@ function Showcase() {
       <ShowcaseHeader />
       <ShowcaseFilters selectedTags={selectedTags} toggleTag={toggleTag} />
       <ShowcaseCards filteredProjects={filteredProjects} />
-      <OpenStickyButton/>
+      <OpenStickyButton />
     </Layout>
   );
 }

--- a/src/pages/tools/index.js
+++ b/src/pages/tools/index.js
@@ -170,7 +170,7 @@ function ShowcaseFilters() {
         <div>
           <h2>Filters</h2>
           <span>{`${filteredProjects.length} builder tool${
-            filteredProjects.length === 1 ? '' : 's'
+            filteredProjects.length === 1 ? "" : "s"
           }`}</span>
         </div>
         <ShowcaseLatestToggle />

--- a/src/pages/tools/index.js
+++ b/src/pages/tools/index.js
@@ -10,6 +10,10 @@ import ShowcaseFilterToggle, {
 } from "@site/src/components/showcase/ShowcaseFilterToggle";
 import clsx from "clsx";
 
+import ShowcaseLatestToggle, {
+  readLatestOperator,
+} from "@site/src/components/showcase/ShowcaseLatestToggle";
+
 import PortalHero from "../portalhero";
 import { toggleListItem } from "../../utils/jsUtils";
 import { SortedShowcases, Tags, TagList } from "../../data/builder-tools";
@@ -47,7 +51,7 @@ function restoreUserState(userState) {
     scrollTopPosition: 0,
     focusedElementId: undefined,
   };
-  
+
   document.getElementById(focusedElementId)?.focus();
   window.scrollTo({ top: scrollTopPosition });
 }
@@ -67,7 +71,12 @@ function replaceSearchTags(search, newTags) {
 }
 
 // Filter projects based on chosen project tags, toggle operator or searchbar value
-function filterProjects(projects, selectedTags, operator, searchName) {
+function filterProjects(projects, selectedTags, latest, operator, searchName) {
+  // Check if "LAST" filter is applied to decide if to filter through all projects or only last ones
+  if (latest === "LAST") {
+    var projects = projects.slice(-10);
+  }
+
   if (searchName) {
     projects = projects.filter((project) =>
       project.title.toLowerCase().includes(searchName.toLowerCase())
@@ -91,6 +100,7 @@ function filterProjects(projects, selectedTags, operator, searchName) {
 function useFilteredProjects() {
   const location = useLocation();
   const [operator, setOperator] = useState("OR");
+  const [latest, setLatest] = useState("LAST");
 
   // On SSR / first mount (hydration) no tag is selected
   const [selectedTags, setSelectedTags] = useState([]);
@@ -100,13 +110,21 @@ function useFilteredProjects() {
   useEffect(() => {
     setSelectedTags(readSearchTags(location.search));
     setOperator(readOperator(location.search));
+    setLatest(readLatestOperator(location.search));
     setSearchName(readSearchName(location.search));
     restoreUserState(location.state);
   }, [location]);
 
   return useMemo(
-    () => filterProjects(SortedShowcases, selectedTags, operator, searchName),
-    [selectedTags, operator, searchName]
+    () =>
+      filterProjects(
+        SortedShowcases,
+        selectedTags,
+        latest,
+        operator,
+        searchName
+      ),
+    [selectedTags, latest, operator, searchName]
   );
 }
 
@@ -144,7 +162,6 @@ function ShowcaseHeader() {
 }
 
 function ShowcaseFilters() {
-
   const filteredProjects = useFilteredProjects();
 
   return (
@@ -156,6 +173,7 @@ function ShowcaseFilters() {
             filteredProjects.length === 1 ? '' : 's'
           }`}</span>
         </div>
+        <ShowcaseLatestToggle />
         <ShowcaseFilterToggle />
       </div>
       <div className={styles.checkboxList}>
@@ -323,7 +341,7 @@ function Showcase() {
       <ShowcaseHeader />
       <ShowcaseFilters selectedTags={selectedTags} toggleTag={toggleTag} />
       <ShowcaseCards filteredProjects={filteredProjects} />
-      <OpenStickyButton/>
+      <OpenStickyButton />
     </Layout>
   );
 }


### PR DESCRIPTION
I'm currently working on a new feature for users to filter showcases and builder tools by latest projects. I would like to hear your opinion on it. 

Currently I'm displaying LAST 10 projects added in the filter. What do you think?

![filter](https://user-images.githubusercontent.com/60065019/187116869-ab35e19c-deb2-4734-85c9-1b46aa47d220.gif)

