### PR TITLE
Update libsodium hash in node-installation-process.md

### DIFF
--- a/docs/operate-a-stake-pool/node-installation-process.md
+++ b/docs/operate-a-stake-pool/node-installation-process.md
@@ -135,7 +135,7 @@ Next, we will download, compile and install `libsodium`.
 ```bash
 git clone https://github.com/input-output-hk/libsodium
 cd libsodium
-git checkout 66f017f1
+git checkout dbb48cc
 ./autogen.sh
 ./configure
 make


### PR DESCRIPTION
## Updating documentation or Bugfix

Minor fix : At cardano-node 8.0.0, libsodium fork reference was [updated upstream](https://github.com/input-output-hk/cardano-node/blob/b0e1bc580955b6260e80e1247f0c671bb1d8fa81/doc/getting-started/install.md?plain=1#L115), rendering the old commit reference on developers.cardano.org stale