### PR TITLE
Add Q2 2025 Ecosystem Tooling Digest

### DIFF
--- a/blog/2025-06-30-april.md
+++ b/blog/2025-06-30-april.md
@@ -1,0 +1,166 @@
+---
+slug: 2025-06-30-ecosystem-tooling-digest
+title: "Q2 2025 Ecosystem Tooling Digest"
+authors: [cf]
+tags: [Open source]
+---
+
+Below is a well-deserved Q2 update highlighting ecosystem tooling and solutions across April, May, and June.
+
+The past three months have been all about tightening up infrastructure, enhancing developer tools, and shipping valuable updates to support the Cardano ecosystem.
+With over 90 pull requests merged and 60+ issues closed in June alone, it’s been a highly productive quarter. 
+
+Check out the highlights below to see what’s been delivered.
+
+---
+## :gear: Cardano Rosetta Java
+
+`cardano-foundation/cardano-rosetta-java`
+
+**April**: 23 PRs merged focused on performance and stability:
+- Spring Boot 3.4 + JDK 21 Virtual Threads
+- Docker build-from-source support, Ubuntu 24.04
+- Sync status upgrades, transaction serialization fixes, and Mithril patching
+- Current release: `v1.2.7` → `v1.2.8` incoming (Mithril fix) → `v1.2.9` already in testing
+
+**May**: Continued evolution of the Cardano Rosetta integration stack coming very soon:
+- Upgraded to JDK 24 LTS and Spring Boot 3.4 for modern runtime compatibility
+- Docker-based infrastructure improvements — cleaner container splits and environment handling
+- Added support for building Postgres, Mithril, and Cardano Node from source in both single-container and Docker Compose setups — a key security feature over pulling pre-built images
+- Retry mechanism added for better node submission resilience
+- Cleaned up pruning variable usage, enhanced `/network/status` endpoint with `oldest_block`
+- Closed issues include runtime upgrades, variable cleanup, and improved Docker orchestration for internal deployments
+
+**June**: 18 PRs Merged | 5 Issues Closed
+
+Wide-ranging fixes and enhancements throughout the Rosetta Java stack:
+- Resolved issues with reward withdrawal, DRep vote delegation parsing, and nested token bundles in the /construction/parse endpoint
+- Upgraded Docker setups for single-container builds (Cardano Node, Mithril, Postgres)
+- Improved environment variable handling, renamed key config fields, and added retry logic
+- Closed issues related to pruning behavior, stake balance endpoint responses, and internal release testing for v1.2.9
+
+
+## :large_blue_diamond: Cardano IBC Incubator
+
+`cardano-foundation/cardano-ibc-incubator`
+
+**May**: Mitigated the token dust attack vector uncovered during the security audit
+
+**June**: 9 PRs Merged | 2 Issues Closed
+- Brought down deployment costs to 570 ADA
+- Upgraded Mithril and Cardano node version
+
+
+## :large_blue_diamond: Ada Handle Resolver
+
+`cardano-foundation/cf-adahandle-resolver`
+
+**May**: Released v0.1.4 — now using Yaci Store 0.1.2 and Spring Boot 3.3.11
+
+
+## :link: Connect with Wallet
+
+`cardano-foundation/cardano-connect-with-wallet`
+
+**April**: The wallet list component caught up with the wallet button — now fully supports CIP-45 and mobile wallets. Nice polish! 
+
+**June**: PRs Merged | 1 Issue Closed
+- Resolved a release issue where CIP-30 wallets weren't being properly detected — improving compatibility across wallet integrations
+
+
+## :moneybag: Java Rewards Calculation
+
+`cardano-foundation/cf-java-rewards-calculation`
+
+**April**: Bug report opened to improve stake key registration checks at epoch boundaries. 
+
+
+## :toolbox: Cardano Client Lib
+
+`bloxbean/cardano-client-lib`
+
+**April**: Fixed performance issue with dummy signers — now avoids unnecessary account generation.
+
+**June**: 4 PRs Merged
+
+Precision fixes to improve developer reliability:
+- Resolved native script parsing issues caused by indefinite-length arrays
+- Migrated repository publishing from OSSRH to the new Maven Central portal
+
+**May**:
+- Fixed a subtle bug in multi-asset value subtraction logic
+- Also opened a new issue to catch transaction builder errors when negative balances are likely — improving developer feedback during build time
+
+
+## :test_tube: Yaci DevKit
+
+`bloxbean/yaci-devkit`
+
+**April**: Open community discussion kicked off on how devs can best use Yaci locally. Great move to engage builders!
+
+**May**:
+- Added fixes for Plutus V3 compatibility with Lucid Evolution
+- Improved community-facing tooling: beta builds now pushed with clearer NPM version tags
+- Feature request raised for managing public network setups using Yaci CLI
+
+**June**: 2 PRs Merged | 1 Issue Closed
+
+CLI and testing enhancements:
+- Added rollback simulation support using DB snapshots and TCP proxy-based forks in Yaci CLI
+- Improved API usability with Swagger annotations
+- Closed the issue for passing --era flags via CLI
+
+
+## :heavy_division_sign: Yaci
+
+`bloxbean/yaci`
+
+**April**: Resolved JSON serialization issue affecting governance number types. Clean and precise.
+
+**June**: 4 PRs Merged
+
+Resilience and parsing improvements:
+- Improved error handling for N2NChainSyncFetcher, allowing continuation on parse failure
+- Fixed native script parsing errors and merged relevant CI and Maven-related changes
+
+
+## :classical_building: Yaci Store
+
+`bloxbean/yaci-store`
+
+**April**: v2.0.0-beta1 Released — now with full ledger-state calculation! This is huge :exploding_head::heart_on_fire::_up_parrot_:
+No need for DB Sync — Yaci Store independently derives rewards, ADAPot, and governance state from block data.
+- Viewers now live for Preview, Preprod, and Mainnet
+- Validated up to: epoch 916 (Preview), 212 (Preprod), 545 (Mainnet)
+- 28 PRs merged, including:
+    - New API endpoints (Proposals, DReps, Rewards, AdaPot, Network Info)
+    - Governance fixes (DRep expiry, snapshot handling)
+    - Native image support, rollback improvements, docs upgrades
+
+**May**: One of the most active repositories this month — with 13 PRs merged tackling governance data integrity, rollback logic, and infrastructure improvements
+
+Major upgrades:
+- Introduced Content-Aware Rollbacks to calculate data correct
+- Improved proposal tracking and refund accuracy in governance modules
+- Fixed Byron-era epoch lengths and slot duration mismatches on local devnet
+- Switched to JDK 24 for runtime
+- Closed a key issue improving governance and adapot module inclusion in yaci-store-all
+
+**June**: 20 PRs Merged | 6 Issues Closed
+
+Big month for Yaci Store — including the 2.0.0-beta2 pre-release!
+- Introduced a powerful plugin framework for granular scope indexing with support for MVEL, SpEL, JS, and Python
+- Added Prometheus metrics and initial monitoring dashboard for sync and Adapot status
+- Implemented witness saving enable/disable option and epoch stake pruning
+- Fixed native script parsing for the Preview network and adjusted stake filtering for inactive DReps
+- Closed key issues related to adapot mismatches, Docker runtime configs, datasource cleanup, and governance metadata
+- Positioned for broader extensibility and production-readiness with the 2.0.0-beta2 milestone
+
+
+#### Thanks you to everyone who contributed throughout Q2. Your dedication, expertise, and energy are driving real progress across the ecosystem!
+
+---
+Monthly changelogs can be below:
+- [April](https://github.com/cardano-foundation/ecosystem-updates/blob/main/github_digest_April_2025.md)
+- [May](https://github.com/cardano-foundation/ecosystem-updates/blob/main/github_digest_May_2025.md)
+- [June](https://github.com/cardano-foundation/ecosystem-updates/blob/main/github_digest_June_2025.md)


### PR DESCRIPTION
This PR adds the Q2 2025 Ecosystem Tooling Digest to the Developer Blog section.
The Tooling Digest highlights three months of progress focused on tightening up infrastructure, enhancing developer tools, and shipping valuable updates to support the Cardano ecosystem.


- [X] I have read the [How to Contribute](https://developers.cardano.org/docs/portal-contribute/).
- [X] I have run `yarn build` after adding my changes **without getting any errors**. 
- [X] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://developers.cardano.org/docs/portal-contribute/#i-committed-yarnlock-to-my-pr-branch-what-do-i-do)).
