### PR TITLE
Open graph images patch

### DIFF
--- a/blog/2021-01-07-january.md
+++ b/blog/2021-01-07-january.md
@@ -7,7 +7,7 @@ author_url: https://github.com/cardano-foundation
 author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
 tags: [pooltools]
 description: Cardano Developer Spotlight January 2021
-image: https://developers.cardano.org/img/og-blog-adatools.png
+image: https://developers.cardano.org/img/og/og-blog-adatools.png
 ---
 
 Welcome to the January Developer Spotlight 2021. This month, we will focus on pool tools. Read on to learn about the **ADATools.io** and the **Pool.pm**.

--- a/blog/2021-02-03-february.md
+++ b/blog/2021-02-03-february.md
@@ -7,7 +7,7 @@ author_url: https://github.com/cardano-foundation
 author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
 tags: [developers, educational]
 description: Cardano Developer Spotlight February 2021
-image: https://developers.cardano.org/img/og-blog-ada-makerspace.png
+image: https://developers.cardano.org/img/og/og-blog-ada-makerspace.png
 ---
 
 Welcome to the February Developer Spotlight 2021. This month, we will focus on educators, and developer-focused content creators. Read on to learn about the **ADA MakerSpace** and the **Hitchhiker's Guides**.

--- a/blog/2021-03-26-march.md
+++ b/blog/2021-03-26-march.md
@@ -7,7 +7,7 @@ author_url: https://github.com/cardano-foundation
 author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
 tags: [hardware, educational]
 description: Cardano Developer Spotlight March 2021
-image: https://developers.cardano.org/img/og-blog-on-the-rocks.png
+image: https://developers.cardano.org/img/og/og-blog-on-the-rocks.png
 ---
 
 Welcome to the March Developer Spotlight 2021. This month, we will focus on both educational content and stake pool tools. Read on to learn about **Cardano on the Rocks** and **JorManager**.

--- a/blog/2021-07-12-developer-portal-launch.md
+++ b/blog/2021-07-12-developer-portal-launch.md
@@ -7,7 +7,7 @@ author_url: https://github.com/cardano-foundation
 author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
 tags: [developer-portal, nft, nfta]
 description: "Finally here: the Cardano developer portal! Accepting all builds."
-image: https://developers.cardano.org/img/og-blog-launch.png
+image: https://developers.cardano.org/img/og/og-blog-launch.png
 ---
 
 ![title image](/img/devblog/developer-portal-launch.jpeg)

--- a/blog/2021-07-26-july.md
+++ b/blog/2021-07-26-july.md
@@ -7,7 +7,7 @@ author_url: https://github.com/cardano-foundation
 author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
 tags: [nft, interview]
 description: "July Spotlight Interview"
-image: https://developers.cardano.org/img/og-blog-nftmaker.png
+image: https://developers.cardano.org/img/og/og-blog-nftmaker.png
 ---
 
 ![title image](/img/devblog/nftmaker-background-img.png)

--- a/blog/2021-08-09-nft-minting-standard.md
+++ b/blog/2021-08-09-nft-minting-standard.md
@@ -7,7 +7,7 @@ author_url: https://github.com/cardano-foundation
 author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
 tags: [developer-portal, nft, nfta]
 description: "How we minted the NFTAs, and why we went for this standard."
-image: https://developers.cardano.org/img/og-blog-nftas.png
+image: https://developers.cardano.org/img/og/og-blog-nftas.png
 ---
 
 ![title image](/img/devblog/nfta.jpg)

--- a/blog/2021-08-23-august.md
+++ b/blog/2021-08-23-august.md
@@ -7,7 +7,7 @@ author_url: https://github.com/cardano-foundation
 author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
 tags: [payment, interview]
 description: "August Spotlight Interview"
-image: https://developers.cardano.org/img/og-blog-mercury.png
+image: https://developers.cardano.org/img/og/og-blog-mercury.png
 ---
 
 ![title image](/img/devblog/mercury-logo.jpg)

--- a/blog/2021-09-20-september.md
+++ b/blog/2021-09-20-september.md
@@ -7,7 +7,7 @@ author_url: https://github.com/cardano-foundation
 author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
 tags: [payment, interview]
 description: "September Spotlight Interview"
-image: https://developers.cardano.org/img/og-blog-nowpayments.png
+image: https://developers.cardano.org/img/og/og-blog-nowpayments.png
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2021-10-28-october.md
+++ b/blog/2021-10-28-october.md
@@ -7,7 +7,7 @@ author_url: https://github.com/cardano-foundation
 author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
 tags: [nft, interview]
 description: "October Spotlight Interview"
-image: https://developers.cardano.org/img/og-blog-tokhun.png
+image: https://developers.cardano.org/img/og/og-blog-tokhun.png
 ---
 
 ![title image](/img/devblog/tokhun.png)

--- a/blog/2021-11-23-november.md
+++ b/blog/2021-11-23-november.md
@@ -7,7 +7,7 @@ author_url: https://github.com/cardano-foundation
 author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
 tags: [wallet, nft, interview]
 description: "November Spotlight Interview"
-image: https://developers.cardano.org/img/og-blog-nami.png
+image: https://developers.cardano.org/img/og/og-blog-nami.png
 ---
 
 ![title image](/img/devblog/nami.png)

--- a/blog/2021-12-20-december.md
+++ b/blog/2021-12-20-december.md
@@ -7,7 +7,7 @@ author_url: https://github.com/cardano-foundation
 author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
 tags: [spo, interview]
 description: "December Spotlight Interview"
-image: https://developers.cardano.org/img/og-blog-adapools.png
+image: https://developers.cardano.org/img/og/og-blog-adapools.png
 ---
 
 ![title image](/img/devblog/adapools.png)

--- a/blog/2022-01-24-january.md
+++ b/blog/2022-01-24-january.md
@@ -7,7 +7,7 @@
  author_image_url: "https://avatars.githubusercontent.com/u/37078161?s=200&v=4"
  tags: [oracle, interview]
  description: "January 2022 Spotlight Interview"
- image: "https://developers.cardano.org/img/og-blog-charlie.png"
+ image: "https://developers.cardano.org/img/og/og-blog-charlie.png"
 ---
 
  ![title image](../static/img/devblog/charli3.png)

--- a/blog/2022-02-28-february.md
+++ b/blog/2022-02-28-february.md
@@ -7,7 +7,7 @@
  author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
  tags: [payment, interview]
  description: "February Spotlight Interview"
- image: https://developers.cardano.org/img/og-blog-coti.png
+ image: https://developers.cardano.org/img/og/og-blog-coti.png
 ---
 
  <!-- ![title image](/img/devblog/coti.jpg) -->

--- a/blog/2022-03-30-march.md
+++ b/blog/2022-03-30-march.md
@@ -7,7 +7,7 @@
  author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
  tags: [education, interview]
  description: "March Spotlight Interview"
- image: https://developers.cardano.org/img/og-blog-lovelace-academy.png
+ image: https://developers.cardano.org/img/og/og-blog-lovelace-academy.png
 ---
 
  ![title image](/img/devblog/lovelace.png)

--- a/blog/2022-04-27-april.md
+++ b/blog/2022-04-27-april.md
@@ -7,7 +7,7 @@
  author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
  tags: [dex, interview]
  description: "April Spotlight Interview"
- image: https://developers.cardano.org/img/og-blog-minswap.png
+ image: https://developers.cardano.org/img/og/og-blog-minswap.png
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2022-05-30-may.md
+++ b/blog/2022-05-30-may.md
@@ -7,7 +7,7 @@ author_url: https://github.com/cardano-foundation
 author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
 tags: [education, interview]
 description: "We interviewed Nicolas Arqueros, the co-founder of dcSpark about the Milkomeda protocol."
-image: https://developers.cardano.org/img/og-blog-milkomeda.png
+image: https://developers.cardano.org/img/og/og-blog-milkomeda.png
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2022-07-11-july.md
+++ b/blog/2022-07-11-july.md
@@ -7,7 +7,7 @@ author_url: https://github.com/cardano-foundation
 author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
 tags: [education, interview]
 description: "We interviewed the Koios team about their consistent query layer for Cardano's developers to build upon, with multiple, redundant endpoints that allow for easy scalability."
-image: https://developers.cardano.org/img/og/og-developer-portal.png
+image: https://developers.cardano.org/img/og/og-blog-koios.png
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/blog/2022-08-11-august.md
+++ b/blog/2022-08-11-august.md
@@ -7,7 +7,7 @@ author_url: https://github.com/cardano-foundation
 author_image_url: https://avatars.githubusercontent.com/u/37078161?s=200&v=4
 tags: [wallet, block explorer, interview]
 description: "We interviewed Ashish Prajapati, the co-founder of Strica about various projects they are building and how they contribute to the Cardano ecosystem."
-image: https://developers.cardano.org/img/og-blog-strica.png
+image: https://developers.cardano.org/img/og/og-blog-strica.png
 ---
 
 import ThemedImage from '@theme/ThemedImage';

--- a/docs/get-started/blockfrost.md
+++ b/docs/get-started/blockfrost.md
@@ -3,7 +3,7 @@ id: blockfrost
 title: Get Started with Blockfrost
 sidebar_label: Blockfrost
 description: Get Started with Blockfrost
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-blockfrost.png
 ---
 
 Blockfrost provides API to access and process information stored on the Cardano blockchain. The basic tier is free and allows 50,000 requests per day.

--- a/docs/get-started/cardano-components.md
+++ b/docs/get-started/cardano-components.md
@@ -3,7 +3,7 @@ id: cardano-components
 title: Cardano Components
 sidebar_label: Overview
 description: This article explains all the different Cardano components and their functions.
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-cardano-components.png
 --- 
 
 The Cardano blockchain is powered by a flock of inter-connected nodes. The [`cardano-node`](https://github.com/input-output-hk/cardano-node#cardano-node-overview) is the software capable of running as a core block producer, as a relay or as a local entry-point to the network. The node itself is made out of several inter-connected component parts:

--- a/docs/get-started/cardano-developer-community.md
+++ b/docs/get-started/cardano-developer-community.md
@@ -3,7 +3,7 @@ id: cardano-developer-community
 title: Get Started in the Cardano Developer Community
 sidebar_label: Developer Community
 description: Get Started in the Cardano Developer Community.
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-developer-community.png
 --- 
 
 Apart from the two leading platforms [Stack Exchange](https://cardano.stackexchange.com) and [Cardano Forum](https://forum.cardano.org/c/developers/29), Cardano developers and stake pool operators spread across different platforms. Each with its niche.

--- a/docs/get-started/cardano-wallet-js.md
+++ b/docs/get-started/cardano-wallet-js.md
@@ -3,7 +3,7 @@ id: cardano-wallet-js
 title: Get Started with cardano-wallet-js
 sidebar_label: cardano-wallet-js
 description: Get Started with cardano-wallet-js
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-cardano-wallet-js.png
 ---
 
 ## cardano-wallet-js

--- a/docs/get-started/cardanocli-js.md
+++ b/docs/get-started/cardanocli-js.md
@@ -3,7 +3,7 @@ id: cardanocli-js
 title: Get Started with cardanocli-js
 sidebar_label: cardanocli-js
 description: Get Started with cardanocli-js
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-cardanocli-js.png
 ---
 
 cardanocli-js wraps the cardano-cli in JavaScript and makes it possible to interact with the cli-commands much faster and more efficient.

--- a/docs/get-started/cardanosharp-wallet.md
+++ b/docs/get-started/cardanosharp-wallet.md
@@ -3,7 +3,7 @@ id: cardanosharp-wallet
 title: Get Started with CardanoSharp Wallet
 sidebar_label: CardanoSharp Wallet
 description: Get Started with CardanoSharp Wallet
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-cardanosharp-wallet.png
 --- 
 
 # CardanoSharp.Wallet 

--- a/docs/get-started/cscli.md
+++ b/docs/get-started/cscli.md
@@ -3,7 +3,7 @@ id: cscli
 title: Get Started with cscli
 sidebar_label: cscli
 description: Get Started with cscli
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-cscli.png
 --- 
 
 `cscli` is a lightweight cross-platform CLI tool for Cardano supporting the following features out of the box:

--- a/docs/get-started/dandelion-apis.md
+++ b/docs/get-started/dandelion-apis.md
@@ -3,7 +3,7 @@ id: dandelion-apis
 title: Get Started with Dandelion APIs
 sidebar_label: Dandelion APIs
 description: Get Started with Dandelion APIs
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-dandelion-apis.png
 --- 
 
 Dandelion currently offer 2 different paths to get started: 

--- a/docs/get-started/installing-cardano-node.md
+++ b/docs/get-started/installing-cardano-node.md
@@ -3,7 +3,7 @@ id: installing-cardano-node
 title: Installing cardano-node and cardano-cli from source
 sidebar_label: Installing cardano-node
 description: This guide shows how to build and install the cardano-node and cardano-cli from the source-code for all major Operating Systems
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-installing-cardano-node.png
 --- 
 import HydraBuildList from '@site/src/components/docs/HydraBuildList';
 

--- a/docs/get-started/installing-cardano-wallet.md
+++ b/docs/get-started/installing-cardano-wallet.md
@@ -3,7 +3,7 @@ id: installing-cardano-wallet
 title: Installing cardano-wallet
 sidebar_label: Installing cardano-wallet
 description: This guide shows how to build and install the cardano-wallet from the source-code for all major Operating Systems
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-installing-cardano-wallet.png
 --- 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/get-started/koios.md
+++ b/docs/get-started/koios.md
@@ -3,7 +3,7 @@ id: koios
 title: Get Started with Koios
 sidebar_label: Koios
 description: Get Started with Koios
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-koios.png
 ---
 
 Koios provides an open-source & elastic API layer that allows you to query Cardano blockchain (across mainnet, testnet and guildnet network).

--- a/docs/get-started/ogmios.md
+++ b/docs/get-started/ogmios.md
@@ -3,7 +3,7 @@ id: ogmios
 title: Get Started with Ogmios
 sidebar_label: Ogmios
 description: Get Started with Ogmios
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-ogmios.png
 ---
 
 **Ogmios** is a lightweight bridge interface for [cardano-node](https://github.com/input-output-hk/cardano-node/). It offers a WebSockets API that enables local clients to speak [Ouroboros' mini-protocols](https://hydra.iohk.io/build/1070091/download/1/network.pdf#chapter.3) via JSON/RPC.

--- a/docs/get-started/overview.md
+++ b/docs/get-started/overview.md
@@ -4,7 +4,7 @@ slug: /get-started/
 title: Get Started
 sidebar_label: Overview
 description: Get Started
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-overview.png
 --- 
 ![Cardano Get Started](../../static/img/card-get-started-title.svg)
 

--- a/docs/get-started/running-cardano.md
+++ b/docs/get-started/running-cardano.md
@@ -3,7 +3,7 @@ id: running-cardano
 title: How to run cardano-node
 sidebar_label: Running cardano-node
 description: This guide will explain and show you how to run the cardano-node and components on your system.
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-running-cardano-node.png
 --- 
 ### Overview 
 

--- a/docs/get-started/secure-workflow.md
+++ b/docs/get-started/secure-workflow.md
@@ -3,7 +3,7 @@ id: secure-workflow
 title: Secure Transaction Workflow
 sidebar_label: Secure Transaction Workflow
 description: Procedures for using private keys separately from the Internet.
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-security-secure-transaction-workflow.png
 --- 
 
 This general guide is written to help Cardano stake pool operators and developers keep to one simple rule:

--- a/docs/get-started/tangocrypto.md
+++ b/docs/get-started/tangocrypto.md
@@ -3,7 +3,7 @@ id: tangocrypto
 title: Getting started with Tangocrypto
 sidebar_label: Tangocrypto
 description: Getting started with Tangocrypto
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-tangocrypto.png
 ---
 
 # What is Tangocrypto?

--- a/docs/get-started/technical-concepts.md
+++ b/docs/get-started/technical-concepts.md
@@ -3,7 +3,7 @@ id: technical-concepts
 title: Get started with the technical concepts
 sidebar_label: Technical Concepts
 description: Get started with the technical concepts behind Cardano.
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-technical-concepts.png
 --- 
 
 To get the most out of the Cardano Developer Portal, you should have programming experience and a basic understanding of blockchain concepts such as [UTxO](#unspent-transaction-output-utxo), [transactions](#transactions), [addresses](#addresses), [key derivation](#key-derivation), and [networking](#networking).

--- a/docs/get-started/testnets-and-devnets.md
+++ b/docs/get-started/testnets-and-devnets.md
@@ -3,7 +3,7 @@ id: testnets-and-devnets
 title: Get started with testnets
 sidebar_label: Testnets
 description: Get started with testnets and devnets
-image: ../img/og/og-developer-portal.png
+image: ../img/og/og-getstarted-testnets.png
 --- 
 
 To make the difference between Cardano mainnet functionality and testnet functionality clearer, we moved the old content of [developers.cardano.org](https://developers.cardano.org) to [testnets.cardano.org](https://testnets.cardano.org) with the launch of this developer portal.


### PR DESCRIPTION
This PR will fix issues introduced with PR #788 and update more pages to use a specific open graph image instead of the default one, that only shows the start page of the developer portal.

<img width="557" alt="Screenshot 2022-09-22 at 13 08 52" src="https://user-images.githubusercontent.com/31965230/191731489-52e4e4c4-b6e9-40b9-9c0c-fe9d9f0f22e8.png">
