### PR TITLE
Update testnets-and-devnets.md

### DIFF
--- a/docs/get-started/testnets-and-devnets.md
+++ b/docs/get-started/testnets-and-devnets.md
@@ -71,7 +71,9 @@ In depth explanation about Cardano Testnet Faucet can be found [here.](/docs/int
 - [testnet.cexplorer.io](https://testnet.cexplorer.io/) is a Pre-Production and Preview block explorer by [Cexplorer](https://cexplorer.io).
 
 ### Which metadata explorers can I use for the Cardano testnets?
-- [pool.pm/test/metadata](https://pool.pm/test/metadata) is a testnet metadata explorer by [Pool.pm](https://pool.pm/)
+- [cardanoscan.io/metadata](https://preprod.cardanoscan.io/metadata) is a preprod metadata explorer by [CardanoScan.io](https://cardanoscan.io/)
+- [cexplorer.io/metadata](https://preprod.cexplorer.io/metadata) is a preprod metadata explorer by [cExplorer.io](https://cexplorer.io/)
+
 
 ### What kind of monitoring tools are available for the testnets?
 - Set up your own node's [Grafana/Promtheus monitoring](/docs/operate-a-stake-pool/grafana-dashboard-tutorial/#4-setting-up-grafana-dashboard) system


### PR DESCRIPTION
removed the incorrect reference to pool as a metadata explorer and added a few actual references.

👋 Hello there! Welcome. Please follow the steps below to tell us about your contribution.

1. Please complete a Checklist
2. Fill in all sections of the template
3. Click "Create pull request"

## Checklist

 <-- Please fill the boxes with [x] before submitting a pull request --> 

- [x] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [x] I have run `yarn build` after adding my changes **without getting any errors**. 
- [x] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://developers.cardano.org/docs/portal-contribute/#i-committed-yarnlock-to-my-pr-branch-what-do-i-do)).

## Updating documentation or Bugfix

<-- Help us understand your motivation by explaining why you decided to make this change. We must be able to understand the purpose of your change from this description.  Does this fix a bug? Does it close an issue? If so please mention it.  -->


I noticed this was listing pool.pm/test/metadata as a metadata explorer and I wanted to correct the mistake and add a meaningful contribution at the same time.