### PR TITLE
PR template - add `yarn.lock` advisement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/builder-tool.md
+++ b/.github/PULL_REQUEST_TEMPLATE/builder-tool.md
@@ -11,6 +11,7 @@
 - [ ] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
 - [ ] I have read the [Builder Tool Requirements](https://github.com/cardano-foundation/developer-portal/edit/staging/src/data/builder-tools.js)
 - [ ] I have run `yarn build` after adding my changes **without getting any errors**. 
+- [ ] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://developers.cardano.org/docs/portal-contribute/#i-committed-yarnlock-to-my-pr-branch-what-do-i-do)).
 
 ## Builder Tool addition
 

--- a/.github/PULL_REQUEST_TEMPLATE/showcase.md
+++ b/.github/PULL_REQUEST_TEMPLATE/showcase.md
@@ -11,6 +11,7 @@
 - [ ] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
 - [ ] I have read the [Showcase Requirements](https://github.com/cardano-foundation/developer-portal/edit/staging/src/data/showcases.js)
 - [ ] I have run `yarn build` after adding my changes **without getting any errors**. 
+- [ ] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://developers.cardano.org/docs/portal-contribute/#i-committed-yarnlock-to-my-pr-branch-what-do-i-do)).
 
 ## Showcase addition
 

--- a/.github/PULL_REQUEST_TEMPLATE/standard-change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/standard-change.md
@@ -10,6 +10,7 @@
 
 - [ ] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
 - [ ] I have run `yarn build` after adding my changes **without getting any errors**. 
+- [ ] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://developers.cardano.org/docs/portal-contribute/#i-committed-yarnlock-to-my-pr-branch-what-do-i-do)).
 
 ## Updating documentation or Bugfix
 


### PR DESCRIPTION
Inspired by recent discussion in https://github.com/cardano-foundation/developer-portal/pull/1286#issuecomment-2264314918 / https://github.com/cardano-foundation/developer-portal/pull/1286#issuecomment-2264424587.

Most `yarn.lock` issues have to be dealt with after the fact and we see it more often than not with new contributors.  Therefore this should help to reduce workload by not having to coordinate removing `yarn.lock` with contributors repeatedly, while assuring a more focused contributor / editor workload on the Portal.

The language is key of course, so as not to call too much attention to a problem that contributors might not have (a justification for keeping it brief, and for keeping the detailed instructions parenthetical)... so feedback about the wording is welcome.

How this currently appears (the last Checklist item in all 3 cases):
- [ ] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://developers.cardano.org/docs/portal-contribute/#i-committed-yarnlock-to-my-pr-branch-what-do-i-do)).