### PR TITLE
Fix search bar on Builder Tools and Showcase

### DIFF
--- a/src/pages/tools/index.js
+++ b/src/pages/tools/index.js
@@ -24,6 +24,7 @@ import {
   Showcases
 } from "../../data/builder-tools";
 import { useHistory, useLocation } from "@docusaurus/router";
+import _debounce from 'lodash/debounce';
 import styles from "./styles.module.css";
 
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
@@ -118,7 +119,11 @@ function useFilteredProjects() {
     setOperator(readOperator(location.search));
     setLatest(readLatestOperator(location.search));
     setSearchName(readSearchName(location.search));
-    restoreUserState(location.state);
+    if (ExecutionEnvironment.canUseDOM && location.state) {
+      setTimeout(() => {
+        restoreUserState(location.state);
+      }, 0);
+    }
   }, [location]);
 
   return useMemo(
@@ -297,33 +302,38 @@ function readSearchName(search) {
 function SearchBar() {
   const history = useHistory();
   const location = useLocation();
-  const [value, setValue] = useState(null);
+  const [value, setValue] = useState(() => readSearchName(location.search) || '');
 
   useEffect(() => {
-    setValue(readSearchName(location.search));
-  }, [location]);
+    setValue(readSearchName(location.search) || '');
+  }, [location.search]);
+
+  const debouncedHistoryPush = useCallback(
+    _debounce((newSearchString) => {
+      history.push({
+        ...location,
+        search: newSearchString,
+        state: prepareUserState(),
+      });
+    }, 300),
+    [history, location] // Dependencies for useCallback
+  );
 
   return (
     <div className={styles.searchContainer}>
       <input
         id="searchbar"
         placeholder="Search builder tools..."
-        value={value ?? undefined}
+        value={value}
         onInput={(e) => {
-          setValue(e.currentTarget.value);
+          const currentInputValue = e.currentTarget.value;
+          setValue(currentInputValue);
           const newSearch = new URLSearchParams(location.search);
           newSearch.delete(SearchNameQueryKey);
-          if (e.currentTarget.value) {
-            newSearch.set(SearchNameQueryKey, e.currentTarget.value);
+          if (currentInputValue) {
+            newSearch.set(SearchNameQueryKey, currentInputValue);
           }
-          history.push({
-            ...location,
-            search: newSearch.toString(),
-            state: prepareUserState(),
-          });
-          setTimeout(() => {
-            document.getElementById("searchbar")?.focus();
-          }, 0);
+          debouncedHistoryPush(newSearch.toString());
         }}
       />
     </div>


### PR DESCRIPTION
This PR addresses an issue where the search bar on the /showcase and /tools pages would lose focus after each character input. This occurred because the URL was updated immediately with every keystroke, causing the component to re-render and, consequently, lose focus.

**Changes Made:**

_Debounced Search Functionality:_

The URL update (and thus the triggering of the filtering logic) is now debounced by 300 milliseconds using lodash/debounce. This means the URL is only updated after the user has paused typing for a short period.
The input in the search field itself is still displayed immediately to have a smooth user experience.

Affected files:

- /src/pages/showcase/index.js
- /src/pages/tools/index.js

_Improved Focus Restoration:_

The restoreUserState function is now called within a setTimeout(..., 0) inside the useEffect hook of the useFilteredProjects function.

This ensures that focus restoration occurs only after all DOM updates and state changes triggered by the URL modification have completed, reliably resolving the focus loss issue.

Affected files:

- /src/pages/showcase/index.js
- /src/pages/tools/index.js

