### PR TITLE
Register Stake Pool: correct "VRS" to VRF

### DIFF
--- a/docs/operate-a-stake-pool/register-stake-pool-metadata.md
+++ b/docs/operate-a-stake-pool/register-stake-pool-metadata.md
@@ -80,7 +80,7 @@ cardano-cli stake-pool registration-certificate \
 | Parameter | Explanation |
 | :--- | :--- |
 | cold-verification-key-file | verification _cold_ key |
-| vrf-verification-key-file | verification _VRS_ key |
+| vrf-verification-key-file | verification _VRF_ key |
 | pool-pledge | pledge lovelace |
 | pool-cost | operational costs per epoch lovelace |
 | pool-margin | operator margin |

--- a/docs/operate-a-stake-pool/register-stake-pool.md
+++ b/docs/operate-a-stake-pool/register-stake-pool.md
@@ -129,7 +129,7 @@ IP based relays, 1 entry per IP address
 | Parameter | Explanation |
 | :--- | :--- |
 | cold-verification-key-file | verification _cold_ key |
-| vrf-verification-key-file | verification _VRS_ key |
+| vrf-verification-key-file | verification _VRF_ key |
 | pool-pledge | pledge lovelace |
 | pool-cost | operational costs per epoch lovelace |
 | pool-margin | operator margin |


### PR DESCRIPTION
I've not done anything in the checklist. 
The PR is for illustrative purposes only. 
I assume this is correcting a typo - I don't know what a `VRS` is otherwise
You may merge or close as you see fit. 