### PR TITLE
Update links to Marlowe playground and tutorial

### DIFF
--- a/docs/smart-contracts/marlowe.md
+++ b/docs/smart-contracts/marlowe.md
@@ -9,9 +9,9 @@ image: /img/og/og-developer-portal.png
 ## Get started with Marlowe 
 Marlowe is a domain-specific language (DSL) that enables users to create blockchain applications that are specifically designed for financial contracts.
 
-If you want to learn Marlowe from the ground up, start with [Marlowe Tutorial](https://play.marlowe-finance.io/doc/marlowe/tutorials/index.html), or jump right into the [Marlowe Playground](https://play.marlowe-finance.io): 
+If you want to learn Marlowe from the ground up, start with [Marlowe Tutorial](https://docs.marlowe.iohk.io/tutorials), or jump right into the [Marlowe Playground](https://play.marlowe.iohk.io): 
 
-[![Marlowe Playground](../../static/img/get-started/smart-contracts/marlowe-playground.jpg)](https://play.marlowe-finance.io)
+[![Marlowe Playground](../../static/img/get-started/smart-contracts/marlowe-playground.jpg)](https://play.marlowe.iohk.io)
 
 On the Cardano Forum, you can [dicuss Marlowe](https://forum.cardano.org/c/developers/cardano-marlowe/149) or if you prefer Telegram, there is a special [Marlowe Telegram Group](https://t.me/IOHK_Marlowe).
 
@@ -33,7 +33,7 @@ The Marlowe Playground is a plug-and-play smart contract builder and simulator t
 
 ### How do I run my Marlowe contract on the Cardano blockchain?
 
-1. Design your contract using [Marlowe Playground](https://play.marlowe-finance.io/#/).
+1. Design your contract using [Marlowe Playground](https://play.marlowe.iohk.io).
 2. Press the `Send to Simulator` button and then press `Download as JSON` to download your contract in JSON format.
 3. *If you want to run your contract at the command line using `marlowe-cli`,* install [`marlowe-cli`](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe-cli/ReadMe.md#installation) and follow the instructions [Running Contracts with Marlowe CLI](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe-cli/lectures/04-marlowe-cli-concrete.md). A video lecture playlist [Marlowe CLI](https://www.youtube.com/playlist?list=PLNEK_Ejlx3x0GbvCw-61e9VfRafBT1JSw) provides an overview of the `marlowe-cli` tool.
 4. *If you want to run your contract in a Jupyter notebook,* then use git to clone [github.com/input-output-hk/marlowe-cardano](https://github.com/input-output-hk/marlowe-cardano), run `nix develop --command jupyter-lab` from the `marlowe-cli/` folder, open the notebook [Marlowe CLI Lecture 4](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe-cli/lectures/04-marlowe-cli-concrete.ipynb), and follow the instructions. A video lecture [Running a Marlowe Contract with Marlowe CLI](https://www.youtube.com/watch?v=DmF7dIKmJMo&list=PLNEK_Ejlx3x0GbvCw-61e9VfRafBT1JSw&index=4) demonstrates running a contract from within a Jupyter notebook.

--- a/src/data/builder-tools.js
+++ b/src/data/builder-tools.js
@@ -539,7 +539,7 @@ export const Showcases = [
     title: "Marlowe Playground",
     description: "In the browser-based Marlowe Playground you can write Marlowe contracts, in a variety of different ways.",
     preview: require("./builder-tools/marlowe-playground.png"),
-    website: "https://play.marlowe-finance.io",
+    website: "https://play.marlowe.iohk.io",
     getstarted: "/docs/smart-contracts/marlowe#marlowe-playground",
     tags: ["favorite", "marlowe", "hosted"],
   },


### PR DESCRIPTION
This PR updates the links to https://marlowe-finance.io/ to point to https://marlowe.iohk.io/ (the new address)
