### PR TITLE
Node installation: Use `IOHKNIX_VERSION` for blst version

### DIFF
--- a/docs/get-started/cardano-node/installing-cardano-node.md
+++ b/docs/get-started/cardano-node/installing-cardano-node.md
@@ -238,7 +238,7 @@ sudo make install
 
 Find out the correct `blst` version:
 ```bash
-BLST_VERSION=$(curl https://raw.githubusercontent.com/input-output-hk/iohk-nix/master/flake.lock | jq -r '.nodes.blst.original.ref')
+BLST_VERSION=$(curl https://raw.githubusercontent.com/input-output-hk/iohk-nix/$IOHKNIX_VERSION/flake.lock | jq -r '.nodes.blst.original.ref')
 echo "Using blst version: ${BLST_VERSION}"
 ```
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [x] I have run `yarn build` after adding my changes **without getting any errors**. 
- [x] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://developers.cardano.org/docs/portal-contribute/#i-committed-yarnlock-to-my-pr-branch-what-do-i-do)).

## Updating documentation or Bugfix

Updated the command to fetch the correct `blst` version by parameterizing the iohk-nix version with the `$IOHKNIX_VERSION` variable.

The documentation states that

> The variable `IOHKNIX_VERSION` is used to retrieve the correct versions of `sodium`, `secp256k1` and `blst`.

However this is not currently the case for `blst` version, which is retrieved from iohk-nix master, and therefore the version can be incorrect for the given node revision.
