### PR TITLE
Update links to testnets overview on Cardano Docs

### DIFF
--- a/docs/get-started/testnets-and-devnets.md
+++ b/docs/get-started/testnets-and-devnets.md
@@ -6,11 +6,10 @@ description: Get started with testnets and devnets
 image: /img/og/og-getstarted-testnets.png
 --- 
 
-To make the difference between Cardano mainnet functionality and testnet functionality clearer, we moved the old content of [developers.cardano.org](https://developers.cardano.org) to [testnets.cardano.org](https://testnets.cardano.org) with the launch of this developer portal.
 ## Cardano testnets
-The [Cardano testnets](https://testnets.cardano.org/en/testnets/cardano/overview/) are your playgrounds when testing [Cardano integration](/docs/integrate-cardano/), building with [transaction metadata](/docs/transaction-metadata/), exploring [native tokens](/docs/native-tokens/) or learning how to [operate a stake pool](/docs/operate-a-stake-pool/).
+The [Cardano testnets](https://docs.cardano.org/cardano-testnets/) are your playgrounds when testing [Cardano integration](/docs/integrate-cardano/), building with [transaction metadata](/docs/transaction-metadata/), exploring [native tokens](/docs/native-tokens/) or learning how to [operate a stake pool](/docs/operate-a-stake-pool/).
 
-The Testnets are an essential part of the development process for Cardano, as they allow developers to test and refine their code before deploying it on the live network, ultimately improving the reliability and security.
+The testnets are an essential part of the development process for Cardano, as they allow developers to test and refine their code before deploying it on the live network, ultimately improving reliability and security.
 
 ### What testnet should I use?
 
@@ -26,7 +25,7 @@ You can download the current Cardano blockchain network configuration files for 
 #### Guild Network
 
 - Guild Network is a community maintained public testnet network that is primarily useful for 'quick' testing for development/integrations, as it runs short 1-hour epochs.
-- The primary use-case for this network is often short-term scope-specific testing, it has gone through previous forks on cardano chain with minimal data to ensure we do have different data objects across older forks. The faucet distribution for this network is manual and available with members across timezones based on request in [support](https://t.me/guild_operators_official) channel.
+- The primary use-case for this network is often short-term scope-specific testing, it has gone through previous forks on the Cardano chain with minimal data to ensure we do have different data objects across older forks. The faucet distribution for this network is manual and available with members across timezones based on request in [support](https://t.me/guild_operators_official) channel.
 - The timeline for forks lead Mainnet but are flexible depending on community needs that could be discussed on [github](https://github.com/cardano-community/guild-operators/) (unless specific conditions require testing beforehand), and is useful for testing data against longer history (over 10K epochs).
 
 You can download the current Cardano blockchain network configuration files for Guild Network [here](https://github.com/cardano-community/guild-operators/tree/alpha/files)
@@ -38,14 +37,14 @@ You can download the current Cardano blockchain network configuration files for 
 - The preprod testnet helps to minimize the risk of bugs, security issues, and other problems that could negatively impact the Mainnet.
 - Hard forks at approximately the same time as Mainnet (within an epoch of each other)
 
-You can download the current Cardano blockchain network configuration files for Pre-Production Testnet here: [The Cardano Operations Book > Pre-Production Testnet.](https://book.world.dev.cardano.org/environments.html#pre-production-testnet)
+You can download the current Cardano blockchain network configuration files for Pre-Production Testnet here: [The Cardano Operations Book > Pre-Production Testnet.](https://book.world.dev.cardano.org/env-preprod.html)
 
 #### Summary
 
 The Pre-Production Testnet is a more comprehensive testing environment used to validate major upgrades, while the Preview Testnet is a more targeted testing environment used to showcase new features and gather feedback from the community.
 
 ### Where to get a testnet wallet?
-- [Daedalus Wallet for Cardano Testnet](https://testnets.cardano.org/en/testnets/cardano/get-started/wallet/) is the Pre-Production and Preview versions of Daedalus wallet.
+- [Daedalus Wallet for Cardano Testnet](https://docs.cardano.org/cardano-testnets/daedalus-testnet) is the Pre-Production and Preview versions of Daedalus wallet.
 - [Nami Wallet](https://namiwallet.io/) is a lightweight wallet developed by Cryptonomic and supports both Pre-Production and Preview testnets.
 - [Eternl Wallet](https://eternl.io/) is a another lightweight wallet supporting both testnets with both single- and multiple-address wallets.
 - [Ledger Nano S and Ledger Nano X](https://www.ledger.com/) are hardware wallets that support both Pre-Production and Preview testnets.
@@ -55,11 +54,11 @@ It's important to note that while all of these wallets support Cardano testnets,
 
 ### Where to get test ada?
 
-Because the [Cardano testnets](https://docs.cardano.org/cardano-testnet/overview/) are independent networks, separate from the Cardano mainnet, they requires their own token: test ada (tAda).
+Because the [Cardano testnets](https://docs.cardano.org/cardano-testnets/) are independent networks, separate from the Cardano mainnet, they require their own token: test ada (tAda).
 
 Test ada is worth nothing. With it you can safely perform all tests free of charge - the reason why you want to develop on the testnets. 
 
-To get free test ada for Preprod or Preview, you need to visit: [Cardano Testnet Faucet.](https://docs.cardano.org/cardano-testnet/tools/faucet)
+To get free test ada for Preprod or Preview, you need to visit: [Cardano Testnet Faucet.](https://docs.cardano.org/cardano-testnets/tools/faucet)
 
 In depth explanation about Cardano Testnet Faucet can be found [here.](/docs/integrate-cardano/testnet-faucet/)
 


### PR DESCRIPTION
We have recently updated the testnets section on docs.cardano.org. This pull request updates several links to the testnets overview on Cardano Docs, deletes the first sentence, as there has been no testnets website for over a year, and adds some minor suggested tweaks (eg, cardano > Cardano). 
