### PR TITLE
Add a new builder tool tag - PureScript

### DIFF
--- a/src/data/builder-tools.js
+++ b/src/data/builder-tools.js
@@ -175,6 +175,14 @@ export const Tags = {
     color: '#7e6a4c',
   },
 
+  // Purescript
+  purescript: {
+    label: "Purescript",
+    description:
+      "PureScript language",
+    icon: null,
+    color: '#0F9D58',
+  },
 };
 
 // Add your builder tool to (THE END OF) this list.


### PR DESCRIPTION
Current staging is failing to build, since one of the builder tools had a non existing tag. I've added PureScript as another filter in Builder Tools.

I would like to hear your opinion if we should add it, or remove the tag completely? 