### PR TITLE
Move guidelines for builder tools and showcase into docs

### DIFF
--- a/docs/portal-contribute.md
+++ b/docs/portal-contribute.md
@@ -52,7 +52,7 @@ Help to add good projects to the [showcase section](http://developers.cardano.or
 * It has to run on Cardano mainnet.
 * It has to have a running product. (no presale, no protected pages, no coming soon messages)
 * It has to have enough community reputation.
-* It has to provide a unique value from existing showcase items. 
+* It has to provide a unique value distinct from existing showcase items. 
 * It has to have a stable domain name. (a random Netlify/Vercel domain is not allowed, no URL shortener, no app store links, or similar)
 * The GitHub account that adds the project must not be new. 
 * The GitHub account must have a history/or already be known in the Cardano community.

--- a/docs/portal-contribute.md
+++ b/docs/portal-contribute.md
@@ -57,7 +57,7 @@ Help to add good projects to the [showcase section](http://developers.cardano.or
 * The GitHub account that adds the project must not be new. 
 * The GitHub account must have a history/or already be known in the Cardano community.
 * Describe what makes your project special, avoid phrases like "the first this and that". Granular details like which project was first is tribal attribute known to cause rift and conflicts.
-* Please refrain from adding NFT projects unless they are immensely different from what is already listed in terms of utility. We can't list hundrets of NFT. For details please follow or take part in the discussion [here](https://github.com/cardano-foundation/developer-portal/discussions/243). (TLDR: we are adding winners of the CNFT awards)
+* Please refrain from adding NFT projects unless they are immensely different from what is already listed in terms of utility. We can't list hundreds of NFT projects. For details please follow or take part in the discussion [here](https://github.com/cardano-foundation/developer-portal/discussions/243). (TL;DR: we are adding winners of the [CNFT Awards](https://www.cnft-awards.io/))
 * If you add a project which main component is NFT, please select "nftproject" as tag. (not "nftsupport")
 
 Mainly the project showcase should be a place where someone new to the ecosystem can come to see what can be done. For example we agreed that projects have to have a running product today on Cardano mainnet, no promises, no pre-sales, no coming soon pages. We also don't [aim to map out a future ecosystem.](https://developers.cardano.org/showcase?tags=ecosystem)

--- a/docs/portal-contribute.md
+++ b/docs/portal-contribute.md
@@ -48,7 +48,7 @@ If you think something is wrong or something fundamental should change, discussi
 
 ### Add a project to showcase 
 Help to add good projects to the [showcase section](http://developers.cardano.org/showcase/). Please note the guidelines for adding new projects:
-* It must be built on Cardano and have a real use case. For example, a forum where people can talk about Cardano is great, but nothing for this showcase section.
+* It must be built on Cardano and have a real use case. For example, a forum where people can talk about Cardano is great, but not for this showcase section.
 * It has to run on Cardano mainnet.
 * It has to have a running product. (no presale, no protected pages, no coming soon messages)
 * It has to have enough community reputation.

--- a/docs/portal-contribute.md
+++ b/docs/portal-contribute.md
@@ -58,7 +58,7 @@ Help to add good projects to the [showcase section](http://developers.cardano.or
 * The GitHub account must have a history/or already be known in the Cardano community.
 * Describe what makes your project special, avoid phrases like "the first this and that". Granular details like which project was first is tribal attribute known to cause rift and conflicts.
 * Please refrain from adding NFT projects unless they are immensely different from what is already listed in terms of utility. We can't list hundreds of NFT projects. For details please follow or take part in the discussion [here](https://github.com/cardano-foundation/developer-portal/discussions/243). (TL;DR: we are adding winners of the [CNFT Awards](https://www.cnft-awards.io/))
-* If you add a project which main component is NFT, please select "nftproject" as tag. (not "nftsupport")
+* If you add a project with a main component of NFTs, please select "nftproject" as tag. (not "nftsupport")
 
 Mainly the project showcase should be a place where someone new to the ecosystem can come to see what can be done. For example we agreed that projects have to have a running product today on Cardano mainnet, no promises, no pre-sales, no coming soon pages. We also don't [aim to map out a future ecosystem.](https://developers.cardano.org/showcase?tags=ecosystem)
 

--- a/docs/portal-contribute.md
+++ b/docs/portal-contribute.md
@@ -46,12 +46,34 @@ If you think something is wrong or something fundamental should change, discussi
 * [Issues in the GitHub Repo](https://github.com/cardano-foundation/developer-portal/issues) 
 * [Discussions in the GitHub Repo](https://github.com/cardano-foundation/developer-portal/discussions)
 
-### Add projects to showcase or builder tools
-Help to add good projects or builder tools. Please note the different guidelines for [adding showcases](https://github.com/cardano-foundation/developer-portal/edit/staging/src/data/showcases.js) or [builder tools](https://github.com/cardano-foundation/developer-portal/edit/staging/src/data/builder-tools.js).
+### Add a project to showcase 
+Help to add good projects to the [showcase section](http://developers.cardano.org/showcase/). Please note the guidelines for adding new projects:
+* It must be built on Cardano and have a real use case. For example, a forum where people can talk about Cardano is great, but nothing for this showcase section.
+* It has to run on Cardano mainnet.
+* It has to have a running product. (no presale, no protected pages, no coming soon messages)
+* It has to have enough community reputation.
+* It has to provide a unique value from existing showcase items. 
+* It has to have a stable domain name. (a random Netlify/Vercel domain is not allowed, no URL shortener, no app store links, or similar)
+* The GitHub account that adds the project must not be new. 
+* The GitHub account must have a history/or already be known in the Cardano community.
+* Describe what makes your project special, avoid phrases like "the first this and that". Granular details like which project was first is tribal attribute known to cause rift and conflicts.
+* Please refrain from adding NFT projects unless they are immensely different from what is already listed in terms of utility. We can't list hundrets of NFT. For details please follow or take part in the discussion [here](https://github.com/cardano-foundation/developer-portal/discussions/243). (TLDR: we are adding winners of the CNFT awards)
+* If you add a project which main component is NFT, please select "nftproject" as tag. (not "nftsupport")
 
 Mainly the project showcase should be a place where someone new to the ecosystem can come to see what can be done. For example we agreed that projects have to have a running product today on Cardano mainnet, no promises, no pre-sales, no coming soon pages. We also don't [aim to map out a future ecosystem.](https://developers.cardano.org/showcase?tags=ecosystem)
 
-Adding projects or builder tools will require [creating a pull request.](#create-pull-requests)
+Adding projects to the [showcase section](http://developers.cardano.org/showcase/) will require [creating a pull request](#create-pull-requests).
+
+### Add tools to builder tools
+Help to add useful tools to the [builder tools section](http://developers.cardano.org/tools/). Please note the guidelines for adding new builder tools:
+* It is an actual builder tool that adds value to Cardano developers.
+* It has a stable domain name (a random for example, Netlify/Vercel domain is not allowed)
+* The GitHub account that adds the builder tool must not be new.
+* The GitHub account must have a history/or already be known in the Cardano community.
+
+A builder tool is a software application or platform that enables users to create, modify, and deploy software applications, or other digital products on Cardano.
+
+Adding tools to the [builder tools section](http://developers.cardano.org/tools/) will require [creating a pull request](#create-pull-requests).
 
 ### Create/improve documentation
 Documentation can constantly be improved, and there are gaps in the developer portal. In particular, the stake pool operator section needs a lot of work. [To create and improve documentation, you should install the portal on your local machine.](#installation)

--- a/src/data/builder-tools.js
+++ b/src/data/builder-tools.js
@@ -2,10 +2,7 @@
  * BUILDER TOOLS SECTION INFO
  *
  * Requirements for adding your builder tool:
- * - It is an actual builder tool that adds value to Cardano developers.
- * - It has a stable domain name (a random for example, Netlify/Vercel domain is not allowed)
- * - The GitHub account that adds the builder tool must not be new.
- * - The GitHub account must have a history/or already be known in the Cardano community.
+ * https://developers.cardano.org/docs/portal-contribute#add-tools-to-builder-tools
  *
  * Instructions:
  * - Add your tool in the json array at the end of the array.

--- a/src/data/showcases.js
+++ b/src/data/showcases.js
@@ -6,20 +6,7 @@
  * every project is promoted.
  * 
  * REQUIREMENTS FOR ADDING YOUR PROJECT TO THE SHOWCASE SECTION:
- * - It must be built on Cardano and have a real use case. For example, a forum where 
- *   people can talk about Cardano is great, but nothing for this showcase section.
- * - It has to run on Cardano mainnet.
- * - It has to have a running product. (no presale, no protected pages, no coming soon messages)
- * - It has to have enough community reputation.
- * - It has to provide a unique value from existing showcase items. (we can't list 
- *   thousands of NFT or native tokens with the current UI)
- * - It has to have a stable domain name. (a random Netlify/Vercel domain is not allowed, no 
- *   URL shortener, no app store links, or similar)
- * - The GitHub account that adds the project must not be new. 
- * - The GitHub account must have a history/or already be known in the Cardano community.
- * - Describe what makes your project special, avoid phrases like "the first this and that". Granular 
- *   details like which project was first is tribal attribute known to cause rift and conflicts.
- * - IF YOU ADD A PROJECT WHICH MAIN COMPONENT IS NFT, PLEASE SELECT "NFTPROJECT" AS TAG. (NOT "NFTSUPPORT")
+ * https://developers.cardano.org/docs/portal-contribute#add-a-project-to-showcase
  *
  * INSTRUCTIONS:
  * - Add your project in the JSON array below.


### PR DESCRIPTION
## Checklist
- [x] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [x] I have run `yarn build` after adding my changes **without getting any errors**. 

## Updating documentation 
- Move guidelines for builder tools and showcase into the docs/portal-contribute and link from the comments 
- Add a sentence about adding NFT projects like mentioned in #1012

I didn't find a good way to add relative links to the comment section so please note that these link will only work **after** the PR is merged into main:

https://developers.cardano.org/docs/portal-contribute#add-tools-to-builder-tools
https://developers.cardano.org/docs/portal-contribute#add-a-project-to-showcase