### PR TITLE
docs: small fixes and tweaks on CLI governance pages

### DIFF
--- a/docs/get-started/cardano-cli/governance/constitutional-committee.md
+++ b/docs/get-started/cardano-cli/governance/constitutional-committee.md
@@ -3,7 +3,7 @@ id: constitutional committee
 sidebar_label: Constitutional committee
 title: Constitutional committee
 sidebar_position: 3
-description: How to generate credentials as Constiutional Committee Member
+description: How to generate credentials as Constitutional Committee Member
 keywords: [Governance, constitutional committee, committee, credentials, CIP1694]
 ---
 
@@ -25,24 +25,26 @@ import TabItem from '@theme/TabItem';
   ]}>
   <TabItem value="key-based">
 
-The most basic setup for a Constiutional Committee member is using Ed25519 keys. An Ed25519 key pair includes a private key and its corresponding public key. The private key is utilized to create digital signatures, while the public key is employed to verify those signatures. On this setup. the constitutional committee member would generate two sets of keys: *cold* and *hot* and issue an authorizaton certificate to link them.
+The most basic setup for a Constitutional Committee member is using Ed25519 keys. An Ed25519 key pair includes a private key and its corresponding public key. The private key is utilized to create digital signatures, while the public key is employed to verify those signatures. On this setup. the constitutional committee member would generate two sets of keys: *cold* and *hot* and issue an authorization certificate to link them.
 
 ### Generate cold key pair:
-```
+
+```shell
 cardano-cli conway governance committee key-gen-cold \
     --cold-verification-key-file cc-cold.vkey \
     --cold-signing-key-file cc-cold.skey
 ```
 As usual, the ed25519 keys are wrapped on a text envelope:
 
-```
+```json
 {
     "type": "ConstitutionalCommitteeColdVerificationKey_ed25519",
     "description": "Constitutional Committee Cold Verification Key",
     "cborHex": "58201e2c2038e3466fdc7b8e1b302b15db28427adb5467b9df09e736e713d7371d04"
 }
 ```
-```
+
+```json
 {
     "type": "ConstitutionalCommitteeColdSigningKey_ed25519",
     "description": "Constitutional Committee Cold Signing Key",
@@ -51,12 +53,12 @@ As usual, the ed25519 keys are wrapped on a text envelope:
 ```
 ### Generate the cold verification key hash:
 
-```
+```shell
 cardano-cli conway governance committee key-hash \
     --verification-key-file cc-cold.vkey > cc-key.hash
 ```
 
-```
+```shell
 cat cc-key.hash
 89181f26b47c3d3b6b127df163b15b74b45bba7c3b7a1d185c05c2de
 ```
@@ -71,9 +73,9 @@ Members of the Interim Constitutional Committee are required to share their Cold
 After the Chang hardfork, members of the Interim Constitutional Committee are required to generate a _hot key pair_ (or hot script) and
 submit an _Authorization Certificate_. This also applies to new Committee members appointed after the interim phase.
 
-To generate a hot key-pair run the follwing command:
+To generate a hot key-pair run the following command:
 
-```
+```shell
 cardano-cli conway governance committee key-gen-hot \
     --verification-key-file cc-hot.vkey \
     --signing-key-file cc-hot.skey
@@ -81,14 +83,15 @@ cardano-cli conway governance committee key-gen-hot \
 
 Hot keys are also ed25519 keys wrapped on a text envelope:
 
-```
+```json
 {
     "type": "ConstitutionalCommitteeHotVerificationKey_ed25519",
     "description": "Constitutional Committee Hot Verification Key",
     "cborHex": "5820d206b8619a933a099e3190afe0a81cb485af66c3d9297f4b109da507ad5259c0"
 }
 ```
-```
+
+```json
 {
     "type": "ConstitutionalCommitteeHotSigningKey_ed25519",
     "description": "Constitutional Committee Hot Signing Key",
@@ -99,17 +102,17 @@ Hot keys are also ed25519 keys wrapped on a text envelope:
 ### Generate the Authorization Certificate:
 
 The _Authorization Certificate_ allows the hot credential to act on behalf of the cold credential by signing transactions where votes are cast. If the 
-*hot* credential is compromised at any point, the committee member must generate a new one and issue a new Authorization Certificate. A new Authorization Certificate registered on-chain overrides the previous one, effectively invalidating any votes signed by the old hot credential. This applies only to actions that have not yet been ratified. Actions that have been already ratified or enacated by the old hot credential are not affected.
+*hot* credential is compromised at any point, the committee member must generate a new one and issue a new Authorization Certificate. A new Authorization Certificate registered on-chain overrides the previous one, effectively invalidating any votes signed by the old hot credential. This applies only to actions that have not yet been ratified. Actions that have been already ratified or enacted by the old hot credential are not affected.
 
 
-```
+```shell
 cardano-cli conway governance committee create-hot-key-authorization-certificate \
     --cold-verification-key-file cc-cold.vkey \
     --hot-verification-key-file cc-hot.vkey \
     --out-file cc-authorization.cert
 ```
 
-```
+```shell
 cat cc-authorization.cert 
 
 {
@@ -121,7 +124,7 @@ cat cc-authorization.cert
 
 ### Submit the authorization certificate in a transaction:
 
-```
+```shell
 cardano-cli conway transaction build \
   --tx-in "$(cardano-cli query utxo --address "$(< payment.addr)" --output-json | jq -r 'keys[0]')" \
   --change-address payment.addr \
@@ -129,14 +132,16 @@ cardano-cli conway transaction build \
   --witness-override 2 \
   --out-file tx.raw
 ```
-```
+
+```shell
 cardano-cli conway transaction sign \
   --tx-body-file tx.raw \
   --signing-key-file payment.skey \
   --signing-key-file cc-cold.skey \
   --out-file tx.signed
 ```
-```
+
+```shell
 cardano-cli conway transaction submit \
   --tx-file tx.signed
 ```
@@ -196,7 +201,7 @@ da1a4d13a1c951f30a7efb4dac2b4c1f603f4eabbfa0ecc7f361bfc1
 
 Create the multisignature `cold.script` file using the simple scrypt syntax. In this example we use the `atLeast` type, so that 2 out of the 3 keys are required for the script to evaluate to true. To learn more about simple scripts read [this article](docs/get-started/cardano-cli/simple-scripts/simple-scripts.md)
 
-```
+```shell
 cat cold.script
 
 {
@@ -222,9 +227,9 @@ cat cold.script
 
 ### Calculate the script hash:
 
-The governance action that proposes "ABC" organization as a Committee Memeber needs to reference their cold script hash. They can obtain it with:
+The governance action that proposes "ABC" organization as a Committee Member needs to reference their cold script hash. They can obtain it with:
 
-```
+```shell
 cardano-cli hash script --script-file cold.script 
 ad31d247bb2549db98020c5a6331732ebe559ad85b5768abbda3eb0d
 ```
@@ -235,14 +240,14 @@ If ratified, "ABC" will need to generate a *Hot* credential and an Authorization
 
 Alice:
 
-```
+```shell
 cardano-cli conway governance committee key-gen-hot \
   --verification-key-file alice-hot.vkey \
   --signing-key-file alice-hot.skey
 ```
 Bob:
 
-```
+```shell
 cardano-cli conway governance committee key-gen-hot \
   --verification-key-file bob-hot.vkey \
   --signing-key-file bob-hot.skey
@@ -250,14 +255,14 @@ cardano-cli conway governance committee key-gen-hot \
 
 Carol:
 
-```
+```shell
 cardano-cli conway governance committee key-gen-hot \
   --verification-key-file carol-hot.vkey \
   --signing-key-file carol-hot.skey
 ```
 ### Get the hot key hashes:
 
-```
+```shell
 cardano-cli conway governance committee key-hash --verification-key-file alice-hot.vkey
 d775c28b6635d6eaecdc149f490f27d651ff4a10e2f37d60dfb23f11
 
@@ -270,7 +275,7 @@ cardano-cli conway governance committee key-hash --verification-key-file carol-h
 
 ### Create the multisignature hot script:
 
-```
+```shell
 cat hot.script
 
 {
@@ -296,7 +301,7 @@ cat hot.script
 
 ### Calculate the hot script hash:
 
-```
+```shell
 cardano-cli hash script --script-file hot.script 
 f5d42214cb2625cfc34e5c0cfb1daceee44a4a3c2e6807ab67cd6adb
 ```
@@ -304,7 +309,7 @@ f5d42214cb2625cfc34e5c0cfb1daceee44a4a3c2e6807ab67cd6adb
 ### Issue the authorization certificate
 
 The _Authorization Certificate_ allows the hot credential to act on behalf of the cold credential by signing transactions where votes are cast. If the 
-*hot* credential is compromised at any point, the committee member must generate a new one and issue a new Authorization Certificate. A new Authorization Certificate registered on-chain overrides the previous one, effectively invalidating any votes signed by the old hot credential. This applies only to actions that have not yet been ratified. Actions that have been already ratified or enacated by the old hot credential are not affected.
+*hot* credential is compromised at any point, the committee member must generate a new one and issue a new Authorization Certificate. A new Authorization Certificate registered on-chain overrides the previous one, effectively invalidating any votes signed by the old hot credential. This applies only to actions that have not yet been ratified. Actions that have been already ratified or enacted by the old hot credential are not affected.
 
 ```
 cardano-cli conway governance committee create-hot-key-authorization-certificate \
@@ -316,7 +321,7 @@ cardano-cli conway governance committee create-hot-key-authorization-certificate
 ### Submit the authorization certificate in a transaction
 
 Build the transaction:
-```
+```shell
 cardano-cli conway transaction build \
   --tx-in "$(cardano-cli query utxo --address "$(< payment.addr)" --output-json | jq -r 'keys[0]')" \
   --change-address "$(< payment.addr)" \

--- a/docs/get-started/cardano-cli/governance/constitutional-committee.md
+++ b/docs/get-started/cardano-cli/governance/constitutional-committee.md
@@ -31,8 +31,8 @@ The most basic setup for a Constitutional Committee member is using Ed25519 keys
 
 ```shell
 cardano-cli conway governance committee key-gen-cold \
-    --cold-verification-key-file cc-cold.vkey \
-    --cold-signing-key-file cc-cold.skey
+  --cold-verification-key-file cc-cold.vkey \
+  --cold-signing-key-file cc-cold.skey
 ```
 As usual, the ed25519 keys are wrapped on a text envelope:
 
@@ -55,7 +55,7 @@ As usual, the ed25519 keys are wrapped on a text envelope:
 
 ```shell
 cardano-cli conway governance committee key-hash \
-    --verification-key-file cc-cold.vkey > cc-key.hash
+  --verification-key-file cc-cold.vkey > cc-key.hash
 ```
 
 ```shell
@@ -77,8 +77,8 @@ To generate a hot key-pair run the following command:
 
 ```shell
 cardano-cli conway governance committee key-gen-hot \
-    --verification-key-file cc-hot.vkey \
-    --signing-key-file cc-hot.skey
+  --verification-key-file cc-hot.vkey \
+  --signing-key-file cc-hot.skey
 ```
 
 Hot keys are also ed25519 keys wrapped on a text envelope:
@@ -107,9 +107,9 @@ The _Authorization Certificate_ allows the hot credential to act on behalf of th
 
 ```shell
 cardano-cli conway governance committee create-hot-key-authorization-certificate \
-    --cold-verification-key-file cc-cold.vkey \
-    --hot-verification-key-file cc-hot.vkey \
-    --out-file cc-authorization.cert
+  --cold-verification-key-file cc-cold.vkey \
+  --hot-verification-key-file cc-hot.vkey \
+  --out-file cc-authorization.cert
 ```
 
 ```shell
@@ -163,23 +163,23 @@ Alice:
 
 ```shell
 cardano-cli conway governance committee key-gen-cold \
-    --cold-verification-key-file alice-cold.vkey \
-    --cold-signing-key-file alice-cold.skey
+  --cold-verification-key-file alice-cold.vkey \
+  --cold-signing-key-file alice-cold.skey
 ```
 
 Bob:
 
 ```shell
 cardano-cli conway governance committee key-gen-cold \
-    --cold-verification-key-file bob-cold.vkey \
-    --cold-signing-key-file bob-cold.skey
+  --cold-verification-key-file bob-cold.vkey \
+  --cold-signing-key-file bob-cold.skey
 ```
 Carol:
 
 ```shell
 cardano-cli conway governance committee key-gen-cold \
-    --cold-verification-key-file carol-cold.vkey \
-    --cold-signing-key-file carol-cold.skey
+  --cold-verification-key-file carol-cold.vkey \
+  --cold-signing-key-file carol-cold.skey
 ```
 
 ### Get verification key hashes:
@@ -311,11 +311,11 @@ f5d42214cb2625cfc34e5c0cfb1daceee44a4a3c2e6807ab67cd6adb
 The _Authorization Certificate_ allows the hot credential to act on behalf of the cold credential by signing transactions where votes are cast. If the 
 *hot* credential is compromised at any point, the committee member must generate a new one and issue a new Authorization Certificate. A new Authorization Certificate registered on-chain overrides the previous one, effectively invalidating any votes signed by the old hot credential. This applies only to actions that have not yet been ratified. Actions that have been already ratified or enacted by the old hot credential are not affected.
 
-```
+```shell
 cardano-cli conway governance committee create-hot-key-authorization-certificate \
---cold-script-hash ad31d247bb2549db98020c5a6331732ebe559ad85b5768abbda3eb0d \
---hot-script-hash f5d42214cb2625cfc34e5c0cfb1daceee44a4a3c2e6807ab67cd6adb \
---out-file cc-authorization.cert
+  --cold-script-hash ad31d247bb2549db98020c5a6331732ebe559ad85b5768abbda3eb0d \
+  --hot-script-hash f5d42214cb2625cfc34e5c0cfb1daceee44a4a3c2e6807ab67cd6adb \
+  --out-file cc-authorization.cert
 ```
 
 ### Submit the authorization certificate in a transaction

--- a/docs/get-started/cardano-cli/governance/delegating-vote.md
+++ b/docs/get-started/cardano-cli/governance/delegating-vote.md
@@ -55,37 +55,37 @@ cardano-cli conway stake-address vote-delegation-certificate \
 
 ```shell
 cardano-cli conway stake-address vote-delegation-certificate \
---stake-verification-key-file stake.vkey \
---drep-script-hash $(< drep-multisig.id) \
---out-file vote-deleg.cert
+  --stake-verification-key-file stake.vkey \
+  --drep-script-hash $(< drep-multisig.id) \
+  --out-file vote-deleg.cert
 ```
 
 ### Submitting the certificate in a transaction
 
 * Build:
 
-```
+```shell
 cardano-cli conway transaction build \
---tx-in $(cardano-cli query utxo --address $(< payment.addr) --testnet-magic 4 --out-file  /dev/stdout | jq -r 'keys[0]') \
---change-address $(< payment.addr) \
---certificate-file vote-deleg.cert \
---witness-override 2 \
---out-file tx.raw
+  --tx-in $(cardano-cli query utxo --address $(< payment.addr) --testnet-magic 4 --out-file  /dev/stdout | jq -r 'keys[0]') \
+  --change-address $(< payment.addr) \
+  --certificate-file vote-deleg.cert \
+  --witness-override 2 \
+  --out-file tx.raw
 ```
 
 * Sign with payment and stake keys:
 
-```
+```shell
 cardano-cli conway transaction sign \
---tx-body-file tx.raw \
---signing-key-file payment.skey \
---signing-key-file stake.skey \
---out-file tx.signed
+  --tx-body-file tx.raw \
+  --signing-key-file payment.skey \
+  --signing-key-file stake.skey \
+  --out-file tx.signed
 ```
 
 * Submit:
 
-```
+```shell
 cardano-cli conway transaction submit \
---tx-file tx.signed
+  --tx-file tx.signed
 ```

--- a/docs/get-started/cardano-cli/governance/gov-queries.md
+++ b/docs/get-started/cardano-cli/governance/gov-queries.md
@@ -7,12 +7,13 @@ description: Query the node to obtain information about the governance state
 keywords: [Governance, queries, CIP1694]
 ---
 
-There are various queries you can do to yoour local node to find relevant information about different aspects of teh governance state. 
+There are various queries you can do to your local node to find relevant information about different aspects of teh governance state. 
 
 ### Query the gov-state
 
 We are showing only the top level keys of the governance state, the dump is to large to show on this tutorial. 
-```
+
+```shell
 cardano-cli conway query gov-state
 
 {

--- a/docs/get-started/cardano-cli/governance/governance-actions.md
+++ b/docs/get-started/cardano-cli/governance/governance-actions.md
@@ -29,7 +29,7 @@ the most recently enacted action of its respective type. Notably, this requireme
 
 You can get the last enacted governance action IDs with:
 
-```bash
+```shell
 cardano-cli conway query gov-state | jq -r .nextRatifyState.nextEnactState.prevGovActionIds
 ```
 ```json
@@ -47,28 +47,28 @@ cardano-cli conway query gov-state | jq -r .nextRatifyState.nextEnactState.prevG
 }
 ```
 
-Please note that both the **update committee** and **motion of no confidence** actions share the same space, referred to as 'Committee,' within the
+Please note that both the **update committee** and **motion of no confidence** actions share the same space, referred to as 'Committee' within the
 governance state. Consequently, the governance state stores a single value to represent both of these actions. The system also verifies either of these
 actions against this single stored value.
 
 **Anchors**
 
-When proposing a governance action, the proposer may employ an *anchor*, which comprises a *URL* hosting a document that outlines the rationale
+When proposing a governance action, the proposer must employ an *anchor*, which comprises a *URL* hosting a document that outlines additional context
 for the proposed changes, along with the document's *hash*.
 
-The document at the URL can be of a free form. It's important that it should communicate to ada holders the *what* and the *why* of the proposal. This tutorial mostly uses 'https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld' as an example, see [here](https://github.com/cardano-foundation/CIPs/blob/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/test-vector.md) for more details.
+The document at the URL can be of a free form. It's important that it should communicate to ada holders the *why* and the *how* of the proposal. This tutorial mostly uses 'https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld' as an example, see [here](https://github.com/cardano-foundation/CIPs/blob/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/test-vector.md) for more details.
 
 See [CIP-100 | Governance Metadata](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0100) and [CIP-0108 | Governance Metadata - Governance Actions](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0108) for standard.
 
 You can use `cardano-cli` to get the hash:
 
-```bash
+```shell
 cardano-cli hash anchor-data --file-text treasury-withdrawal.jsonld
 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4
 ```
 Alternatively, utilize b2sum to hash the document:
 
-```bash
+```shell
 b2sum -l 256 treasury-withdrawal.jsonld
 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4  treasury-withdrawal.jsonld
 ```
@@ -83,15 +83,15 @@ Assume you want to add three CC members who have generated cold keys and have pr
 - `ea8738081fca0726f4e781f5e55fda05f8745432a5f8a8d09eb0b34b`
 - `7f6721067362d4ae9ca73469fe983ce5572dad9028386100104b0da0`
 
-You can create a proposal to add them as new CC members with an expiration epoch (`--epoch`) for each of them. This is a good time to review the threshold. Let’s say that our proposal will change the Committee threshld to 66%:
+You can create a proposal to add them as new CC members with an expiration epoch (`--epoch`) for each of them. This is a good time to review the threshold. Let’s say that our proposal will change the Committee threshold to 66%:
 
 * Create the proposal:
 
-```bash
+```shell
 cardano-cli conway governance action update-committee \
   --testnet \
   --governance-action-deposit $(cardano-cli query protocol-parameters | jq -r '.govActionDeposit') \
-  --deposit-return-stake-verification-key-file stake.vkey \931f1d8cdfdc82050bd2baadfe384df8bf99b00e36cb12bfb8795beab3ac7fe5
+  --deposit-return-stake-verification-key-file stake.vkey \
   --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
   --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --add-cc-cold-verification-key-hash 89181f26b47c3d3b6b127df163b15b74b45bba7c3b7a1d185c05c2de \
@@ -110,7 +110,7 @@ cardano-cli conway governance action update-committee \
 
 Assume that you want to remove the CC member with the key hash `89181f26b47c3d3b6b127df163b15b74b45bba7c3b7a1d185c05c2de`. You can do this with:
 
-```bash
+```shell
 cardano-cli conway governance action update-committee \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
@@ -126,7 +126,7 @@ cardano-cli conway governance action update-committee \
 
 ### Update committee to only change the *threshold*:
 
-```bash
+```shell
 cardano-cli conway governance action update-committee \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
@@ -146,7 +146,7 @@ on Mainnet. It is available in https://ipfs.io/ipfs/Qmdo2J5vkGKVu2ur43PuTrM7Fdae
 
 ### Find the last enacted Constitution governance action 
 
-Find the last enacted governance action of this type, If the query returns `null` it means the current consitution (if it exists) is not enacted in a governance action, but instead supplied on the Conway genesis file.
+Find the last enacted governance action of this type, If the query returns `null` it means the current constitution (if it exists) is not enacted in a governance action, but instead supplied on the Conway genesis file.
 
 ```shell
 cardano-cli conway query gov-state | jq -r '.nextRatifyState.nextEnactState.prevGovActionIds.Constitution'
@@ -165,24 +165,24 @@ cardano-cli conway query gov-state | jq -r '.nextRatifyState.nextEnactState.prev
 
 ### Prepare the constiution anchor.
 
-When proposing a new constitution, you are required to put it on a URL that is publicly accessible and, idealy, in some sort of persistent form. For example 
+When proposing a new constitution, you are required to put it on a URL that is publicly accessible and, ideally, in some sort of persistent form. For example 
 put it on IPFS, like the [interim constitution](https://ipfs.io/ipfs/Qmdo2J5vkGKVu2ur43PuTrM7FdaeyfeFav8fhovT6C2tto)
 
 * Download the file from its url:
 
-```bash
+```shell
 wget https://ipfs.io/ipfs/Qmdo2J5vkGKVu2ur43PuTrM7FdaeyfeFav8fhovT6C2tto -O constitution.txt
 ```
 
 * Get its hash, you can do it with blake2 or with cardano-cli:
 
-```bash
+```shell
 b2sum -l 256 constitution.txt
 a77245f63bc7504c6ce34383633729692388dc1823723b0ee9825743a87a6a6d  constitution.txt
 ```
 or
 
-```bash
+```shell
 cardano-cli conway governance hash anchor-data --file-text constitution.txt
 a77245f63bc7504c6ce34383633729692388dc1823723b0ee9825743a87a6a6d
 ```
@@ -198,10 +198,11 @@ The guardrails script applies only to protocol parameter update and treasury wit
 
 Follow the instructions in the README.md file to compile the PlutusV3 script. A successful compilation creates the 'compiled' directory containing the script in a text envelope.
 
-```
+```shell
 cat compiled/guardrails-script.plutus 
 ```
-```
+
+```json
 {
     "type": "PlutusScriptV3",
     "description": "",
@@ -218,9 +219,9 @@ edcd84c10e36ae810dc50847477083069db796219b39ccde790484e0
 
 #### Create the proposal to update the constitution:
 
-When there is no previously enacted constiutition: 
+When there is no previously enacted constitution: 
 
-```bash
+```shell
 cardano-cli conway governance action create-constitution \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
@@ -234,7 +235,7 @@ cardano-cli conway governance action create-constitution \
 ```
 When there is a previously enacted constitution, we need to reference the previous governance action id (TXID and INDEX):
 
-```bash
+```shell
 cardano-cli conway governance action create-constitution \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
@@ -254,7 +255,7 @@ From here, you just need to [submit the proposal in a transaction](#submitting-t
 
 - Find the last governance action enacted of this type:
 
-```bash
+```shell
 cardano-cli conway query gov-state | jq -r '.nextRatifyState.nextEnactState.prevGovActionIds.Committee'
 ```
 ```json
@@ -266,7 +267,7 @@ cardano-cli conway query gov-state | jq -r '.nextRatifyState.nextEnactState.prev
 
 #### Create a motion no-confidence governance action:
 
-```bash
+```shell
 cardano-cli conway governance action create-no-confidence \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
@@ -287,7 +288,7 @@ Also, treasury withdrawals must reference the Guardrails script when present.
 
 #### Create the treasury withdrawal proposal:
 
-```bash
+```shell
 cardano-cli conway governance action create-treasury-withdrawal \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
@@ -308,11 +309,11 @@ From here, you just need to [submit the proposal in a transaction](#submitting-t
 
 #### Create the 'info' governance action:
 
-```bash
+```shell
 cardano-cli conway governance action create-info --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url  https://tinyurl.com/yc74fxx4 \
+  --anchor-url  https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
   --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --out-file info.action
 ```
@@ -324,7 +325,7 @@ When updating protocol parameters, you must reference the Guardrails script. Thi
 because, actions can be created off-line so the cli may not have access to a node, and also because a governance action may be submitted in advance, 
 anticipating that a new Guardrails script will be ratified and enacted during the proposal's lifespan.
 
-```bash
+```shell
 cardano-cli conway governance action create-protocol-parameters-update \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
@@ -340,36 +341,35 @@ cardano-cli conway governance action create-protocol-parameters-update \
 
 Continue with [build, sign and submit the transactions](#submitting-a-treasuy-withdrawal-and-protocol-parameter-update-governance-action) 
 
-## Submitting Motion of no-confidence, Update committee, New Constitution, Hardfork inititation or Info proposals in a transaction
+## Submitting Motion of no-confidence, Update committee, New Constitution, Hardfork initiation or Info proposals in a transaction
 
 Submitting the `*.action` file to the blockchain is the essential step in bringing your proposal to life and making it accessible for the community to participate in the
 voting process. This process essentially transforms your proposal from a conceptual idea into an actionable item. Once submitted, it becomes part of the public ledger,
 while also allowing members of the governance bodies to review, discuss, and ultimately cast their votes on its approval or rejection.
 
-* Note that you can also use `build-raw` and `calculate-min-fee` to build transactions in an off-line settting. The example below uses the convenient `build`:
+* Note that you can also use `build-raw` and `calculate-min-fee` to build transactions in an off-line setting. The example below uses the convenient `build`:
 
-```bash
+```shell
 cardano-cli conway transaction build \
-  \
   --tx-in "$(cardano-cli query utxo --address "$(< payment.addr)" --output-json | jq -r 'keys[0]')" \
   --change-address $(< payment.addr) \
   --proposal-file info.action \
   --out-file tx.raw
 ```
-```bash
+
+```shell
 cardano-cli conway transaction sign \
-  \
   --tx-body-file tx.raw \
   --signing-key-file payment.skey \
   --out-file tx.signed
 ```
-```bash
+
+```shell
 cardano-cli conway transaction submit \
-  \
   --tx-file tx.signed
 ```
 
-## Submitting a Treasuy-withdrawal or Protocol-parameter-update governance action
+## Submitting a Treasury-withdrawal or Protocol-parameter-update governance action
 
 :::info
 These types of proposals must reference the guardrails script, therefore must supply a collateral and the guardrails script either directly or as 
@@ -382,32 +382,31 @@ When building the transaction, we include the `*.action` file and supply the gua
 
 ```shell
 cardano-cli conway transaction build \
---proposal-script-file guardrails-script.plutus \
---tx-in-collateral "$(cardano-cli query utxo --address "$(< payment.addr)" --output-json | jq -r 'keys[0]')" \
---proposal-redeemer-value {} \
---tx-in "$(cardano-cli query utxo --address "$(< payment.addr)" --output-json | jq -r 'keys[0]')" \
---change-address "$(< payment.addr)" \
---proposal-file pp-update.action \
---out-file pparams-tx.raw
+  --proposal-script-file guardrails-script.plutus \
+  --tx-in-collateral "$(cardano-cli query utxo --address "$(< payment.addr)" --output-json | jq -r 'keys[0]')" \
+  --proposal-redeemer-value {} \
+  --tx-in "$(cardano-cli query utxo --address "$(< payment.addr)" --output-json | jq -r 'keys[0]')" \
+  --change-address "$(< payment.addr)" \
+  --proposal-file pp-update.action \
+  --out-file pparams-tx.raw
 
 Estimated transaction fee: Coin 313228
-
 ```
 
 - Sign the transaction with `payment.skey`:
 
-```bash
+```shell
 cardano-cli conway transaction sign \
---tx-file pparams-tx.raw \
---signing-key-file payment.skey \
---out-file pparams-tx.signed 
+  --tx-file pparams-tx.raw \
+  --signing-key-file payment.skey \
+  --out-file pparams-tx.signed 
 ```
 
 - Submit it to the chain with:
 
-```bash
+```shell
 cardano-cli conway transaction submit \
---tx-file pparams-tx.signed
+  --tx-file pparams-tx.signed
 ```
 
 ## Finding the governance action ID of your proposal
@@ -417,17 +416,18 @@ proposal serve as the action ID. An effective way to find your governance action
 
 First, find your key hash with:
 
-```bash
+```shell
 cardano-cli conway stake-address key-hash --stake-verification-key-file stake.vkey
 ```
 `8e0debc9fdc6c616ac40d98bf3950b436895eea9cccf0396a6e5e12b`
 
 Use `jq` to filter the `gov-state` output by the stake key hash. The output contains all the relevant information about your governance actions, including `actionId`:
 
-```bash
+```shell
 cardano-cli conway query gov-state \
 | jq -r --arg keyHash "8e0debc9fdc6c616ac40d98bf3950b436895eea9cccf0396a6e5e12b" '.proposals | to_entries[] | select(.value.returnAddr.credential.keyHash | contains($keyHash)) | .value'
 ```
+
 ```json
 {
   "action": {

--- a/docs/get-started/cardano-cli/governance/governance-actions.md
+++ b/docs/get-started/cardano-cli/governance/governance-actions.md
@@ -56,22 +56,21 @@ actions against this single stored value.
 When proposing a governance action, the proposer may employ an *anchor*, which comprises a *URL* hosting a document that outlines the rationale
 for the proposed changes, along with the document's *hash*.
 
-The document at the URL can be of a free form. It's important that it should communicate to ada holders the *what* and the *why* of the proposal. This tutorial mostly uses 'https://raw.githubusercontent.com/Ryun1/metadata/main/cip108/treasury-withdrawal.jsonld' as an example, see [here](https://github.com/Ryun1/CIPs/blob/governance-metadata-actions/CIP-0108/test-vector.md) for more details.
+The document at the URL can be of a free form. It's important that it should communicate to ada holders the *what* and the *why* of the proposal. This tutorial mostly uses 'https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld' as an example, see [here](https://github.com/cardano-foundation/CIPs/blob/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/test-vector.md) for more details.
 
-See [CIP-100 | Governance Metadata](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0100) and [CIP-0108? | Governance Metadata - Governance Actions](https://github.com/cardano-foundation/CIPs/pull/632) for standard.
-Following CIP-100, we canonize the metadata anchor first, via [JSON-LD playground](https://json-ld.org/playground/), which we then hash.
+See [CIP-100 | Governance Metadata](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0100) and [CIP-0108 | Governance Metadata - Governance Actions](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0108) for standard.
 
 You can use `cardano-cli` to get the hash:
 
 ```bash
-cardano-cli hash anchor-data --file-text treasury-withdrawal.canonical
-931f1d8cdfdc82050bd2baadfe384df8bf99b00e36cb12bfb8795beab3ac7fe5
+cardano-cli hash anchor-data --file-text treasury-withdrawal.jsonld
+311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4
 ```
 Alternatively, utilize b2sum to hash the document:
 
 ```bash
-b2sum -l 256 treasury-withdrawal.canonical
-931f1d8cdfdc82050bd2baadfe384df8bf99b00e36cb12bfb8795beab3ac7fe5  treasury-withdrawal.canonical
+b2sum -l 256 treasury-withdrawal.jsonld
+311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4  treasury-withdrawal.jsonld
 ```
 You will need to supply the hash of the document when creating a governance action.
 
@@ -92,9 +91,9 @@ You can create a proposal to add them as new CC members with an expiration epoch
 cardano-cli conway governance action update-committee \
   --testnet \
   --governance-action-deposit $(cardano-cli query protocol-parameters | jq -r '.govActionDeposit') \
-  --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url https://raw.githubusercontent.com/Ryun1/metadata/main/cip108/treasury-withdrawal.jsonld \
-  --anchor-data-hash 931f1d8cdfdc82050bd2baadfe384df8bf99b00e36cb12bfb8795beab3ac7fe5 \
+  --deposit-return-stake-verification-key-file stake.vkey \931f1d8cdfdc82050bd2baadfe384df8bf99b00e36cb12bfb8795beab3ac7fe5
+  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
+  --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --add-cc-cold-verification-key-hash 89181f26b47c3d3b6b127df163b15b74b45bba7c3b7a1d185c05c2de \
   --epoch 100 \
   --add-cc-cold-verification-key-hash ea8738081fca0726f4e781f5e55fda05f8745432a5f8a8d09eb0b34b \
@@ -116,8 +115,8 @@ cardano-cli conway governance action update-committee \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url https://raw.githubusercontent.com/Ryun1/metadata/main/cip108/treasury-withdrawal.jsonld \
-  --anchor-data-hash 931f1d8cdfdc82050bd2baadfe384df8bf99b00e36cb12bfb8795beab3ac7fe5 \
+  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
+  --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --remove-cc-cold-verification-key-hash 89181f26b47c3d3b6b127df163b15b74b45bba7c3b7a1d185c05c2de \
   --threshold 1/2 \
   --prev-governance-action-tx-id fe2c99fe6bc75a9666427163d51ae7dbf5a60df40135361b7bfd53ac6c7912ec \
@@ -132,8 +131,8 @@ cardano-cli conway governance action update-committee \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url https://raw.githubusercontent.com/Ryun1/metadata/main/cip108/treasury-withdrawal.jsonld \
-  --anchor-data-hash 931f1d8cdfdc82050bd2baadfe384df8bf99b00e36cb12bfb8795beab3ac7fe5 \
+  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
+  --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --threshold 60/100 \
   --prev-governance-action-tx-id fe2c99fe6bc75a9666427163d51ae7dbf5a60df40135361b7bfd53ac6c7912ec \
   --prev-governance-action-index 0 \
@@ -142,7 +141,7 @@ cardano-cli conway governance action update-committee \
 
 ## Updating the constitution
 
-This section describes how to propose a new constitution. Lets's use as an axample the interim constitution that is to be used 
+This section describes how to propose a new constitution. Lets's use as an example the interim constitution that is to be used 
 on Mainnet. It is available in https://ipfs.io/ipfs/Qmdo2J5vkGKVu2ur43PuTrM7FdaeyfeFav8fhovT6C2tto
 
 ### Find the last enacted Constitution governance action 
@@ -193,7 +192,7 @@ a77245f63bc7504c6ce34383633729692388dc1823723b0ee9825743a87a6a6d
 While the constitution is an informal, off-chain document, there will also be an optional script that can enforce some guidelines. This script acts 
 to supplement the constitutional committee by restricting some proposal types.
 
-At the Chang hardfork, the interim constitution will be suplemented with a Guardrails script. It is soon to be open sourced, you will find it here: https://github.com/IntersectMBO/constitution-priv 
+At the Chang hardfork, the interim constitution will be supplemented with a Guardrails script. It is soon to be open sourced, you will find it here: https://github.com/XXXX
 
 The guardrails script applies only to protocol parameter update and treasury withdrawal proposals.
 
@@ -240,8 +239,8 @@ cardano-cli conway governance action create-constitution \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url https://raw.githubusercontent.com/Ryun1/metadata/main/cip108/treasury-withdrawal.jsonld \
-  --anchor-data-hash 931f1d8cdfdc82050bd2baadfe384df8bf99b00e36cb12bfb8795beab3ac7fe5 \
+  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
+  --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --constitution-url https://ipfs.io/ipfs/Qmdo2J5vkGKVu2ur43PuTrM7FdaeyfeFav8fhovT6C2tto \
   --constitution-hash "a77245f63bc7504c6ce34383633729692388dc1823723b0ee9825743a87a6a6d" \
   --constitution-script-hash "edcd84c10e36ae810dc50847477083069db796219b39ccde790484e0" \
@@ -272,8 +271,8 @@ cardano-cli conway governance action create-no-confidence \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url https://raw.githubusercontent.com/Ryun1/metadata/main/cip108/treasury-withdrawal.jsonld \
-  --anchor-data-hash 931f1d8cdfdc82050bd2baadfe384df8bf99b00e36cb12bfb8795beab3ac7fe5 \
+  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
+  --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --prev-governance-action-tx-id fe2c99fe6bc75a9666427163d51ae7dbf5a60df40135361b7bfd53ac6c7912ec \
   --prev-governance-action-index 0 \
   --out-file no-confidence.action
@@ -293,8 +292,8 @@ cardano-cli conway governance action create-treasury-withdrawal \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url https://raw.githubusercontent.com/Ryun1/metadata/main/cip108/treasury-withdrawal.jsonld \
-  --anchor-data-hash 931f1d8cdfdc82050bd2baadfe384df8bf99b00e36cb12bfb8795beab3ac7fe5 \
+  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
+  --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --funds-receiving-stake-verification-key-file stake.vkey \
   --constitution-script-hash "edcd84c10e36ae810dc50847477083069db796219b39ccde790484e0" \
   --transfer 50000000000 \
@@ -314,7 +313,7 @@ cardano-cli conway governance action create-info --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
   --anchor-url  https://tinyurl.com/yc74fxx4 \
-  --anchor-data-hash 931f1d8cdfdc82050bd2baadfe384df8bf99b00e36cb12bfb8795beab3ac7fe5 \
+  --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --out-file info.action
 ```
 From here, you just need to [submit the proposal in a transaction](#submitting-the-action-file-in-a-transaction) 
@@ -330,8 +329,8 @@ cardano-cli conway governance action create-protocol-parameters-update \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url https://raw.githubusercontent.com/Ryun1/metadata/main/cip108/treasury-withdrawal.jsonld \
-  --anchor-data-hash 931f1d8cdfdc82050bd2baadfe384df8bf99b00e36cb12bfb8795beab3ac7fe5 \
+  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
+  --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --constitution-script-hash "edcd84c10e36ae810dc50847477083069db796219b39ccde790484e0" \
   --key-reg-deposit-amt 1000000 \
   --out-file pp-update.action

--- a/docs/get-started/cardano-cli/governance/governance-actions.md
+++ b/docs/get-started/cardano-cli/governance/governance-actions.md
@@ -56,7 +56,7 @@ actions against this single stored value.
 When proposing a governance action, the proposer must employ an *anchor*, which comprises a *URL* hosting a document that outlines additional context
 for the proposed changes, along with the document's *hash*.
 
-The document at the URL can be of a free form. It's important that it should communicate to ada holders the *why* and the *how* of the proposal. This tutorial mostly uses 'https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld' as an example, see [here](https://github.com/cardano-foundation/CIPs/blob/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/test-vector.md) for more details.
+The document at the URL can be of a free form. It's important that it should communicate to ada holders the *why* and the *how* of the proposal. This tutorial mostly uses 'https://raw.githubusercontent.com/cardano-foundation/CIPs/master/CIP-0108/examples/treasury-withdrawal.jsonld' as an example, see [here](https://github.com/cardano-foundation/CIPs/blob/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/test-vector.md) for more details.
 
 See [CIP-100 | Governance Metadata](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0100) and [CIP-0108 | Governance Metadata - Governance Actions](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0108) for standard.
 
@@ -92,7 +92,7 @@ cardano-cli conway governance action update-committee \
   --testnet \
   --governance-action-deposit $(cardano-cli query protocol-parameters | jq -r '.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
+  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/master/CIP-0108/examples/treasury-withdrawal.jsonld \
   --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --add-cc-cold-verification-key-hash 89181f26b47c3d3b6b127df163b15b74b45bba7c3b7a1d185c05c2de \
   --epoch 100 \
@@ -115,7 +115,7 @@ cardano-cli conway governance action update-committee \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
+  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/master/CIP-0108/examples/treasury-withdrawal.jsonld \
   --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --remove-cc-cold-verification-key-hash 89181f26b47c3d3b6b127df163b15b74b45bba7c3b7a1d185c05c2de \
   --threshold 1/2 \
@@ -131,7 +131,7 @@ cardano-cli conway governance action update-committee \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
+  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/master/CIP-0108/examples/treasury-withdrawal.jsonld \
   --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --threshold 60/100 \
   --prev-governance-action-tx-id fe2c99fe6bc75a9666427163d51ae7dbf5a60df40135361b7bfd53ac6c7912ec \
@@ -163,7 +163,7 @@ cardano-cli conway query gov-state | jq -r '.nextRatifyState.nextEnactState.prev
 }
 ```
 
-### Prepare the constiution anchor.
+### Prepare the constitution anchor.
 
 When proposing a new constitution, you are required to put it on a URL that is publicly accessible and, ideally, in some sort of persistent form. For example 
 put it on IPFS, like the [interim constitution](https://ipfs.io/ipfs/Qmdo2J5vkGKVu2ur43PuTrM7FdaeyfeFav8fhovT6C2tto)
@@ -192,7 +192,7 @@ a77245f63bc7504c6ce34383633729692388dc1823723b0ee9825743a87a6a6d
 While the constitution is an informal, off-chain document, there will also be an optional script that can enforce some guidelines. This script acts 
 to supplement the constitutional committee by restricting some proposal types.
 
-At the Chang hardfork, the interim constitution will be supplemented with a Guardrails script. It is soon to be open sourced, you will find it here: https://github.com/XXXX
+At the Chang hardfork, the interim constitution will be supplemented with a Guardrails script. The raw files can be found at [Plutus/cardano-constitution](https://github.com/IntersectMBO/plutus/tree/master/cardano-constitution).
 
 The guardrails script applies only to protocol parameter update and treasury withdrawal proposals.
 
@@ -240,7 +240,7 @@ cardano-cli conway governance action create-constitution \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
+  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/master/CIP-0108/examples/treasury-withdrawal.jsonld \
   --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --constitution-url https://ipfs.io/ipfs/Qmdo2J5vkGKVu2ur43PuTrM7FdaeyfeFav8fhovT6C2tto \
   --constitution-hash "a77245f63bc7504c6ce34383633729692388dc1823723b0ee9825743a87a6a6d" \
@@ -272,7 +272,7 @@ cardano-cli conway governance action create-no-confidence \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
+  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/master/CIP-0108/examples/treasury-withdrawal.jsonld \
   --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --prev-governance-action-tx-id fe2c99fe6bc75a9666427163d51ae7dbf5a60df40135361b7bfd53ac6c7912ec \
   --prev-governance-action-index 0 \
@@ -293,7 +293,7 @@ cardano-cli conway governance action create-treasury-withdrawal \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
+  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/master/CIP-0108/examples/treasury-withdrawal.jsonld \
   --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --funds-receiving-stake-verification-key-file stake.vkey \
   --constitution-script-hash "edcd84c10e36ae810dc50847477083069db796219b39ccde790484e0" \
@@ -313,7 +313,7 @@ From here, you just need to [submit the proposal in a transaction](#submitting-t
 cardano-cli conway governance action create-info --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url  https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
+  --anchor-url  https://raw.githubusercontent.com/cardano-foundation/CIPs/master/CIP-0108/examples/treasury-withdrawal.jsonld \
   --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --out-file info.action
 ```
@@ -330,7 +330,7 @@ cardano-cli conway governance action create-protocol-parameters-update \
   --testnet \
   --governance-action-deposit $(cardano-cli conway query gov-state | jq -r '.currentPParams.govActionDeposit') \
   --deposit-return-stake-verification-key-file stake.vkey \
-  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/4640b74025c4d7f233c47ebc8319e634d2de39de/CIP-0108/examples/treasury-withdrawal.jsonld \
+  --anchor-url https://raw.githubusercontent.com/cardano-foundation/CIPs/master/CIP-0108/examples/treasury-withdrawal.jsonld \
   --anchor-data-hash 311b148ca792007a3b1fee75a8698165911e306c3bc2afef6cf0145ecc7d03d4 \
   --constitution-script-hash "edcd84c10e36ae810dc50847477083069db796219b39ccde790484e0" \
   --key-reg-deposit-amt 1000000 \

--- a/docs/get-started/cardano-cli/governance/governance.md
+++ b/docs/get-started/cardano-cli/governance/governance.md
@@ -3,7 +3,7 @@ id: cardano-governance
 title: Cardano governance
 sidebar_label: CLI - Governance 
 sidebar_position: 5
-description: Overiew ov cardano governance across ledger eras. 
+description: Overview ov cardano governance across ledger eras. 
 keywords: [governance, update proposals, cardano, cardano-node]
 ---
 
@@ -34,7 +34,7 @@ Transitioning from one era to the next is triggered by an **update proposal** th
 The general mechanism for updating protocol parameters in Byron is as follows:
 
 1. **Update proposal is registered.** An update proposal starts with a transaction that proposes new values for some protocol parameters or a new protocol version. This kind of transaction can only be initiated by a genesis key via its delegate.
-2. **Accumulating votes.** Genesis key delegates **vote** for or against the proposal. The proposal must accumulate a sufficient number of votes before it can be confirmed. The threshold is determined by the **minThd** field of the [softforkRule protocol parameter](https://github.com/input-output-hk/cardano-ledger/blob/2a0abd500b9e01efe6dc47146fa8b805ef9ef307/eras/byron/ledger/impl/src/Cardano/Chain/Update/SoftforkRule.hs#L24).
+2. **Accumulating votes.** Genesis key delegates **vote** for or against the proposal. The proposal must accumulate a sufficient number of votes before it can be confirmed. The threshold is determined by the **minThd** field of the [softfork Rule protocol parameter](https://github.com/input-output-hk/cardano-ledger/blob/2a0abd500b9e01efe6dc47146fa8b805ef9ef307/eras/byron/ledger/impl/src/Cardano/Chain/Update/SoftforkRule.hs#L24).
 3. **Confirmed (enough votes).** The system records the 'SlotNo' of the slot in which the required threshold of votes was met. At this point, 2k slots (two times the security parameter k) need to pass before the update is stably confirmed and can be _endorsed_. Endorsements for proposals that are not yet stably confirmed are not invalid but rather silently ignored.
 4. **Stably-confirmed.** The last required vote is 2k slots deep. Ready to accumulate endorsements. A block whose header's protocol version number is that of the proposal is interpreted as an **endorsement**. In other words, the nodes are ready for the upgrade. Once the number of endorsers satisfies a threshold (same as for voting), the confirmed proposal becomes a **candidate proposal**.
 5. **Candidate.** Enough nodes have endorsed the proposal. At this point, further 2k slots need to pass before the update becomes a stable candidate and can be adopted.
@@ -75,9 +75,9 @@ If you are running a private testnet, you can use this feature to update your te
 
 ```shell
 cardano-cli babbage governance action create-protocol-parameters-update \
---genesis-verification-key-file genesis-keys/non.extended.shelley.delegate.vkey \
---number-of-pools 1000 \
---out-file updateNOpt.proposal
+  --genesis-verification-key-file genesis-keys/non.extended.shelley.delegate.vkey \
+  --number-of-pools 1000 \
+  --out-file updateNOpt.proposal
 ```
 
 Build, sign, and submit the transaction: 
@@ -88,17 +88,17 @@ fee=1000000
 change=$(($balance - $fee))
 
 cardano-cli babbage transaction build-raw \
---fee $fee \
---tx-in $(cardano-cli query utxo --address $(< payment.addr) --out-file /dev/stdout | jq -r 'keys[0]' \
---tx-out $(< payment.addr)+$change \
---update-proposal-file updateNOpt.proposal \
---out-file updateNOpt.tx.raw
+  --fee $fee \
+  --tx-in $(cardano-cli query utxo --address $(< payment.addr) --out-file /dev/stdout | jq -r 'keys[0]' \
+  --tx-out $(< payment.addr)+$change \
+  --update-proposal-file updateNOpt.proposal \
+  --out-file updateNOpt.tx.raw
 
 cardano-cli conway transaction sign \
---tx-body-file updateNOpt.tx.raw \
---signing-key-file payment.skey \
---signing-key-file genesis-keys/non.extended.shelley.delegate.skey \ 
---out-file updateNOpt.tx.signed
+  --tx-body-file updateNOpt.tx.raw \
+  --signing-key-file payment.skey \
+  --signing-key-file genesis-keys/non.extended.shelley.delegate.skey \ 
+  --out-file updateNOpt.tx.signed
 
 cardano-cli conway transaction submit --tx-file updateNOpt.tx.signed
 ```

--- a/docs/get-started/cardano-cli/governance/register-drep.md
+++ b/docs/get-started/cardano-cli/governance/register-drep.md
@@ -30,8 +30,8 @@ import TabItem from '@theme/TabItem';
 
 ```shell
 cardano-cli conway governance drep key-gen \
---verification-key-file drep.vkey \
---signing-key-file drep.skey
+  --verification-key-file drep.vkey \
+  --signing-key-file drep.skey
 ```
 This returns the keys wrapped on text envelopes:  
 
@@ -410,7 +410,7 @@ cardano-cli conway transaction witness \
   --out-file payment.witness
 ```
 
-Witnessing the transaction with the DRep keys from each memeber:
+Witnessing the transaction with the DRep keys from each member:
 
 ```shell
 cardano-cli conway transaction witness \

--- a/docs/get-started/cardano-cli/governance/register-drep.md
+++ b/docs/get-started/cardano-cli/governance/register-drep.md
@@ -182,7 +182,7 @@ Submit it to the chain:
 
 ```shell
 cardano-cli conway transaction submit \
---tx-file tx.signed
+  --tx-file tx.signed
 ```
 
 ### Query the DRep state to confirm:

--- a/docs/get-started/cardano-cli/governance/voting.md
+++ b/docs/get-started/cardano-cli/governance/voting.md
@@ -25,11 +25,11 @@ Assume we need to submit a vote on the governance action with ID `df58f714c0765f
 
 1. Obtain the URL and hash of the new constitution proposal from the governance state:
 
-```
+```shell
 cardano-cli conway query gov-state | \
-jq -r --arg govActionId "df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79" '.proposals | to_entries[] | select(.value.actionId.txId | contains($govActionId)) | .value'
+  jq -r --arg govActionId "df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79" '.proposals | to_entries[] | select(.value.actionId.txId | contains($govActionId)) | .value'
 ```
-```
+```json
 {
   "action": {
     "contents": [
@@ -70,13 +70,13 @@ jq -r --arg govActionId "df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf
 ```
 2. Download the file from the URL registered on the proposal:
 
-````
+````shell
 wget https://tinyurl.com/mr3ferf9 -O constitution.txt
 ````
 
 3. Verify that the hash of the file matches the `dataHash` registered on the proposal:
 
-````
+````shell
 b2sum -l 256 constitution.txt
 5d372dca1a4cc90d7d16d966c48270e33e3aa0abcb0e78f0d5ca7ff330d2245d  constitution.txt
 ````
@@ -89,70 +89,70 @@ In the future, voting apps, explorers, wallets, and other tools could perform th
 
 Voting with DRep keys:
 
-```
+```shell
 cardano-cli conway governance vote create \
-    --yes \
-    --governance-action-tx-id "df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79" \
-    --governance-action-index "0" \
-    --drep-verification-key-file drep.vkey \
-    --out-file df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79-constitution.vote
+  --yes \
+  --governance-action-tx-id "df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79" \
+  --governance-action-index "0" \
+  --drep-verification-key-file drep.vkey \
+  --out-file df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79-constitution.vote
 ```
 
 Voting with CC hot keys:
 
-```
+```shell
 cardano-cli conway governance vote create \
-    --yes \
-    --governance-action-tx-id "df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79" \
-    --governance-action-index "0" \
-    --cc-hot-verification-key-file cc-hot.vkey \
-    --out-file df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79-constitution.vote
+  --yes \
+  --governance-action-tx-id "df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79" \
+  --governance-action-index "0" \
+  --cc-hot-verification-key-file cc-hot.vkey \
+  --out-file df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79-constitution.vote
 ```
 Voting with SPO keys:
 
-```
+```shell
 cardano-cli conway governance vote create \
-    --yes \
-    --governance-action-tx-id "df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79" \
-    --governance-action-index "0" \
-    --cold-verification-key-file cold.vkey \
-    --out-file df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79-constitution.vote
+  --yes \
+  --governance-action-tx-id "df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79" \
+  --governance-action-index "0" \
+  --cold-verification-key-file cold.vkey \
+  --out-file df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79-constitution.vote
 ```
 
 ### Include the vote in a transaction
 
 Build the transaction:
 
-```
+```shell
 cardano-cli conway transaction build \
-    --tx-in "$(cardano-cli query utxo --address $(< payment.addr) --output-json | jq -r 'keys[0]')" \
-    --change-address $(< payment.addr) \
-    --vote-file df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79-constitution.vote \
-    --witness-override 2 \
-    --out-file vote-tx.raw
+  --tx-in "$(cardano-cli query utxo --address $(< payment.addr) --output-json | jq -r 'keys[0]')" \
+  --change-address $(< payment.addr) \
+  --vote-file df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79-constitution.vote \
+  --witness-override 2 \
+  --out-file vote-tx.raw
 ```
 Sign it with the DRep key:
-```
+```shell
 cardano-cli transaction sign --tx-body-file vote-tx.raw \
-    --signing-key-file drep.skey \
-    --signing-key-file payment.skey \
-    --out-file vote-tx.signed
+  --signing-key-file drep.skey \
+  --signing-key-file payment.skey \
+  --out-file vote-tx.signed
 ```
 OR sign it with the CC hot key:
-```
+```shell
 cardano-cli transaction sign --tx-body-file vote-tx.raw \
-    --signing-key-file cc-hot.skey \
-    --signing-key-file payment.skey \
-    --out-file vote-tx.signed
+  --signing-key-file cc-hot.skey \
+  --signing-key-file payment.skey \
+  --out-file vote-tx.signed
 ```
 OR sign it with the SPO cold key:
-```
+```shell
 cardano-cli transaction sign --tx-body-file vote-tx.raw \
-    --signing-key-file cold.skey \
-    --signing-key-file payment.skey \
-    --out-file vote-tx.signed
+  --signing-key-file cold.skey \
+  --signing-key-file payment.skey \
+  --out-file vote-tx.signed
 ```
 Submit the transaction:
-```
+```shell
 cardano-cli transaction submit --tx-file vote-tx.signed
 ```


### PR DESCRIPTION
## Checklist

- [x] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [x] I have run `yarn build` after adding my changes **without getting any errors**. 
- [x] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://developers.cardano.org/docs/portal-contribute/#i-committed-yarnlock-to-my-pr-branch-what-do-i-do)).

## Updating documentation or Bugfix

#### What?

##### Governance actions page

- Substituting broken links (to my repo) for permalinks based on the CIPs repo
- Updated info around metadata standards, to take into consideration https://github.com/cardano-foundation/CIPs/pull/835
- Fixing typos on governance actions page
- Making the governance actions page more consistent
- Made code blocks use `shell` consistently

##### Other Governance CLI Pages

- Fixed typos
- Made code blocks use `shell` consistently
- Made cardano-cli command indentation consistent

#### Motivation

@gufmar spotted the CIP108 anchor errors and let me know! 