### PR TITLE
Purge/orcfax

### DIFF
--- a/src/data/builder-tools.js
+++ b/src/data/builder-tools.js
@@ -1005,15 +1005,6 @@ export const Showcases = [
     tags: ["c", "serialization", "sdk", "lowlevel"]
   },
   {
-    title: "Orcfax",
-    description:
-      "Orcfax is a decentralized oracle service designed to publish data about real world events to the Cardano blockchain. Orcfax data is made available to on-chain smart contracts in Cardano's eUTXO native format using the Orcfax Protocol.",
-    preview: require("./showcase/orcfax.png"),
-    website: "https://orcfax.io",
-    getstarted: "https://docs.orcfax.io/consume",
-    tags: ["oracle"],
-  },
-  {
     title: "Lucid Evolution",
     description:
       "Highly scalable, production-ready transaction builder & off-chain framework for users and dApps",

--- a/src/data/showcases.js
+++ b/src/data/showcases.js
@@ -1104,6 +1104,15 @@ export const Showcases = [
     source: "https://github.com/cardano-foundation/cardano-governance-voting-tool",
     tags: ["governance", "opensource"],
   },
+  {
+    title: "Orcfax",
+    description:
+      "Orcfax is a decentralized oracle service designed to publish data about real world events to the Cardano blockchain. Orcfax data is made available to on-chain smart contracts in Cardano's eUTXO native format using the Orcfax Protocol.",
+    preview: require("./showcase/orcfax.png"),
+    website: "https://orcfax.io",
+    source: "https://github.com/orcfax",
+    tags: ["oracle", "opensource"],
+  },
 ];
 
 export const TagList = Object.keys(Tags);

--- a/src/data/showcases.js
+++ b/src/data/showcases.js
@@ -1110,7 +1110,7 @@ export const Showcases = [
       "Orcfax is a decentralized oracle service designed to publish data about real world events to the Cardano blockchain. Orcfax data is made available to on-chain smart contracts in Cardano's eUTXO native format using the Orcfax Protocol.",
     preview: require("./showcase/orcfax.png"),
     website: "https://orcfax.io",
-    source: "https://github.com/orcfax",
+    source: "https://github.com/orcfax/orcfax-aiken",
     tags: ["oracle", "opensource"],
   },
 ];


### PR DESCRIPTION
## Summary

This PR updates the showcase item **Orcfax** on the Developer Portal.

## Rationale

- Oracles are displayed in showcase as products built on Cardano. (see Charli3)

> Related Issue #1485, #1528  