### PR TITLE
On-Chain Polls: Fix verify-poll parameter

### DIFF
--- a/docs/operate-a-stake-pool/on-chain-polls.md
+++ b/docs/operate-a-stake-pool/on-chain-polls.md
@@ -132,7 +132,7 @@ Assuming you still have the original `poll.json` file, and a signed transaction 
 ```
 $ cardano-cli governance verify-poll \
   --poll-file poll.json \
-  --signed-tx-file answer.signed
+  --tx-file answer.signed
 ```
 ​
 Upon successful execution, this should produce something like:


### PR DESCRIPTION
It's --tx-file, not --signed-tx-file


## Checklist

- [x] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [x] I have run `yarn build` after adding my changes **without getting any errors**. 

## Updating documentation or Bugfix

![image](https://github.com/cardano-foundation/developer-portal/assets/2385844/b7d9cfd4-c42d-4adb-9b4b-2b2ade96ba29)

