### PR TITLE
fix: remove unused babel.config.js

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: [require.resolve("@docusaurus/core/lib/babel/preset")],
-};


### PR DESCRIPTION
## Checklist

- [x ] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [x ] I have run `yarn build` after adding my changes **without getting any errors**. 
- [x ] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://developers.cardano.org/docs/portal-contribute/#i-committed-yarnlock-to-my-pr-branch-what-do-i-do)).

## Updating documentation or Bugfix

Docusaurus 3.x includes built-in Babel support, making the root-level `babel.config.js` redundant. Both the dev server (yarn start) and production build (yarn build) work correctly without it.

The framework ships with built-in Babel presets (@babel/preset-env, @babel/preset-react, etc.), so manual Babel configuration is no longer needed in most cases. This file appears to be a leftover from earlier Docusaurus versions and can be safely removed.


