### PR TITLE
Node installation: update Ubuntu/Debian dependencies for cardano-node

### DIFF
--- a/docs/get-started/cardano-node/installing-cardano-node.md
+++ b/docs/get-started/cardano-node/installing-cardano-node.md
@@ -51,7 +51,7 @@ For Debian/Ubuntu:
 
 ```bash
 sudo apt-get update -y
-sudo apt-get install automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libncursesw5 libtool autoconf liblmdb-dev -y
+sudo apt-get install automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libncurses-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libtool autoconf liblmdb-dev -y
 ```
 
 Possible issue with `pkg-config`:


### PR DESCRIPTION
## Checklist

- [x] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [x] I have run `yarn build` after adding my changes **without getting any errors**. 
- [x] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://developers.cardano.org/docs/portal-contribute/#i-committed-yarnlock-to-my-pr-branch-what-do-i-do)).

## Updating documentation or Bugfix

Fix:

- Replaced `libncursesw5` with `libncurses-dev` - `libncurses5` was removed in 24.04
- Removed `libtinfo-dev` - `libtinfo-dev` is a transitional package that can safely be removed. 

## Additional Info
- https://packages.debian.org/buster/libtinfo-dev
- https://packages.debian.org/buster/libncurses-dev
