### PR TITLE
Fix displaying unfiltered 10 last projects in showcases 

### DIFF
--- a/src/data/builder-tools.js
+++ b/src/data/builder-tools.js
@@ -187,7 +187,7 @@ export const Tags = {
 
 // Add your builder tool to (THE END OF) this list.
 // Please don't add the "favorite"-tag yourself.
-const Showcases = [
+export const Showcases = [
   {
     title: "cardano-cli",
     description: "The companion command-line to interact with a Cardano node, manipulate addresses or create transactions.",

--- a/src/data/showcases.js
+++ b/src/data/showcases.js
@@ -210,7 +210,7 @@ export const Tags = {
 // Add your project to (THE END OF) this list.
 // Please don't add the "favorite"-tag yourself.
 // Provide pure NFT projects only get the tag NFT, not "tokens"
-const Showcases = [
+export const Showcases = [
   {
     title: "Cardano Kidz",
     description:
@@ -1063,8 +1063,10 @@ const Showcases = [
 export const TagList = Object.keys(Tags);
 function sortShowcases() {
   let result = Showcases;
+
   // Sort by site name
   result = sortBy(result, (showcase) => showcase.title.toLowerCase());
+
   // Sort by favorite tag, favorite first
   result = sortBy(result, (showcase) => !showcase.tags.includes("favorite"));
   return result;

--- a/src/pages/showcase/index.js
+++ b/src/pages/showcase/index.js
@@ -16,7 +16,7 @@ import ShowcaseLatestToggle, {
 
 import PortalHero from "../portalhero";
 import { toggleListItem } from "../../utils/jsUtils";
-import { SortedShowcases, Tags, TagList } from "../../data/showcases";
+import { SortedShowcases, Tags, TagList, Showcases } from "../../data/showcases";
 import { useHistory, useLocation } from "@docusaurus/router";
 import styles from "./styles.module.css";
 
@@ -70,10 +70,10 @@ function replaceSearchTags(search, newTags) {
 }
 
 // Filter projects based on chosen project tags, toggle operator or searchbar value
-function filterProjects(projects, selectedTags, latest, operator, searchName) {
+function filterProjects(projects, selectedTags, latest, operator, searchName, unfilteredProjects) {
   // Check if "LAST" filter is applied to decide if to filter through all projects or only last ones
   if (latest === "LAST") {
-    var projects = projects.slice(-10);
+    var projects = unfilteredProjects.slice(-10);
   }
 
   if (searchName) {
@@ -121,7 +121,8 @@ function useFilteredProjects() {
         selectedTags,
         latest,
         operator,
-        searchName
+        searchName,
+        Showcases
       ),
     [selectedTags, latest, operator, searchName]
   );

--- a/src/pages/tools/index.js
+++ b/src/pages/tools/index.js
@@ -16,7 +16,7 @@ import ShowcaseLatestToggle, {
 
 import PortalHero from "../portalhero";
 import { toggleListItem } from "../../utils/jsUtils";
-import { SortedShowcases, Tags, TagList } from "../../data/builder-tools";
+import { SortedShowcases, Tags, TagList, Showcases } from "../../data/builder-tools";
 import { useHistory, useLocation } from "@docusaurus/router";
 import styles from "./styles.module.css";
 
@@ -71,10 +71,10 @@ function replaceSearchTags(search, newTags) {
 }
 
 // Filter projects based on chosen project tags, toggle operator or searchbar value
-function filterProjects(projects, selectedTags, latest, operator, searchName) {
+function filterProjects(projects, selectedTags, latest, operator, searchName, unfilteredProjects) {
   // Check if "LAST" filter is applied to decide if to filter through all projects or only last ones
   if (latest === "LAST") {
-    var projects = projects.slice(-10);
+    var projects = unfilteredProjects.slice(-10);
   }
 
   if (searchName) {
@@ -122,7 +122,8 @@ function useFilteredProjects() {
         selectedTags,
         latest,
         operator,
-        searchName
+        searchName,
+        Showcases
       ),
     [selectedTags, latest, operator, searchName]
   );


### PR DESCRIPTION
Previously if filter is enabled wouldn't display the actual last 10 projects from the array but filtered by favourite and alphabetical 