### PR TITLE
Developer Blog: removed expired entries, some updates

### DIFF
--- a/blog/2021-08-23-august.md
+++ b/blog/2021-08-23-august.md
@@ -51,7 +51,7 @@ I believe that people should choose their financial freedom, which is why mercha
 
 I am the primary developer of Mercury for WooCommerce. I have been a Cardano stake pool owner/operator since the ITN (Ticker: BUFFY) and have always strived to support the Cardano community in every way possible. This includes countless hours spent helping fellow SPOs in public and private Telegram chats, development, and contribution to community tools including simpleLiveView/CNTools gLiveView, Python Slot Leader Log script, Leader Logs Sigma API, development of the first Cardano on-chain voting mechanism (utilizing transaction metadata), and most recently Cardano Mercury for WooCommerce.
 
-The testing and development of Mercury for WooCommerce would not have been possible without the feedback, brainstorming, and testing contributions of [Kyle Solomon](https://twitter.com/ADAFrog_Pool) (Adosia IoT, Heidrun, spacecoins, FROG stake pool) and Latheesan Kanesamoorthy (primary developer and co-founder of [Tokhun.io](https://tokhun.io/), Heidrun contributor).
+The testing and development of Mercury for WooCommerce would not have been possible without the feedback, brainstorming, and testing contributions of [Kyle Solomon](https://twitter.com/ADAFrog_Pool) (Adosia IoT, Heidrun, spacecoins, FROG stake pool) and Latheesan Kanesamoorthy (primary developer and co-founder of Tokhun.io, Heidrun contributor).
 
 Special thanks to JP Birch [(MADinArt)](https://twitter.com/MADinArt3) for his help developing the Mercury logos and branding and Marek Mahut and the team at [Five Binaries](https://twitter.com/fivebinaries) for the amazing Blockfrost API, which has helped make Cardano integrations like Mercury a painless and straightforward process.
 

--- a/blog/2023-01-02-january.md
+++ b/blog/2023-01-02-january.md
@@ -128,7 +128,7 @@ The future of Gimbalabs will only happen with you! So rather than continuing to 
 
 **_Who else are you working with?_**
 
-We are working in partnership with other open-source builders like [Mesh](https://meshjs.dev/), [TxPipe](https://txpipe.io/), [Plu-TS](https://github.com/HarmonicLabs/plu-ts) and others to create a comprehensive stack for Cardano developers. We are working alongside organisations like [OneUpOneDown](https://oneuponedown.org/), [Cardano4Climate](https://cardano4climate.com/), [WADA](https://www.wada.org/), and [Littlefish Foundation](https://littlefish.foundation/) to launch projects and cultivate leaders globally.
+We are working in partnership with other open-source builders like [Mesh](https://meshjs.dev/), [TxPipe](https://txpipe.io/), [Plu-TS](https://github.com/HarmonicLabs/plu-ts) and others to create a comprehensive stack for Cardano developers. We are working alongside organisations like [OneUpOneDown](https://oneuponedown.org/), [Cardano4Climate](https://cardano4climate.com/), [WADA](https://wada.org), and [Littlefish Foundation](https://littlefish.foundation/) to launch projects and cultivate leaders globally.
 
 We are collaborators at heart, and we've supported more projects to launch and partnerships to take root than we can count. 
 

--- a/blog/2025-01-17-january.md
+++ b/blog/2025-01-17-january.md
@@ -1,6 +1,6 @@
 ---
 slug: 2025-01-17-media-cardano-developer-office-hours
-title: "Cardano Developer Office Hours #12 - Presenting the yaci-devkit"
+title: "Presenting the yaci-devkit"
 authors: [cf]
 tags: [media, Developer Office Hours]
 ---

--- a/blog/2025-02-05-february.md
+++ b/blog/2025-02-05-february.md
@@ -1,6 +1,6 @@
 ---
 slug: 2025-02-05-media-cardano-developer-office-hours
-title: "Cardano Developer Office Hours #13 - Java Implementation on Rosetta"
+title: "Java Implementation on Rosetta"
 authors: [cf]
 tags: [media, Developer Office Hours]
 ---


### PR DESCRIPTION
This PR removes the inactive URL for tokhun.io, updates the URL for https://wada.org/, and updates the Developer Office Hour tiles.

- [X] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [X] I have run `yarn build` after adding my changes **without getting any errors**. 
- [X] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://developers.cardano.org/docs/portal-contribute/#i-committed-yarnlock-to-my-pr-branch-what-do-i-do)).

