### PR TITLE
fix: blockfrost link - get started

### DIFF
--- a/src/data/builder-tools.js
+++ b/src/data/builder-tools.js
@@ -374,7 +374,7 @@ export const Showcases = [
     description: "Instant and scalable API to the Cardano blockchain.",
     preview: require("./builder-tools/blockfrost.png"),
     website: "https://blockfrost.io",
-    getstarted: "/docs/get-started/blockfrost",
+    getstarted: "/docs/get-started/blockfrost/get-started/",
     tags: ["favorite", "http", "json", "hosted"],
   },
   {


### PR DESCRIPTION
Fix for broken link. (Get Started)

<img width="346" alt="image" src="https://user-images.githubusercontent.com/3112191/236563666-8188b219-bea2-4e74-bf1f-59b6c2701418.png">
