### PR TITLE
fix typo 'who' -> 'how'

### DIFF
--- a/docs/get-started/technical-concepts.md
+++ b/docs/get-started/technical-concepts.md
@@ -83,7 +83,7 @@ How dropped transactions happen on cardano and how to ensure we always deliver t
 <iframe width="100%" height="325" src="https://www.youtube.com/embed/gm-phCUGEoY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture fullscreen"></iframe>
 
 ## SundaeSwap & Merkel Trees
-Learn about the SundaeSwap ISO and who Merkel Trees work.
+Learn about the SundaeSwap ISO and how Merkel Trees work.
 <iframe width="100%" height="325" src="https://www.youtube.com/embed/hStyO1L1qOE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture fullscreen"></iframe>
 
 ## DripDropz & Phyrhose


### PR DESCRIPTION

## Checklist

 <-- Please fill the boxes with [x] before submitting a pull request --> 

- [x ] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [x ] I have run `yarn build` after adding my changes **without getting any errors**. 
- [x ] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://developers.cardano.org/docs/portal-contribute/#i-committed-yarnlock-to-my-pr-branch-what-do-i-do)).

## Updating documentation or Bugfix

Fixinging the typo: `and who Merkel Trees work.`
with: `and how Merkel Trees work.`
