### PR TITLE
Fix cardano-node build instructions on recent MacOS M1

### DIFF
--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -462,12 +462,38 @@ cabal configure --with-compiler=ghc-8.10.7
 echo "package trace-dispatcher" >> cabal.project.local
 echo "  ghc-options: -Wwarn" >> cabal.project.local
 echo "" >> cabal.project.local
+
+echo "package HsOpenSSL" >> cabal.project.local
+echo "  flags: -homebrew-openssl" >> cabal.project.local
+echo "" >> cabal.project.local
 ```
 
 #### Building and installing the node
 ```bash
 cabal build all
 ```
+:::caution
+More recent versions of MacOS seems to install openssl in a different location than expected by default. If you have installed openssl via **homebrew** and encounter the following build error:
+
+```
+Failed to build HsOpenSSL-0.11.7.2. The failure occurred during the configure
+step.
+[1 of 1] Compiling Main (...)
+Linking .../dist-newstyle/tmp/src-75805/HsOpenSSL-0.11.7.2/dist/setup/setup ...
+Configuring HsOpenSSL-0.11.7.2...
+setup: Can’t find OpenSSL library
+```
+
+You'll most likely need to add relevant symlinks as follows:
+
+```
+sudo mkdir -p /usr/local/opt/openssl
+sudo ln -s /opt/homebrew/opt/openssl@3/lib /usr/local/opt/openssl/lib
+sudo ln -s /opt/homebrew/opt/openssl@3/include /usr/local/opt/openssl/include
+```
+
+This is a wart of the `HsOpenSSL` library wrapper, and using classic methods such as setting `LDFLAGS` & `CPPFLAGS`, or using `--extra-include-dirs` and `--extra-lib-dirs` won't work properly.
+:::
 
 Install the newly built node and CLI to the $HOME/.local/bin directory:
 


### PR DESCRIPTION
On a brand-new MacOS w/ M1 (not sure if the problem really is the ARM arch here, or simply that homebrew has changed default installation paths of openssl libs & includes); exact same issue also hit by at least one other MacOS M1 user. 

Moreover It seems that on MacOS, the [`HsOpenSSL`](https://github.com/haskell-cryptography/HsOpenSSL/blob/master/HsOpenSSL.cabal#L90-L96) haskell package also require an extra flag (`-homebrew-openssl` or `-macport-openssl` depending on the mean of installation) without what it will simply not find OpenSSL. 

![Screenshot from 2022-09-10 08-59-32](https://user-images.githubusercontent.com/5680256/189473155-4c4ae251-fff5-4366-b654-c910cb5c38c9.png)

