### PR TITLE
feat: generate llms.txt and welcome AI crawlers

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -238,6 +238,33 @@ module.exports = {
       '@docusaurus/plugin-client-redirects',
       { redirects },
     ],
+    [
+      'docusaurus-plugin-llms',
+      {
+        generateLLMsTxt: true,
+        generateLLMsFullTxt: true,
+        generateMarkdownFiles: true,
+        docsDir: 'docs',
+        includeBlog: false,
+        excludeImports: true,
+        removeDuplicateHeadings: true,
+        ignoreFiles: [
+          'portal-archived-changelog.md',
+        ],
+        includeOrder: [
+          'get-started/**',
+          'learn/**',
+          'governance/**',
+          'operate-a-stake-pool/**',
+          'community/**',
+          'contribute/**',
+          'build/**',
+        ],
+        includeUnmatchedLast: true,
+        title: 'Cardano Developer Portal',
+        description: 'Documentation for building on Cardano: getting started, core concepts, governance, stake pool operations, and community contribution.',
+      },
+    ],
   ],
 
   presets: [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build-stats": "node scripts/generate-stats.js",
     "docusaurus": "docusaurus",
     "start": "yarn build-stats && docusaurus start",
-    "build": "yarn build-stats && docusaurus build",
+    "build": "yarn build-stats && docusaurus build && node scripts/fix-llms-paths.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "serve": "docusaurus serve",
@@ -41,6 +41,6 @@
     ]
   },
   "devDependencies": {
-    "docusaurus-plugin-llms": "^0.4.0"
+    "docusaurus-plugin-llms": "0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "docusaurus-plugin-llms": "^0.4.0"
   }
 }

--- a/scripts/fix-llms-paths.js
+++ b/scripts/fix-llms-paths.js
@@ -1,0 +1,99 @@
+// Post-build patch for docusaurus-plugin-llms slug bug.
+//
+// docusaurus-plugin-llms v0.4.0 generates `.md` siblings at paths derived from
+// `slug:` frontmatter, but doesn't account for `routeBasePath: 'docs'`. So for
+// docs with `slug:`, appending `.md` to the rendered URL returns 404 because
+// the file lives at a different path than the page.
+//
+// This script moves the misplaced `.md` files to their URL-aligned location
+// and rewrites the URLs inside `llms.txt` and `llms-full.txt`.
+//
+// Remove this script and its `build` step wiring once upstream is fixed.
+// Tracking issue: https://github.com/cardano-foundation/developer-portal/issues/1791
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const BUILD = path.join(ROOT, 'build');
+
+// Each entry: [pluginOutputPath, urlAlignedPath] relative to build/
+//
+// Two patterns produce misaligned `.md`:
+//   (1) `slug:` frontmatter — page URL differs from source path.
+//   (2) Filename matches parent dir name (e.g. `foo/bar/bar.md`) —
+//       Docusaurus collapses the URL to `/docs/foo/bar/`.
+//
+// Update if you add new docs of either pattern and the plugin is still
+// broken upstream.
+const moves = [
+  // (1) slug: frontmatter
+  ['learn/core-concepts.md',                                          'docs/learn/core-concepts.md'],
+  ['docs/operate-a-stake-pool/operate-a-stake-pool.md',               'docs/operate-a-stake-pool.md'],
+  ['docs/governance/governance.md',                                   'docs/governance.md'],
+  ['governance/cardano-governance/governance-model.md',               'docs/governance/cardano-governance/governance-model.md'],
+  ['governance/cardano-governance/submitting-governance-actions.md',  'docs/governance/cardano-governance/submitting-governance-actions.md'],
+  ['governance/cardano-governance/constitutional-committee-guide.md', 'docs/governance/cardano-governance/constitutional-committee-guide.md'],
+  ['governance/cardano-governance/governance-actions.md',             'docs/governance/cardano-governance/governance-actions.md'],
+  ['smart-contracts/lessons.md',                                      'docs/smart-contracts/lessons.md'],
+  ['docs/get-started/get-started.md',                                 'docs/get-started.md'],
+  // (2) filename matches parent dir name
+  ['docs/governance/cardano-governance/cardano-governance.md',                                  'docs/governance/cardano-governance.md'],
+  ['docs/get-started/infrastructure/cardano-cli/simple-scripts/simple-scripts.md',              'docs/get-started/infrastructure/cardano-cli/simple-scripts.md'],
+  ['docs/get-started/infrastructure/cardano-cli/native-assets/native-assets.md',                'docs/get-started/infrastructure/cardano-cli/native-assets.md'],
+  ['docs/get-started/infrastructure/cardano-cli/plutus-scripts/plutus-scripts.md',              'docs/get-started/infrastructure/cardano-cli/plutus-scripts.md'],
+];
+
+function moveFile(fromAbs, toAbs) {
+  if (!fs.existsSync(fromAbs)) {
+    throw new Error(`Expected plugin output missing: ${path.relative(ROOT, fromAbs)} — plugin behavior may have changed, update scripts/fix-llms-paths.js`);
+  }
+  if (fs.existsSync(toAbs)) {
+    throw new Error(`Destination already exists: ${path.relative(ROOT, toAbs)}`);
+  }
+  fs.mkdirSync(path.dirname(toAbs), { recursive: true });
+  fs.renameSync(fromAbs, toAbs);
+}
+
+function cleanupEmptyDirs(startAbs) {
+  let dir = startAbs;
+  while (dir.startsWith(BUILD) && dir !== BUILD) {
+    if (!fs.existsSync(dir)) { dir = path.dirname(dir); continue; }
+    if (fs.readdirSync(dir).length > 0) break;
+    fs.rmdirSync(dir);
+    dir = path.dirname(dir);
+  }
+}
+
+function rewriteLlmsTxt(replacements) {
+  for (const filename of ['llms.txt', 'llms-full.txt']) {
+    const filePath = path.join(BUILD, filename);
+    if (!fs.existsSync(filePath)) continue;
+    let content = fs.readFileSync(filePath, 'utf8');
+    for (const [oldUrlPath, newUrlPath] of replacements) {
+      // URLs in llms.txt look like https://developers.cardano.org/learn/core-concepts.md
+      // Replace by suffix match so we don't have to hardcode the host.
+      const oldSuffix = '/' + oldUrlPath;
+      const newSuffix = '/' + newUrlPath;
+      // Escape regex metachars in the suffix
+      const escaped = oldSuffix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      content = content.replace(new RegExp(escaped + '(?=[):\\s])', 'g'), newSuffix);
+    }
+    fs.writeFileSync(filePath, content);
+  }
+}
+
+function main() {
+  let moved = 0;
+  for (const [from, to] of moves) {
+    const fromAbs = path.join(BUILD, from);
+    const toAbs = path.join(BUILD, to);
+    moveFile(fromAbs, toAbs);
+    cleanupEmptyDirs(path.dirname(fromAbs));
+    moved++;
+  }
+  rewriteLlmsTxt(moves);
+  console.log(`[fix-llms-paths] Moved ${moved} slug-affected .md files to URL-aligned paths and updated llms.txt`);
+}
+
+main();

--- a/scripts/fix-llms-paths.js
+++ b/scripts/fix-llms-paths.js
@@ -38,10 +38,10 @@ const moves = [
   ['smart-contracts/lessons.md',                                      'docs/smart-contracts/lessons.md'],
   ['docs/get-started/get-started.md',                                 'docs/get-started.md'],
   // (2) filename matches parent dir name
-  ['docs/governance/cardano-governance/cardano-governance.md',                                  'docs/governance/cardano-governance.md'],
-  ['docs/get-started/infrastructure/cardano-cli/simple-scripts/simple-scripts.md',              'docs/get-started/infrastructure/cardano-cli/simple-scripts.md'],
-  ['docs/get-started/infrastructure/cardano-cli/native-assets/native-assets.md',                'docs/get-started/infrastructure/cardano-cli/native-assets.md'],
-  ['docs/get-started/infrastructure/cardano-cli/plutus-scripts/plutus-scripts.md',              'docs/get-started/infrastructure/cardano-cli/plutus-scripts.md'],
+  ['docs/governance/cardano-governance/cardano-governance.md',     'docs/governance/cardano-governance.md'],
+  ['docs/learn/cardano-cli/simple-scripts/simple-scripts.md',      'docs/learn/cardano-cli/simple-scripts.md'],
+  ['docs/learn/cardano-cli/native-assets/native-assets.md',        'docs/learn/cardano-cli/native-assets.md'],
+  ['docs/learn/cardano-cli/plutus-scripts/plutus-scripts.md',      'docs/learn/cardano-cli/plutus-scripts.md'],
 ];
 
 function moveFile(fromAbs, toAbs) {

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,37 @@
+# Default: allow all crawlers
 User-agent: *
+Allow: /
+
+# Explicitly welcome AI/LLM crawlers — this site is open documentation
+# intended to be ingested and cited by AI assistants.
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: CCBot
 Allow: /
 
 Sitemap: https://developers.cardano.org/sitemap.xml

--- a/yarn.lock
+++ b/yarn.lock
@@ -3996,6 +3996,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.0.tgz#4f41a41190216ee36067ec381526fe9539c4f0ae"
+  integrity sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
@@ -5197,6 +5204,15 @@ dns-packet@^5.2.2:
   integrity sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
+
+docusaurus-plugin-llms@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.4.0.tgz#020f00d83459c7feb71c7b6e61774d864336d8ae"
+  integrity sha512-jYlj2HJ5+gu7oJZuJ83Hk8KlB65YlZZ/7UpHXiL7Qr+qpNBkVocmt2Molc6F3HNr5RqcfhWD/98CvgyNztg/ow==
+  dependencies:
+    gray-matter "^4.0.3"
+    minimatch "^9.0.3"
+    yaml "^2.8.1"
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -7761,6 +7777,13 @@ minimatch@3.1.5:
   integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^9.0.3:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
 
 minimist@^1.2.0, minimist@^1.2.3:
   version "1.2.8"
@@ -10817,6 +10840,11 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yaml@^2.8.1:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
 
 yocto-queue@^1.0.0:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5205,7 +5205,7 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
-docusaurus-plugin-llms@^0.4.0:
+docusaurus-plugin-llms@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.4.0.tgz#020f00d83459c7feb71c7b6e61774d864336d8ae"
   integrity sha512-jYlj2HJ5+gu7oJZuJ83Hk8KlB65YlZZ/7UpHXiL7Qr+qpNBkVocmt2Molc6F3HNr5RqcfhWD/98CvgyNztg/ow==


### PR DESCRIPTION
following suggestions in #1738:

- add llms.txt generation via `docusaurus-plugin-llms` (index + full-text + per-page `.md` siblings) following llmstxt.org
- Reading-flow section order; blog and archived changelog excluded from the full bundle
- `robots.txt` explicitly welcomes major AI crawlers (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, …)