### PR TITLE
Adding a link to Plutus resources on Cardano Docs

### DIFF
--- a/docs/smart-contracts/plutus.md
+++ b/docs/smart-contracts/plutus.md
@@ -9,7 +9,7 @@ image: ../img/og/og-developer-portal.png
 ## Get started with Plutus 
 Plutus is the smart contract platform of the Cardano blockchain. It allows you to write applications that interact with the Cardano blockchain.
 
-Take a look at the [Plutus Tutorial](https://plutus.readthedocs.io/en/latest/tutorials/) if you want to learn Plutus from the beginning. If you don't know Haskell yet, consider [starting with Haskell](#get-started-with-haskell).
+Take a look at the [Plutus Tutorial](https://plutus.readthedocs.io/en/latest/tutorials/) if you want to learn Plutus from the beginning or see [Plutus resources](https://docs.cardano.org/plutus/plutus-resources), where you can find references to all Plutus-related repositories, documentation, and training materials. If you don't know Haskell yet, consider [starting with Haskell](#get-started-with-haskell).
 
 [Follow Chris Moreton's content updates](https://plutus-pioneer-program.readthedocs.io/en/latest/plutus_pioneer_program.html). With a high effort he transcribes the lectures of the Plutus Pioneer Program. 
 


### PR DESCRIPTION
Hello :) We have recently created a new section on Cardano Docs, which serves as a Plutus index - a list of different references to Plutus materials. We will be growing this list & also asking the community to contribute. I have just added a link to it from your Plutus overview. Thanks so much

