### PR TITLE
Air gap: Fix grammar problem from last edit

### DIFF
--- a/docs/get-started/air-gap.md
+++ b/docs/get-started/air-gap.md
@@ -6,7 +6,7 @@ description: Secure your private keys on a network-free transaction host.
 image: /img/og/og-security-air-gap-environment.png
 ---
 
-"Air gap" originally meant a computer or subnetwork was surrounded by "air" — as defined by no data cable connections in or out — so it would be isolated from other computers & networks. These days it also means there are no radio-based network connection either (WiFi, Bluetooth, etc.).
+"Air gap" originally meant a computer or subnetwork was surrounded by "air" — as defined by no data cable connections in or out — so it would be isolated from other computers & networks. These days it also means there are no radio-based network connections either (WiFi, Bluetooth, etc.).
 
 Developers & Cardano stake pool operators generally need an air gap environment in which to work with payment keys, stake pool keys and other cryptocurrency resources that offer high-value targets for hackers.
 


### PR DESCRIPTION
A very small grammar fix, so labelling `typo` but not a typo (I caused it inadvertently with #1178).  Not many narrative changes in that last edit, so hopefully not too many other such mistakes.