### PR TITLE
SPO node installation: Update links moved to IntersectMBO

### DIFF
--- a/docs/operate-a-stake-pool/node-installation-process.md
+++ b/docs/operate-a-stake-pool/node-installation-process.md
@@ -176,18 +176,18 @@ cd $HOME/cardano-src
 Download the `cardano-node` repository:
 
 ```bash
-git clone https://github.com/input-output-hk/cardano-node.git
+git clone https://github.com/IntersectMBO/cardano-node.git
 cd cardano-node
 git fetch --all --recurse-submodules --tags
 ```
 Switch the repository to the latest tagged commit:
 
 ```bash
-git checkout $(curl -s https://api.github.com/repos/input-output-hk/cardano-node/releases/latest | jq -r .tag_name)
+git checkout $(curl -s https://api.github.com/repos/IntersectMBO/cardano-node/releases/latest | jq -r .tag_name)
 ```
 
 :::important
-If upgrading an existing node, please ensure that you have read the [release notes on GitHub](https://github.com/input-output-hk/cardano-node/releases) for any changes.
+If upgrading an existing node, please ensure that you have read the [release notes on GitHub](https://github.com/IntersectMBO/cardano-node/releases) for any changes.
 :::
 
 ## Configuring the build options


### PR DESCRIPTION
Links to the cardano-node repository were updated, but the links on the bottom still lead to 404 e.g this one: 

https://github.com/input-output-hk/cardano-node/blob/master/doc/getting-started/install.md
