### PR TITLE
Fix package name for liburing in Cardano node install guide

### DIFF
--- a/docs/get-started/infrastructure/node/installing-cardano-node.md
+++ b/docs/get-started/infrastructure/node/installing-cardano-node.md
@@ -82,7 +82,7 @@ tools on your system:
   <TabItem value="ubuntu" label="Debian/Ubuntu" default>
     ```bash
     sudo apt-get update -y
-    sudo apt-get install automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libncurses-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libtool autoconf liblmdb-dev libsnappy-dev protobuf-compiler liburing2 -y
+    sudo apt-get install automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libncurses-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libtool autoconf liblmdb-dev libsnappy-dev protobuf-compiler liburing-dev -y
     ```
   </TabItem>
   <TabItem value="fedora" label="Fedora, RedHat or CentOS">


### PR DESCRIPTION
Corrects the package name from `liburing2` to `liburing-dev` in the Debian/Ubuntu installation instructions.

The dev package is needed, without it the cabal build fails with
> Resolving dependencies...
Error: [Cabal-7107]
Could not resolve dependencies:
[__0] trying: cardano-node-10.7.1 (user goal)
[__1] trying: ouroboros-consensus-3.0.1.0 (dependency of cardano-node)
[__2] trying: blockio-0.1.1.1 (dependency of ouroboros-consensus)
[__3] trying: blockio:-serialblockio
[__4] next goal: blockio-uring (dependency of blockio -serialblockio)
[__4] rejecting: blockio-uring; 0.1.0.3, 0.1.0.2 (conflict: pkg-config package liburing>=2.0 && <3, not found in the pkg-config database)
[__4] rejecting: blockio-uring-0.1.0.1 (conflict: pkg-config package liburing>=2.0 && <2.12, not found in the pkg-config database)
[__4] rejecting: blockio-uring-0.1.0.0 (conflict: pkg-config package liburing>=2.0 && <2.10, not found in the pkg-config database)
[__4] fail (backjumping, conflict set: blockio, blockio-uring, blockio:serialblockio)

The `liburing2` doesn't need to be explicitly listed.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/cardano-foundation/developer-portal/blob/staging/CONTRIBUTING.md).
- [ ] I have run `yarn build` after adding my changes **without getting any errors**. 
- [x] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://github.com/cardano-foundation/developer-portal/blob/staging/CONTRIBUTING.md#faq)).