### PR TITLE
Fix preprod typo

### DIFF
--- a/docs/get-started/running-cardano.md
+++ b/docs/get-started/running-cardano.md
@@ -61,7 +61,7 @@ curl -O -J https://book.world.dev.cardano.org/environments/preview/byron-genesis
 curl -O -J https://book.world.dev.cardano.org/environments/preview/shelley-genesis.json
 curl -O -J https://book.world.dev.cardano.org/environments/preview/alonzo-genesis.json
 ```
-#### Testnet / Prerod
+#### Testnet / Preprod
 
 **NetworkMagic**: `1`
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [x] I have run `yarn build` after adding my changes **without getting any errors**. 

## Updating documentation or Bugfix

Fixed just a small typo (missing "p") in the subtitle. "prerod" to "preprod" :)