### PR TITLE
Frankenwallet: Edit for grammar, formatting + correctness

### DIFF
--- a/.github/actions/yarn-build/Dockerfile
+++ b/.github/actions/yarn-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.18
+FROM node:lts-alpine3.18
 
 RUN apk add --no-cache git
 RUN npm i -g --force yarn

--- a/.github/actions/yarn-build/Dockerfile
+++ b/.github/actions/yarn-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:18-alpine3.18
 
 RUN apk add --no-cache git
 RUN npm i -g --force yarn

--- a/.github/actions/yarn-build/Dockerfile
+++ b/.github/actions/yarn-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine3.18
+FROM node:20-alpine3.18
 
 RUN apk add --no-cache git
 RUN npm i -g --force yarn

--- a/docs/get-started/air-gap.md
+++ b/docs/get-started/air-gap.md
@@ -6,7 +6,7 @@ description: Secure your private keys on a network-free transaction host.
 image: /img/og/og-security-air-gap-environment.png
 ---
 
-"Air gap" originally meant a computer or subnetwork was surrounded by "air" and so could have no data cable connections in or out, so it would be isolated from other computers & networks. These days it also means no radio-based network connection either (WiFi, Bluetooth, etc.).
+"Air gap" originally meant a computer or subnetwork was surrounded by "air" — as defined by no data cable connections in or out — so it would be isolated from other computers & networks. These days it also means there are no radio-based network connection either (WiFi, Bluetooth, etc.).
 
 Developers & Cardano stake pool operators generally need an air gap environment in which to work with payment keys, stake pool keys and other cryptocurrency resources that offer high-value targets for hackers.
 

--- a/docs/operate-a-stake-pool/frankenwallet.md
+++ b/docs/operate-a-stake-pool/frankenwallet.md
@@ -7,9 +7,9 @@ description: An encrypted, air-gapped Linux bootable USB drive for Cardano trans
 
 ## An encrypted, air-gapped Linux bootable USB drive for Cardano (and other) secure operations
 
-Frankenwallet is not a package, library or product, but rather a set of installation guides, security standards and templates that allow Cardano SPOs, token minters, users with funds in bare addresses, and smart contract creators to use an ordinary USB drive for the level of security isolation appropriate to their use case.
+Frankenwallet is not a package, library or product, but rather a set of installation guides, security standards and templates that allow Cardano SPOs, token minters, users with funds in bare addresses, and smart contract creators to configure an ordinary USB drive to boot Linux with a level of security isolation and software prerequisites appropriate to their use case.
 
-When one's primary computer is booted from this removable drive, the secure ("cold") configuration & usage protocol allows users to:
+When one's primary computer is booted from this removable drive, the secure ("cold") configuration & workflow conventions allow operators to:
 
   - store and work securely and flexibly with private keys
   - sign transactions and securely keep records of transaction details  
@@ -33,12 +33,12 @@ At the time of this writing, the full instructions for:
   - how to provision & build your own Frankenwallet
   - how to use the tool for stake pool operations & secure transactions
 
-... are in the online book at this external link: [The Frankenwallet](https://cosd.com/frankenwallet).  If you see any problems with this material, please submit an issue at:
+… are in the online book at this external link: [The Frankenwallet](https://cosd.com/frankenwallet).  If you see any problems with this material, please submit an issue at:
 
-  - [github:rphair/frankenwallet](https://github.com/rphair/frankenwallet) if you find an error in the material at this web site
+  - [github:rphair/frankenwallet](https://github.com/rphair/frankenwallet) if you find an error in the material in the externally linked web site
   - [github:cardano-foundation/developer-portal](https://github.com/cardano-foundation/developer-portal) with any updates or corrections to this page itself.
 
-This is a one-page summary of those external instructions, so you can see if the Frankenwallet is something you might use in your workflow and/or being at the official instructions according to your own level of interest & expertise.
+This is a one-page summary of those external instructions to help you (the operator) decide if the Frankenwallet is something you might use in your workflow according to your own level of interest & expertise.
 
 ### Use cases for the Frankenwallet
 
@@ -60,13 +60,13 @@ This is a one-page summary of those external instructions, so you can see if the
 
 ### Some other use cases & limitations of this material
 
-➤ You *can* use the Frankenwallet instructions to set up an Air Gap node on a full computer... but since the time of its development, this procedure has been adapted to a more appropriate page on the Dev Portal (the aforementioned [Air Gap Environment](/docs/get-started/air-gap)).
+➤ You *can* use the Frankenwallet instructions to set up an Air Gap node on a full computer… but since the time of its development, this procedure has been adapted to a more appropriate page on the Dev Portal (the aforementioned [Air Gap Environment](/docs/get-started/air-gap)).
 
 From [Frankenwallet \> Miscellaneous FAQ's](https://cosd.com/frankenwallet/intro/faq):
 
-➤ Your VirtualBox or other VM software on your host computer *does not* isolate you from the network, even if you have it disabled... nor can it be ever assumed that the screen or keyboard are isolated either... so VMs are generally unsuitable to create an air gap *<span class="underline">or</span>* to implement these instructions.
+➤ Your VirtualBox or other VM software on your host computer *does not* isolate you from the network, even if you have the network device disabled… nor can it be ever assumed that the screen or keyboard are isolated either… so VMs are generally unsuitable to create an air gap *<span class="underline">or</span>* to implement these instructions.
 
-➤ Ubuntu + GNOME, though heavyweight and tainted by default with proprietary software, are chosen for their universal documentation especially when it comes to issues of OS installation and dual booting.
+➤ Ubuntu + GNOME, though heavyweight and tainted by default with proprietary software, are chosen for their universal documentation especially when it comes to issues of OS installation (_without_ that proprietary software!) and dual booting.
 
 ➤ Read more about the [Evil Maid](http://theinvisiblethings.blogspot.com/2009/01/why-do-i-miss-microsoft-bitlocker.html) to see what she, he, or it can & cannot do with your Frankenwallet by compromising your host computer's BIOS in a way to which all commercial computers are vulnerable.
 
@@ -78,7 +78,7 @@ From [Frankenwallet \> Preparation](https://cosd.com/frankenwallet/prepare):
 
 You will avoid moving files around on memory sticks *<span class="underline">and</span>* transferring them over a network (impossible with Air Gap machines) because, when you boot from a USB device based operating system, the main disk on that computer is <span class="underline">*also*</span> accessible as if <span class="underline">*it*</span> were an external device.
 
-Therefore you can plan an area on your host computer (called here the Host Folder) which the Frankenwallet will use to store any encrypted files... as well as read the raw data for the transactions that you will prepare in the air gapped environment.
+Therefore you can plan an area on your host computer (called here the Host Folder) which the Frankenwallet will use to store any encrypted files… as well as read the raw data for the transactions that you will prepare in the air gapped environment.
 
 :::warning warning
 
@@ -90,22 +90,28 @@ Remember early & often that nothing should be stored on the host computer that i
 
 Though regularly used Frankenwallets have been built on cheap & slow USB drives, to make this tool a dependable part of your workflow you should get either:
 
-  - a memory stick with a high benchmark for reading <span class="underline">and writing</span> speed
+  - a memory stick with a high benchmark for reading <span class="underline">and writing</span> speed, or
   - (for best results in author's experience) a SATA SSD drive plus a SATA-to-USB adapter cable.
 
 Users who have built dual-boot configurations before will also know you should **familiarise yourself with the computer's BIOS settings** in anticipation of the same type of setup.
 
-Note there are <span class="underline">limitations about using a Mac</span> as host computer which stem from the different means of booting (see [Frankenwallet \> What if I have a Mac?](https://cosd.com/frankenwallet/prepare/hardware))  
+Note there are <span class="underline">limitations about using a Mac</span> as host computer which stem from the different means of booting (see [Frankenwallet \> Hardware Requirements](https://cosd.com/frankenwallet/prepare/hardware) \> What if I have a Mac?).
 
 ### Choosing passwords
 
 (from Frankenwallet passwords \> [low security](https://cosd.com/frankenwallet/prepare/password-low) & [high security](https://cosd.com/frankenwallet/prepare/password-high))  
 
-The [low security password](https://cosd.com/frankenwallet/prepare/password-low) can be one you've already used to encrypt files on the host computer... strong enough you feel comfortable backing up files over the net.
+The [low security password](https://cosd.com/frankenwallet/prepare/password-low) can be one you've already used to encrypt files on the host computer… strong enough you feel comfortable backing up files over the net.
 
-The [high security password](https://cosd.com/frankenwallet/prepare/password-high)... called the Frankenwallet password itself... should also be stictly long & complex, but should never have been used in a network environment, not even on a network connected machine... otherwise you will be defeating the purpose of using the Air Gap for any purposes of file storage or backup of files to the host computer  
+The [high security password](https://cosd.com/frankenwallet/prepare/password-high)… called the Frankenwallet password itself… should also be stictly long & complex, but should never have been used in a network environment, not even on a network connected machine… otherwise you will be defeating the purpose of using the Air Gap for any purposes of file storage or backup of files to the host computer  
 
 See each of these web links to see which of the Cardano asset & stake pool files it would typically be used to encrypt.
+
+:::info optional
+
+If you intend to use the ["cool" Frankenwallet](#the-cool-frankenwallet-a-sandbox-for-crypto-wallets) configuration (supporting light browser-based wallets) with a Chrome-based browser like Brave, you should be ready with a second high-security password used only to encrypt your most confidential data… since by default you will have to enter the user account password in the browser UI to unlock the GNOME keyring and therefore expose it in an uncertain security context.
+
+:::
 
 :::tip
 
@@ -127,7 +133,7 @@ No need to disconnect from the Internet yet because you will be using it to do y
 
 Select the Minimal software installation (no network hungry apps & games) and plan to install the LibreOffice package later.
 
-Don't tick **third party hardware for graphics and WiFi** because these black boxes can be full of institutional spyware.
+Don't tick **third party hardware for graphics and WiFi** because the proprietary vendor software provided for these devices can contain institutional spyware.
 
 ### Installation notes: partitioning
 
@@ -141,7 +147,7 @@ Note the password you chose will be required now to boot the OS as well as decry
 
 :::warning warning
 
-At the next screen Erase disk and install Ubuntu, watch out that you don't accidentally select your computer's own drive... this can be very easy to do\!
+At the next screen Erase disk and install Ubuntu, watch out that you don't accidentally select your computer's own drive… this can be very easy to do\!
 
 :::
 
@@ -197,24 +203,24 @@ For [highly secure stake pool & asset files](https://cosd.com/frankenwallet/prep
   - First create the file archive (with 7z) or text document (with LibreOffice) using your "high security" password.
   - Then copy it to your host folder, where it can remain stored or backed up (over the network if desired) along with all your other computer's data.
   - This is safe (pending the usual arguments) because **you never have entered, and never will enter, the Frankenwallet (high security) password on your host computer <span class="underline">or</span> any other machine**.
-  - This means you can only verify these backups on this or another Frankenwallet... never on the host computer environment itself\!  
+  - This means you can only verify these backups on this or another Frankenwallet… never on the host computer environment itself\!  
 
 For [less secure stake pool & asset files](https://cosd.com/frankenwallet/prepare/password-low), and documents with general transaction records & source data:
 
   - First create the file archive (with 7z) or text document (with LibreOffice) using your "high security" password.
   - These files you might feel comfortable verifying on your host computer.
-  - NOTE for less urgently secure stake pool pool files (e.g. verification keys, node counters) you might provide a second dedicated password... with "security level" between your general encryption password and the "high security" password... which you only use for the purposes of your assets & stake pool public keys.  
+  - NOTE for less urgently secure stake pool pool files (e.g. verification keys, operational certificate counters) you might provide a second dedicated password… with "security level" between your general encryption password and the "high security" password… which you only use for the purposes of your assets & stake pool public keys.  
 
 ### The "cool" Frankenwallet: a sandbox for crypto wallets
 
 from [Frankenwallet \> Cool environments](https://cosd.com/frankenwallet/cool):
 
-Relaxing the Internet environment (meaning **this device should no longer be used for cold, unencrypted key storage**) allows you to use this devices as a node or browser-based wallet.  
+Relaxing the Internet environment (meaning **this device should no longer be used for cold, unencrypted key storage**) allows you to use this device for node- or browser-based wallets.
 
-Even low-bandwidth memory sticks have been tested in use with the resource intensive Daedalus node wallet, and they still work.  But keep in mind that a node wallet will be considered very slow to sync... especially when your Frankenwallet is booted from your "daily driver" computer and it can be used for no other purpose in the meantime.
+Even low-bandwidth memory sticks have been tested in use with the resource intensive Daedalus node wallet, and they still work.  But keep in mind that a node wallet will be considered very slow to sync… especially when your "daily driver" computer is booted from your Frankenwallet and can be used for no other purpose until booted normally again.
 
-For browser-based wallets, the performance will be better... although the Firefox (or other browser) configuration becomes vital to avoid some institutional or extension spyware possibility compromising your keys.
+For browser-based wallets, the performance will be better… although the Firefox (or other browser) configuration becomes vital to avoid some institutional or extension spyware possibly compromising your keys.
 
-In either case, you can still use the Frankenwallet to **copy the wallet key phrases to an encrypted file** on your host computer: so you can have a record of them with a password that has never been entered on your host machine.
+In either case, you can still use the Frankenwallet to **copy the wallet key phrases to an encrypted file** on your host computer: so you can keep them encrypted with a password that has never been entered on your host machine.
 
-Also keep in mind your security isolation can never be considered complete once you've allowed Internet connection from this "cool" environment... though this "sandbox" is still better than the complete exposure you'd have by running a node or browser based wallet on your network-connected, daily-use machine.
+Also keep in mind your security isolation can never be considered complete once you've allowed Internet connection from this "cool" environment… though this "sandbox" is still better than the complete exposure you'd have by running a node or browser based wallet on your network-connected, daily-use machine.


### PR DESCRIPTION
This is the first full edit of the Frankenwallet operators' digest page since it was posted.  This page may be getting some more attention because of a current Catalyst proposal ([Frankenwallet: DIY boot drive for privacy, security & SPO](https://cardano.ideascale.com/c/idea/114304)) so I wanted to ensure the security standards are as readable and specific as possible.

Also fixed up an awkward introduction to the linked & related Air Gap page.