### PR TITLE
Redirect old SPO course links to moved or related pages

### DIFF
--- a/docs/get-started/overview.md
+++ b/docs/get-started/overview.md
@@ -25,7 +25,7 @@ Besides cryptographic research, there was game-theoretic research, identity-mana
 ## What you need to bring
 To get the most out of the Cardano Developer Portal, you should  have programming experience and a basic understanding of blockchain concepts of Cardano such as [UTxO](technical-concepts#unspent-transaction-output-utxo), [transactions](technical-concepts#transactions), [addresses](technical-concepts#addresses), [key derivation](technical-concepts#key-derivation), and [networking](technical-concepts#networking). 
 
-If you are unfamiliar with these terms, start with [technical concepts](technical-concepts), and you can complete the [stake pool course](../operate-a-stake-pool/#stake-pool-course) afterward. It will also help you understand basic concepts, even if you don't want to run a stake pool. 
+If you are unfamiliar with these terms, start with [technical concepts](technical-concepts), and you can complete the [stake pool course](../operate-a-stake-pool/) afterward. It will also help you understand basic concepts, even if you don't want to run a stake pool. 
 
 ## Cardano is different 
 If you have experience with other smart contract platforms and want to start building on Cardano, it is vital to know its differences:

--- a/docs/portal-contribute.md
+++ b/docs/portal-contribute.md
@@ -164,7 +164,6 @@ developer-portal
 │   ├── integrate-cardano
 │   ├── native-tokens
 │   ├── operate-a-stake-pool
-│   ├── stake-pool-course
 │   ├── transaction-metadata
 │   └── *.md
 ├── examples

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -220,38 +220,81 @@ module.exports = {
             from: '/docs/governance/cardano-improvement-proposals/',
           },
           {
-            // redirect everything that went into the old stake pool course to the overview 
-            // of the new stake pool operator category. Not perfect but seems good enough.
+            // redirect as many pages as possible from old SPO course to new SPO course
+            // (any old page not existing on new course, include in redirection to top level)
             to: '/docs/operate-a-stake-pool/',
             from: [ 
-                    '/docs/stake-pool-course/', 
-                    '/docs/stake-pool-course/introduction-to-cardano',
+                    '/docs/stake-pool-course/',
                     '/docs/stake-pool-course/lesson-1',
                     '/docs/stake-pool-course/lesson-2',
                     '/docs/stake-pool-course/lesson-3',
                     '/docs/stake-pool-course/lesson-4',
                     '/docs/stake-pool-course/lesson-5',
-                    '/docs/stake-pool-course/handbook/grafana-dashboard-tutorial',
-                    '/docs/stake-pool-course/handbook/grafana-loki',
                     '/docs/stake-pool-course/handbook/setup-virtual-box-written',
                     '/docs/stake-pool-course/handbook/setup-a-server-on-aws-written',
-                    '/docs/stake-pool-course/handbook/setup-firewall',
-                    '/docs/stake-pool-course/handbook/install-cardano-node-written',
-                    '/docs/stake-pool-course/handbook/run-cardano-node-handbook',
-                    '/docs/stake-pool-course/handbook/use-cli',
-                    '/docs/stake-pool-course/handbook/utxo-model',
-                    '/docs/stake-pool-course/handbook/keys-addresses',
-                    '/docs/stake-pool-course/handbook/create-simple-transaction',
-                    '/docs/stake-pool-course/handbook/create-stake-pool-keys',
-                    '/docs/stake-pool-course/handbook/register-stake-keys',
-                    '/docs/stake-pool-course/handbook/generate-stake-pool-keys',
-                    '/docs/stake-pool-course/handbook/configure-topology-files',
-                    '/docs/stake-pool-course/handbook/register-stake-pool-metadata',
-                    '/docs/stake-pool-course/handbook/apply-logging-prometheus',
                     '/docs/stake-pool-course/assignments/assignment-1',
                     '/docs/stake-pool-course/assignments/assignment-2',
                     '/docs/stake-pool-course/assignments/kes_period'
                   ]
+          },
+          {
+            to: '/docs/operate-a-stake-pool/introduction-to-cardano/',
+            from: '/docs/stake-pool-course/introduction-to-cardano',
+          },
+          {
+
+            to: '/docs/operate-a-stake-pool/grafana-dashboard-tutorial/',
+            from: [ 
+                    '/docs/stake-pool-course/handbook/grafana-dashboard-tutorial',
+                    '/docs/stake-pool-course/handbook/grafana-loki',
+                    '/docs/stake-pool-course/handbook/apply-logging-prometheus',
+                  ]
+          },
+          {
+            to: '/docs/operate-a-stake-pool/hardening-server/',
+            from: '/docs/stake-pool-course/handbook/setup-firewall',
+          },
+          {
+            to: '/docs/operate-a-stake-pool/node-installation-process/',
+            from: '/docs/stake-pool-course/handbook/install-cardano-node-written',
+          },
+          {
+            to: '/docs/get-started/running-cardano/',
+            from: '/docs/stake-pool-course/handbook/run-cardano-node-handbook',
+          },
+          {
+            to: '/docs/get-started/create-simple-transaction/',
+            from: [ 
+                    '/docs/stake-pool-course/handbook/use-cli',
+                    '/docs/stake-pool-course/handbook/create-simple-transaction',
+                  ]
+          },
+          {
+            to: '/docs/get-started/technical-concepts/',
+            from: '/docs/stake-pool-course/handbook/utxo-model',
+          },
+          {
+            to: '/docs/operate-a-stake-pool/cardano-key-pairs/',
+            from: '/docs/stake-pool-course/handbook/keys-addresses',
+          },
+          {
+            to: '/docs/operate-a-stake-pool/generating-wallet-keys/',
+            from: '/docs/stake-pool-course/handbook/create-stake-pool-keys',
+          },
+          {
+            to: '/docs/operate-a-stake-pool/register-stake-address/',
+            from: '/docs/stake-pool-course/handbook/register-stake-keys',
+          },
+          {
+            to: '/docs/operate-a-stake-pool/register-stake-pool/',
+            from: [ 
+                    '/docs/stake-pool-course/handbook/generate-stake-pool-keys',
+                    '/docs/stake-pool-course/handbook/register-stake-pool-metadata',
+                  ]
+          },
+          {
+            to: '/docs/operate-a-stake-pool/cardano-relay-configuration/',
+            from: '/docs/stake-pool-course/handbook/configure-topology-files',
           },
         ],
       },


### PR DESCRIPTION
Fixes #1258.  There weren't any "broken" links (as identified in the issue) on the Dev Portal itself; which can still be tested with something like
```
find blog changelog docs examples scripts static -L -type f -print0 | xargs -0 grep stake-pool-course
```
... only an obsolete anchor on the site Overview page and the obsolete section still listed in the file tree on `portal-contribute.md`.  Therefore the affected links are 1) only in the SPO section (unless contradicted in #1258) and 2) are fixed by installing sensible redirects here (since there will never again be actual content at those pages).

There aren't many subjective decisions here, but one of them was redirecting `/docs/stake-pool-course/handbook/setup-firewall` to the beginning of `/docs/operate-a-stake-pool/hardening-server/` rather than the Firewall section within that page (due to the old & new contexts being slightly different).  Any further suggestions please feel free to mark them up in your review.

Tested in local build ✅ along with selected redirects copy/pasted as they would be when appearing in external sites.

cc @klntsky @katomm