### PR TITLE
Modify maximum Changelog users icons from 10 to 20 before unfold option

### DIFF
--- a/src/plugins/changelog/theme/ChangelogItem/Header/Authors/index.tsx
+++ b/src/plugins/changelog/theme/ChangelogItem/Header/Authors/index.tsx
@@ -20,7 +20,7 @@ export default function BlogPostAuthors({
   if (authorsCount === 0) {
     return null;
   }
-  const filteredAuthors = authors.slice(0, expanded ? authors.length : 10);
+  const filteredAuthors = authors.slice(0, expanded ? authors.length : 20);
   return (
     <div
       className={clsx(
@@ -39,7 +39,7 @@ export default function BlogPostAuthors({
           />
         </div>
       ))}
-      {authors.length > 10 && (
+      {authors.length > 20 && (
         <button
           className={clsx('clean-btn', styles.toggleButton)}
           type="button"


### PR DESCRIPTION
Modify maximum users icons displayed from 10 to 20 to display more user icons. At the end of the day we want to display more icons so users can easily find themselves on the list. 

Old: 
<img width="670" alt="Screenshot 2022-09-19 at 15 07 22" src="https://user-images.githubusercontent.com/60065019/190974926-d941afbb-54ee-4b31-96ba-47fd85d4e979.png">

New: 
<img width="726" alt="Screenshot 2022-09-19 at 15 05 49" src="https://user-images.githubusercontent.com/60065019/190974785-24d18dfc-06df-4dd9-957c-6299bb792eba.png">


