### PR TITLE
remove Developer Portal Discord links

### DIFF
--- a/docs/get-started/cardano-developer-community.md
+++ b/docs/get-started/cardano-developer-community.md
@@ -31,9 +31,6 @@ Head to the [IOG Discord](https://discord.com/invite/w6TwW9bGA6) if you want to 
 [**t.me/IOHK_Marlowe**](https://t.me/IOHK_Marlowe)  
 Dedicated channel for Marlowe developers and users. Marlowe is a specialised domain-specific language for financial smart contracts on Cardano. You can ask questions, participate in discussions and meet the team behind Marlowe.
 
-[**Developer Portal Discord**](https://discord.gg/Exe6XmqKDx)  
-If you would like to help develop the Developer Portal further, please join our [Discord](https://discord.gg/Exe6XmqKDx). 
-
 [**CIPs - biweekly meetings**](https://discord.com/invite/Jy9YM69Ezf)  
 CIP meetings discuss Cardano Improvement Proposals every other week. Join Editors and community members in the dedicated discord server to keep up with the ongoing technical discussions regarding standards, processes and ongoing Cardano conversations.
 

--- a/docs/portal-contribute.md
+++ b/docs/portal-contribute.md
@@ -42,7 +42,6 @@ If you are a talented graphic designer, you can improve various charts and diagr
 
 ### Participate in the discussions
 If you think something is wrong or something fundamental should change, discussions are the appropriate start to find consensus. There are always [ongoing discussions](https://github.com/cardano-foundation/developer-portal/discussions/243) on how to handle or improve something. Please take part in them. Even if you are not a developer, your views are valuable:
-* [Developer Portal Discord](https://discord.gg/Exe6XmqKDx) 
 * [Issues in the GitHub Repo](https://github.com/cardano-foundation/developer-portal/issues) 
 * [Discussions in the GitHub Repo](https://github.com/cardano-foundation/developer-portal/discussions)
 
@@ -101,7 +100,7 @@ You should have an excellent technical understanding, great ethics and have alre
 ### How to connect with the developer community?
 Cardano developers and stake pool operators spread across many different platforms. [We aim to provide a complete overview.](/docs/get-started/cardano-developer-community) 
 
-If you are interested in connecting with people from the Developer Portal, either visit [the Discord](https://discord.gg/Exe6XmqKDx) or [open a thread in the forum](https://forum.cardano.org/c/developers/29). 
+If you are interested in connecting with people from the Developer Portal, [open a thread in the forum](https://forum.cardano.org/c/developers/29). 
 
 
 ## Installation

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -156,10 +156,6 @@ module.exports = {
               href: "https://forum.cardano.org/c/developers/29",
             },
             {
-              label: "Developer Portal Discord",
-              href: "https://discord.com/invite/Exe6XmqKDx",
-            },
-            {
               label: "Developer Ecosystem Survey",
               href: "https://cardano-foundation.github.io/state-of-the-developer-ecosystem",
             },


### PR DESCRIPTION
**Description:**  
This pull request will update the Cardano Developer Portal by removing references to the Developer Portal Discord. The following changes will be made:

1. **docs/get-started/cardano-developer-community.md**
   - Remove the section referencing the Developer Portal Discord, including the link and description.

2. **docs/portal-contribute.md**
   - Remove the invitation to join the Developer Portal Discord for contributions.

3. **docusaurus.config.js**
   - Remove the Developer Portal Discord link from the configuration file.

**Additional Notes:**  
Please review the changes to ensure that all references to the Developer Portal Discord have been appropriately removed and that the site's integrity remains intact.

---
