### PR TITLE
Allow SPOs to reload topology configuration changes

### DIFF
--- a/docs/operate-a-stake-pool/cardano-relay-configuration.md
+++ b/docs/operate-a-stake-pool/cardano-relay-configuration.md
@@ -162,6 +162,7 @@ User              = <$USER>
 Type              = simple
 WorkingDirectory  = <$HOME>/cardano-testnet
 ExecStart         = /bin/bash -c '<$HOME>/cardano-testnet/startTestNode.sh'
+ExecReload        = pkill -HUP cardano-node
 KillSignal        = SIGINT
 RestartKillSignal = SIGINT
 TimeoutStopSec    = 300
@@ -220,3 +221,9 @@ Dec  1 15:31:40 localhost cardano-testnode[162851]: #033[35m[localhos:cardano.no
 ```
 
 Syncing the blockchain from zero can take a while. Please be patient. If you want to stop syncing, you can do so using the command `sudo systemctl stop cardano-node`. Restarting the relay node will resume syncing the blockchain.
+
+## Reloading the Topology configuration
+
+If you have made changes to your topology configuration file (eg. mainnet-topology.json) that controls the relays your node will connect to, you can reload this configuration change without having to perform a full node restart. Type:
+
+    sudo systemctl reload cardano-node

--- a/docs/operate-a-stake-pool/cardano-relay-configuration.md
+++ b/docs/operate-a-stake-pool/cardano-relay-configuration.md
@@ -224,6 +224,6 @@ Syncing the blockchain from zero can take a while. Please be patient. If you wan
 
 ## Reloading the Topology configuration
 
-If you have made changes to your topology configuration file (eg. mainnet-topology.json) that controls the relays your node will connect to, you can reload this configuration change without having to perform a full node restart. Type:
+The topology configuration file controls the relays your node will connect to (eg. mainnet-topology.json). If you have made updates to this configuration you can load these changes without having to perform a full node restart by typing:
 
     sudo systemctl reload cardano-node

--- a/docs/operate-a-stake-pool/cardano-relay-configuration.md
+++ b/docs/operate-a-stake-pool/cardano-relay-configuration.md
@@ -224,6 +224,6 @@ Syncing the blockchain from zero can take a while. Please be patient. If you wan
 
 ## Reloading the Topology configuration
 
-The topology configuration file controls the relays your node will connect to (eg. mainnet-topology.json). If you have made updates to this configuration you can load these changes without having to perform a full node restart by typing:
+In case you have made an update to `topology.json` file, since this node is assumed to be running in P2P mode - you can can load these changes without having to perform a full node restart using command below:
 
     sudo systemctl reload cardano-node


### PR DESCRIPTION
## Checklist

- [x] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [x] I have run `yarn build` after adding my changes **without getting any errors**. 

## Updating documentation or Bugfix

Added the ability to reload topology configuration changes for a running relay node to the sample systemd file.