### PR TITLE
Get started with Cardano CLI: Add era to stake-address

### DIFF
--- a/docs/get-started/cardano-cli/get-started/get-started.md
+++ b/docs/get-started/cardano-cli/get-started/get-started.md
@@ -74,7 +74,7 @@ Testnet addresses start with 'addr_test' and mainnet addresses with 'addr'.
 ### Generate a stake key pair 
 
 ```shell
-cardano-cli stake-address key-gen \
+cardano-cli latest stake-address key-gen \
 --verification-key-file stake.vkey \
 --signing-key-file stake.skey
 ```


### PR DESCRIPTION
I received the following error with version **10.11.1.0** on macos and it seems like the era was missing from the command
```
cardano-cli stake-address key-gen \
--verification-key-file stake.vkey \
--signing-key-file stake.skey
Invalid argument `stake-address'

Usage: cardano-cli 
                     ( address
                     | key
                     | node
                     | hash
                     | query
                     | legacy
                     | byron
                     | conway
                     | latest
                     | debug commands
                     | version
                     | cip-format
                     | compatible
                     )
```