### PR TITLE
Installing cardano-node: MacOS missing openssl

### DIFF
--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -290,6 +290,7 @@ brew install libtool
 brew install autoconf
 brew install automake
 brew install pkg-config
+brew install openssl
 ```
 
 #### You will need to install llvm in case you are using M1


### PR DESCRIPTION
Thanks for the Mac installation doc. It worked perfectly (Intel) but I was missing openssl. I though it would be useful to add it in the brew packages list.