### PR TITLE
Update cardano-cli link in Builder Tools

### DIFF
--- a/src/data/builder-tools.js
+++ b/src/data/builder-tools.js
@@ -317,7 +317,7 @@ export const Showcases = [
     title: "cardano-cli",
     description: "The companion command-line to interact with a Cardano node, manipulate addresses or create transactions.",
     preview: require("./builder-tools/cardano-cli.png"),
-    website: "https://github.com/IntersectMBO/cardano-node/tree/master/cardano-cli#cardano-cli",
+    website: "https://github.com/IntersectMBO/cardano-cli#overview-of-the-cardano-cli-repository",
     getstarted: null,
     tags: ["favorite", "cli", "serialization"]
   },


### PR DESCRIPTION
Fixes https://github.com/cardano-foundation/developer-portal/issues/1327 (thanks for noticing this, @bezirg).

@CarlosLopezDeLara I know the heading for the first text section on this page has changed several times, but I do think using the anchor to jump to that text (past all the GitHub files) is important for new arrivals.  If that first heading changes again, this anchor won't work anymore and it will just land at the beginning of the GitHub page... which it would do anyway if the anchor were left off the link.