### PR TITLE
Dev Community links: fix CIPs server invite

### DIFF
--- a/docs/get-started/cardano-developer-community.md
+++ b/docs/get-started/cardano-developer-community.md
@@ -34,7 +34,7 @@ Dedicated channel for Marlowe developers and users. Marlowe is a specialized dom
 [**Developer Portal Discord**](https://discord.gg/Exe6XmqKDx)  
 If you would like to help develop the Developer Portal further, please join our [Discord](https://discord.gg/Exe6XmqKDx). 
 
-[**CIPs - biweekly meetings**](https://discord.gg/tDeGHPEWEG)  
+[**CIPs - biweekly meetings**](https://discord.com/invite/Jy9YM69Ezf)  
 CIP meetings discuss Cardano Improvement Proposals every other week. Join Editors and community members in the dedicated discord server to keep up with the ongoing technical discussions regarding standards, processes and ongoing Cardano conversations.
 
 ## Stake pool operator channels


### PR DESCRIPTION
I noticed this link had gone off when pointed to this page by the CF SPO delegation application.  There are a few CIP Discord server invites that are not set to expire, so I've set it to the same one currently listed in the CIPs repository (and in `CIP-0001`): https://github.com/cardano-foundation/CIPs/blob/master/README.md