### PR TITLE
Fix issue Search Field on Showcase Page Not Clickable in Desktop Browser

### DIFF
--- a/src/components/BackgroundWrapper/styles.module.css
+++ b/src/components/BackgroundWrapper/styles.module.css
@@ -25,3 +25,7 @@
 [data-theme="dark"] .backgroundAda:before {
   color: #98b7f2; /* dark mode color for the A */
 }
+
+.backgroundAda:before {
+  pointer-events: none;
+}


### PR DESCRIPTION
**Fixes Issue:**  
[[Cardano Foundation Developer Portal Issue #1402](https://github.com/cardano-foundation/developer-portal/issues/1402)](https://github.com/cardano-foundation/developer-portal/issues/1402)  

**Summary of Changes:**  
This PR resolves an issue where the background pseudo-element in the `backgroundAda` class was blocking click events on underlying elements such as the search bar. To fix this, the following code was added to the end of the file `src/components/BackgroundWrapper/styles.module.css`:

```css
.backgroundAda:before {
  pointer-events: none;
}
```

**Details:**  
- This update ensures that the pseudo-element no longer interferes with click events.  
- If the search bar is placed within a container using the `.backgroundAda` class, this change allows user interactions to pass through seamlessly, regardless of the size or positioning of the background graphic.

**Testing:**  
- Verified that the change allows clicks on the search bar without affecting the visual styling of `.backgroundAda`.  
- Confirmed no regressions in other components using the `.backgroundAda` class.
