### PR TITLE
Marlowe page: add security review

### DIFF
--- a/docs/smart-contracts/marlowe.md
+++ b/docs/smart-contracts/marlowe.md
@@ -72,9 +72,10 @@ Marlowe uses two validators: the _semantics validator_ for the Marlowe DSL and a
 
 ## More resources
 
-### Documentation
+### Documentation & overview
 
 - Official [Marlowe documentation](https://docs.marlowe.iohk.io)
+- [A comprehensive guide to Marlowe's security: audit outcomes, built-in functional restrictions, and ledger security features](https://iohk.io/en/blog/posts/2023/06/27/a-comprehensive-guide-to-marlowes-security-audit-outcomes-built-in-functional-restrictions-and-ledger-security-features/)
 
 ### GitHub repositories
 


### PR DESCRIPTION
Not to get in the habit of adding these links one at a time (https://github.com/cardano-foundation/developer-portal/pull/1095, https://github.com/cardano-foundation/developer-portal/pull/1078) but I believe this blog entry today, which developed from the recently linked Tweag audit, also serves as a substantial documentation page.

@joseph-fajen @bwbush please confirm if you think this link is presented appropriately or not.