### PR TITLE
docs: update governance overview to reflect live mainnet status

### DIFF
--- a/docs/governance/cardano-governance/overview.md
+++ b/docs/governance/cardano-governance/overview.md
@@ -4,73 +4,78 @@ slug: /governance/cardano-governance/governance-model
 title: Introduction to Cardano Protocol Governance
 sidebar_label: Overview
 sidebar_position: 1
-description: Cardano is implementing a decentralized governance model that empowers Ada holders, introduces Delegated Representatives (DReps), leverages Stake Pool Operators (SPOs), and establishes a Constitutional Committee to ensure a democratic decision-making process. 
+description: Cardano features a live, fully decentralized governance model that empowers Ada holders, Delegated Representatives (DReps), Stake Pool Operators (SPOs), and a Constitutional Committee to ensure a democratic decision-making process. 
 ---
 
-## Cardano's Future Governance Model and Roles
+# Cardano Protocol Governance
 
-Cardano is advancing towards a decentralized governance model designed to empower community participation and ensure robust decision-making processes. This model is detailed in [CIP-1694](https://github.com/cardano-foundation/CIPs/blob/master/CIP-1694/README.md), which outlines a framework for governance through a tricameral model and a structured decision-making process via seven different types of [governance actions](governance-actions.md). A governance action is a transaction-triggered on-chain event with a time-limited window for execution.
+Cardano operates on a fully decentralized governance model designed to empower community participation and ensure robust, transparent decision-making. Detailed in [CIP-1694](https://github.com/cardano-foundation/CIPs/blob/master/CIP-1694/README.md), this framework utilizes a tricameral (three-body) model to oversee the network. 
 
-### Ada Holders {#ada-holders}
+Any proposed change to the network is submitted as a **governance action**, a transaction-triggered on-chain event with a time-limited window for voting and execution.
 
-Ada holders are at the core of Cardano’s governance, wielding critical voting power and the ability to shape the blockchain's future:
+## The Tricameral Governance Model
 
-- **Delegation of Voting Power**: Ada holders can delegate their voting rights to DReps to aggregate their influence. This delegation process involves creating and issuing a delegation certificate from the Ada holder's stake key to the chosen DRep.
-- **Participation as DReps**: Ada holders can register as DReps, locking a deposit of `dRepDeposit`, allowing them to directly partake in the governance process, propose changes, and represent community interests.
-- **Submitting Governance Actions**: Any Ada holder can propose governance actions on the blockchain network. To initiate such an action, a deposit of `govActionDeposit` lovelace must be provided. This deposit will be returned once the action reaches its conclusion, either through enactment or expiration.
-- **Influence on Network Operations**: By delegating to specific SPOs, Ada holders indirectly influence the operational stability and security of the network and delegate their voting power for SPOs.
+Cardano’s governance relies on three distinct governing bodies working together to balance power, represent the community, and protect the network. 
 
-Their active involvement ensures that governance remains decentralized and aligned with the interests of the broader community. Each associated stake key can issue two types of delegation certificates, one for a delegation to a stake pool and the other for a delegation to a DRep.
+### 1. Ada Holders & Delegated Representatives (DReps)
+Ada holders are the core of Cardano’s governance. Because every Ada holder has voting power, they have the ultimate say in shaping the blockchain's future. 
 
-### Delegated Representatives (DReps) {#dreps}
+* **Delegation:** Ada holders can delegate their voting rights to Delegated Representatives (DReps) to aggregate their influence. This is similar to delegating stake to a stake pool, but it specifically directs voting power.
+* **Becoming a DRep:** Any Ada holder can register to become a DRep. By locking a refundable deposit, they can actively debate proposals, gather community feedback, and vote on behalf of the Ada holders who have delegated to them.
+* **Submitting Actions:** Any Ada holder can propose a governance action on-chain by providing a refundable deposit.
 
-DReps will serve as officials representing Ada holders in the governance system. Every ada holder has the choice to either register themselves as a DRep to represent themselves or others or delegate their voting power to a DRep of their choice. Their primary roles include:
+### 2. Stake Pool Operators (SPOs)
+SPOs are fundamental to the network's operational integrity and security. Alongside producing blocks, they play a crucial role in governance:
+* **Voting on Technical Changes:** SPOs vote on specific governance actions, particularly those that impact the technical operation of the network, such as hard forks.
+* **Implementing Upgrades:** Once a technical change is approved through governance, SPOs are responsible for upgrading their node infrastructure to comply with the new rules.
 
-- **Proposing and debating changes to the Cardano protocol**: DReps propose and debate changes to the Cardano protocol, but they also play a crucial communication role. They gather feedback from the community and represent constituent interests during governance discussions.
-- **Voting on proposals**: DReps vote on proposals based on the priorities and interests of the Ada holders they represent.
-- **Voting power**: DReps' voting power is proportional to the stake delegated to them.
+### 3. The Constitutional Committee (CC)
+The Constitutional Committee oversees the governance process to ensure that all approved actions adhere to the foundational principles defined in the Cardano Constitution. 
+* **Providing Checks and Balances:** The CC does not create proposals; rather, it reviews the constitutionality of submitted governance actions.
+* **Community Elected:** The CC is a community-elected body, ensuring that the oversight of the network remains in the hands of the Cardano ecosystem.
 
-### Stake Pool Operators (SPOs) {#spos}
+---
 
-SPOs are fundamental to the network's operational integrity and will also play a crucial role in governance by:
+## Governance Actions
 
-- **Maintaining network infrastructure**: SPOs ensure the continuous, stable operation of the Cardano network.
-- **Participating in governance discussions**: SPOs contribute to governance discussions, particularly on technical aspects and implementation of protocol changes.
-- **Voting on governance actions**
-- **Implementing approved changes**: SPOs are responsible for upgrading their infrastructure to comply with changes approved through the governance process.
-- **Voting power**: SPOs' voting power is based on their active stake.
+A governance action is how changes are formally proposed and executed on Cardano. To maintain a structured decision-making process, CIP-1694 defines seven specific types of governance actions:
 
-### Constitutional Committee (CC) {#cc}
+1. **Motion of no-confidence**
+2. **Update to the Constitutional Committee and/or threshold**
+3. **Update to the Constitution**
+4. **Hard-Fork Initiation**
+5. **Protocol Parameter Update**
+6. **Treasury Withdrawals**
+7. **Info Action**
 
-The Constitutional Committee will oversee and guide the governance process to adhere to Cardano’s foundational governance principles as defined in the Cardano Constitution. It will:
+*For a detailed explanation of each action type and its specific voting thresholds, please visit the [Governance Actions](governance-actions.md) page.*
 
-- **Interpret the Cardano Constitution**: The CC ensures that governance actions align with the Constitution.
-- **Provide checks and balances**: The CC offers a system of checks and balances by reviewing the constitutionality of governance actions.
-- **Ensure transparency and fairness**: The CC works to maintain a governance process that is transparent, fair, and in line with the overall objectives of the Cardano ecosystem.
-- **Voting power**: Each CC member has one vote.
+---
 
-#### Interim Constitutional Committee
+## The Decision-Making Process
 
-During the [bootstrapping phase](https://github.com/cardano-foundation/CIPs/tree/master/CIP-1694#bootstrapping-phase), which we will enter right after the Chang hard fork, an Interim Constitutional Committee will be established to:
+The life cycle of a governance decision generally follows these steps:
 
-- **Support initial governance structures**: Ensure the smooth functioning of governance systems after the bootstrap phase.
-- **Transition to a fully established CC**: Provide guidelines and frameworks for a fully-fledged Constitutional Committee.
-- **Voting power**: Each member has one vote.
+1. **Off-Chain Discussion:** Long before a vote happens on-chain, proposals undergo rigorous debate in community forums, Intersect working groups, and social channels. Building consensus off-chain is highly recommended before submitting an action.
+2. **On-Chain Submission:** An Ada holder submits the formal governance action to the blockchain, alongside a required Ada deposit.
+3. **Voting:** DReps, SPOs, and the CC vote on the action. The required voting thresholds depend on the specific type of governance action. 
+4. **Enactment:** Actions are checked for ratification at the end of an epoch. If the required thresholds are met, the action is ratified and enacted at the next epoch boundary, and the initial deposit is returned.
 
-The interim Constitutional Committee will have the power to change protocol parameters and, together with SPOs, initiate hard forks.
+---
 
-## Decision Making Process
+## A Brief History of Cardano Governance
 
-The governance process will involve:
+Cardano’s transition to fully decentralized governance was a phased, meticulously planned process:
 
-1. **Off-Chain Discussion**: The majority of discussions and consensus-building about specific governance issues will happen off-chain before any governance action has been submitted to the blockchain. Gathering support for changes will be among the most difficult tasks of proposers. Proposals will undergo thorough discussion in various forums, allowing community members and stakeholders to provide feedback and suggest refinements.
-2. **Governance Action Submission**: Any Ada holder can submit a governance action as long as a sufficient ada deposit is provided.
-3. **Voting**: Decisions on governance actions will be made through a democratic voting process involving DReps, SPOs, and the CC. The required thresholds that have to be met to ratify a governance action are specified in the governance protocol parameters. A detailed overview of the governance parameters can be found [here](https://github.com/thenic95/cardano-governance/blob/main/Reports/Cardano%20Governance%20Parameter/cardano-governance-parameter-overview.md).
-4. **Enactment**: Governance actions are checked for ratification only at the epoch boundary. Once ratified, actions will be enacted at the next epoch boundary. The governance action deposit will be returned once a governance action has been enacted or expired.
+* **SanchoNet (2023):** Launched as a public testnet, SanchoNet allowed the community, developers, and SPOs to safely experiment with the earliest CIP-1694 features.
+* **Chang Hard Fork (2024):** The first phase of the governance rollout, the Chang hard fork laid the technical foundation for decentralized governance and initiated the bootstrapping phase.
+* **Plomin Hard Fork (January 2025):** Originally known as Chang Phase 2 (and renamed in honor of community member Matthew Plomin), this milestone upgrade finalized the transition. It removed the training wheels, fully activating on-chain governance, enabling all action types, and granting Ada holders total control over the protocol's evolution. 
 
-## Cardano's Public Testnet for Governance Features
+---
 
-In July 2023, a public Cardano testnet named SanchoNet was announced to test all the governance features described in CIP-1694. Since then, the teams at IOG have introduced new governance features, enabling the Cardano community to gradually familiarize themselves with the novel system. SanchoNet is accessible to everyone, allowing anyone to join and test the new governance features. Additional documentation about SanchoNet is available at https://sancho.network/
+## Get Involved
+
+Governance is live, and your voice matters. You can participate right now by connecting your wallet to community governance platforms like [Cardano GovTool](https://gov.tools/). From there, you can view active proposals, register as a DRep, or delegate your voting power to a DRep who aligns with your vision for Cardano.
 
 ---
 


### PR DESCRIPTION
- Rewrote the governance model page to use present tense, reflecting that CIP-1694 and decentralized governance are now fully live on mainnet.
- Clarified the tricameral model (Ada Holders/DReps, SPOs, and the elected Constitutional Committee).
- Added a high-level list of the 7 governance action types.
- Moved historical context (SanchoNet, Chang, and Plomin hard forks) into a dedicated "Brief History" section.
- Replaced the outdated SanchoNet call-to-action with links to live mainnet participation tools like GovTool.
- Improved overall readability for general Ada holders.
