### PR TITLE
Fix tutorial links in plutus.md

### DIFF
--- a/docs/smart-contracts/plutus.md
+++ b/docs/smart-contracts/plutus.md
@@ -37,9 +37,9 @@ There is a written tutorial on [how to compile and test a Plutus App](https://pl
 
 ## Further Tutorials
 - [Writing a basic Plutus app in the Plutus Playground](https://plutus-apps.readthedocs.io/en/latest/plutus/tutorials/basic-apps.html)
-- [Using Plutus Tx](https://plutus-apps.readthedocs.io/en/latest/plutus/tutorials/plutus-tx.html)
-- [Writing basic validator scripts](https://plutus-apps.readthedocs.io/en/latest/plutus/tutorials/basic-validators.html)
-- [Writing basic minting policies](https://plutus-apps.readthedocs.io/en/latest/plutus/tutorials/basic-minting-policies.html)
+- [Using Plutus Tx](https://plutus.readthedocs.io/en/latest/tutorials/plutus-tx.html)
+- [Writing basic validator scripts](https://plutus.readthedocs.io/en/latest/tutorials/basic-validators.html)
+- [Writing basic minting policies](https://plutus.readthedocs.io/en/latest/tutorials/basic-minting-policies.html)
 - [Property-based testing of Plutus contracts](https://plutus-apps.readthedocs.io/en/latest/plutus/tutorials/contract-testing.html)
 
 ## How-to guides


### PR DESCRIPTION
## Quickfix

Seems like the links were incorrectly updated during the `plutus` repository split. 
