### PR TITLE
Remove duplicate sidebar link

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -285,7 +285,7 @@ module.exports = {
         type: "link",
         label: "Changelog",
         href: "/changelog",
-      }
+      },
     ],
   },
 };

--- a/sidebars.js
+++ b/sidebars.js
@@ -285,12 +285,7 @@ module.exports = {
         type: "link",
         label: "Changelog",
         href: "/changelog",
-      },
-      {
-        type: "link",
-        label: "Changelog",
-        href: "/changelog",
-      },
+      }
     ],
   },
 };


### PR DESCRIPTION
- [x] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [x] I have run `yarn build` after adding my changes **without getting any errors**. 

## Updating documentation or Bugfix

Just removing a sidebar link to changelog that got duplicated recently (https://github.com/cardano-foundation/developer-portal/commit/4fc8930d3ecdc2a0ee95b8b26283c102fc981add#diff-9a6a0fdafefb0eecffb77784bc94f5ad984062167b8bcb7c4a899c90f6f567e8)