### PR TITLE
Replace Changelog title and remove copyright

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -225,7 +225,7 @@ module.exports = {
     [
       require.resolve('./src/plugins/changelog/index.js'),
       {
-        blogTitle: 'Docusaurus changelog',
+        blogTitle: 'Developer Portal Changelog',
         blogDescription:
           'Keep yourself up-to-date about new features in every release',
         blogSidebarCount: 'ALL',
@@ -237,10 +237,9 @@ module.exports = {
         authorsMapPath: 'authors.json',
         feedOptions: {
           type: 'all',
-          title: 'Docusaurus changelog',
+          title: 'Developer Portal Changelog',
           description:
             'Keep yourself up-to-date about new features in every release',
-          copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
           language: 'en',
         },
       },


### PR DESCRIPTION
## Checklist

- [x] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [x] I have run `yarn build` after adding my changes **without getting any errors**. 

## Updating documentation or Bugfix

- Replace `Docusaurus Changelog` title with `Developer Portal Changelog`
- Remove Copyright 

<img width="251" alt="title" src="https://user-images.githubusercontent.com/60065019/200604616-eb8d3dca-f7f9-40f8-bf6b-ab1f9a83f587.png">

