### PR TITLE
Fix mobile jump bug when using search bar in Showcase/Tool pages

### DIFF
--- a/src/pages/showcase/index.js
+++ b/src/pages/showcase/index.js
@@ -322,10 +322,11 @@ function SearchBar() {
           history.push({
             ...location,
             search: newSearch.toString(),
+            state: prepareUserState(),
           });
           setTimeout(() => {
             document.getElementById("searchbar")?.focus();
-          }, 1);
+          }, 0);
         }}
       />
     </div>

--- a/src/pages/tools/index.js
+++ b/src/pages/tools/index.js
@@ -321,10 +321,11 @@ function SearchBar() {
           history.push({
             ...location,
             search: newSearch.toString(),
+            state: prepareUserState(),
           });
           setTimeout(() => {
             document.getElementById("searchbar")?.focus();
-          }, 1);
+          }, 0);
         }}
       />
     </div>


### PR DESCRIPTION
## Checklist

- [x] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [x] I have run `yarn build` after adding my changes **without getting any errors**. 

## Updating documentation or Bugfix

Mobile version would perform a jump to the top of the page when using searchbar in showcase/tool pages. This PR fixes this issue. 