### PR TITLE
Registering a Pool: remove GitHub & TinyURL

### DIFF
--- a/docs/operate-a-stake-pool/register-stake-pool.md
+++ b/docs/operate-a-stake-pool/register-stake-pool.md
@@ -62,7 +62,7 @@ cardano-cli stake-pool metadata-hash --pool-metadata-file poolMetaData.json > po
 
 ## Get the hash of your JSON file
 
-Upload your `poolMetaData.json` file to a web site that you administer or a public web site. For example, you can upload to GitHub.
+Upload your `poolMetaData.json` file to a web site that you administer or a public web site.
 Verify the metadata hashes by comparing your uploaded .json file and your local .json file's hash.
 
 ```
@@ -148,10 +148,6 @@ In case an error similar to the one below appears, then the URL length needs to 
 ```
 
 and you must generate the certificate again with the new, shorter URL.
-
-:::tip
-[TinyUrl](https://tinyurl.com/) can used to achieve a shorter URL address.
-:::
 
 ## Create a delegation certificate pledge
 

--- a/docs/operate-a-stake-pool/register-stake-pool.md
+++ b/docs/operate-a-stake-pool/register-stake-pool.md
@@ -62,7 +62,7 @@ cardano-cli stake-pool metadata-hash --pool-metadata-file poolMetaData.json > po
 
 ## Get the hash of your JSON file
 
-Upload your `poolMetaData.json` file to a web site that you administer or a public web site.
+Make your poolMetadata.json available as a web URL accessible on internet, ideally without  redirections. You can do so by uploading it to your website as well.
 Verify the metadata hashes by comparing your uploaded .json file and your local .json file's hash.
 
 ```


### PR DESCRIPTION
## Checklist

- [x] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [x] I have run `yarn build` after adding my changes **without getting any errors**. 

## Updating documentation or Bugfix

I removed Git as the recommended place for saving metadata and also removed any mention of TinyURL. As @SmaugPool mentioned here, TinyURL uses Cloudflare with occasional CAPTCHA for human verification, making it unsuitable for requests from automated APIs.

https://github.com/coincashew/coincashew/issues/179

I decided to drop GitHub too, because Git was never a good place for metadata (Git has a rate limiter, for example, which might cause issues), especially now when there is no way to shorten URLs.