### PR TITLE
Minting NFTs: missing command output

### DIFF
--- a/docs/native-tokens/minting-nfts.md
+++ b/docs/native-tokens/minting-nfts.md
@@ -441,6 +441,11 @@ cardano-cli query utxo --address $address --mainnet
 ```
 
 and should see something like this:
+```bash
+                         TxHash                                   TxIx        Amount
+--------------------------------------------------------------------------------------
+e86535386ecd803d061a923c0da1fad82f46b0f2e3fdd766fb23e7f1b490a0e8     0        1518558 lovelace + 1 ad79da159614ff55130b3a28189fbe5c429c0dfc1c0aeaf94a1de95e.4b6964646f7330373138 + TxOutDatumNone
+```
 
 ### Displaying your NFT
 


### PR DESCRIPTION

- [X] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [X] I have run `yarn build` after adding my changes **without getting any errors**. 

## Updating documentation or Bugfix

The Minting NFTs tutorial offers a command and states what the user should see, but the example is not provided. This commit adds an example of what one might see when querying a UTXO with an NFT present.