### PR TITLE
Add a link to community developed smart contract languages

### DIFF
--- a/docs/smart-contracts/overview.md
+++ b/docs/smart-contracts/overview.md
@@ -24,5 +24,14 @@ In another world, you'd like to build programs, possibly even replace a major co
 - The smart contract is a piece of code that allows a decentralized system to operate.
 
 ## Programming languages
+
+There are a variety of smart contract languages exist.
+
+#### Official languages
+
 - [Marlowe](marlowe) - a domain-specific language, it covers the world of financial contracts.
 - [Plutus](plutus) - a platform to write full applications that interact with the Cardano blockchain. 
+
+#### Community projects
+
+You can find an overview over community led smart contract languages [here](https://aiken-lang.org/ecosystem-overview#the-alternatives)

--- a/docs/smart-contracts/overview.md
+++ b/docs/smart-contracts/overview.md
@@ -25,7 +25,7 @@ In another world, you'd like to build programs, possibly even replace a major co
 
 ## Programming languages
 
-There are a variety of smart contract languages exist.
+There are a variety of smart contract languages available for developing dApps on Cardano.
 
 #### Official languages
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [x] I have run `yarn build` after adding my changes **without getting any errors**. 

## Updating documentation or Bugfix

The Cardano smart contract page is the first search result when looking for "Smart contract development on Cardano". It is important to fight the misconception that Cardano allows only Haskell contracts and to show the strength and diversity of the Cardano community. it would hence be great to either list community led alternatives directly or link to the list provided by the community when introducing potential new developers to Cardano.