### PR TITLE
Remove Plutus Playground from Builder Tools

### DIFF
--- a/src/data/builder-tools.js
+++ b/src/data/builder-tools.js
@@ -528,14 +528,6 @@ export const Showcases = [
     tags: ["sdk", "python"],
   },
   {
-    title: "Plutus Playground",
-    description: "The Plutus Playground is a lightweight, web-based environment for exploratory Plutus development.",
-    preview: require("./builder-tools/plutus-playground.png"),
-    website: "https://playground.plutus.iohkdev.io",
-    getstarted: "/docs/smart-contracts/plutus#plutus-playground",
-    tags: ["favorite", "plutus", "hosted"],
-  },
-  {
     title: "Marlowe Playground",
     description: "In the browser-based Marlowe Playground you can write Marlowe contracts, in a variety of different ways.",
     preview: require("./builder-tools/marlowe-playground.png"),


### PR DESCRIPTION
Defunct for a while now I believe.  Fixes #https://github.com/cardano-foundation/developer-portal/issues/1328.

Keeping separate from https://github.com/cardano-foundation/developer-portal/pull/1329 because there might be one or two Plutus evaluators to put in its place... 🤔