### PR TITLE
Introduce copy markdown button - swizzle breadcrumbs

### DIFF
--- a/src/components/CopyMarkdownActions/index.js
+++ b/src/components/CopyMarkdownActions/index.js
@@ -1,0 +1,202 @@
+// "Copy page" dropdown shown in the docs breadcrumb row.
+// The raw .md files are generated at build time by docusaurus-plugin-llms
+// (and relocated by scripts/fix-llms-paths.js); this only consumes them —
+// no markdown is generated client-side.
+import React, {useEffect, useRef, useState} from 'react';
+import {useLocation} from '@docusaurus/router';
+
+const RESET_MS = 2000;
+
+function CopyIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      aria-hidden="true">
+      <rect x="5.75" y="5.75" width="8" height="8" rx="1.5" />
+      <path d="M10.25 5.75V3.5A1.5 1.5 0 0 0 8.75 2H3.5A1.5 1.5 0 0 0 2 3.5v5.25a1.5 1.5 0 0 0 1.5 1.5h2.25" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      aria-hidden="true">
+      <path d="M3 8.5l3.5 3.5L13 5" />
+    </svg>
+  );
+}
+
+function FileIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      aria-hidden="true">
+      <path d="M9 1.75H4.5A1.75 1.75 0 0 0 2.75 3.5v9A1.75 1.75 0 0 0 4.5 14.25h7A1.75 1.75 0 0 0 13.25 12.5V5.5z" />
+      <path d="M9 1.75V5.5h4.25" />
+    </svg>
+  );
+}
+
+function ChevronIcon({open}) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      aria-hidden="true"
+      className={`copy-markdown__chevron${open ? ' copy-markdown__chevron--open' : ''}`}>
+      <path d="M4 6l4 4 4-4" />
+    </svg>
+  );
+}
+
+export default function CopyMarkdownActions() {
+  // useLocation (not useDoc) so this component is safe to render outside a
+  // DocProvider — DocBreadcrumbs is also used by generated category index
+  // pages, which have no DocProvider and would make useDoc() throw.
+  const {pathname} = useLocation();
+  // The .md sibling lives at the current route with the trailing slash
+  // replaced by the extension.
+  const markdownUrl = pathname.replace(/\/$/, '') + '.md';
+
+  const [open, setOpen] = useState(false);
+  const [status, setStatus] = useState('idle'); // 'idle' | 'copied' | 'error'
+  const containerRef = useRef(null);
+  const resetTimer = useRef(null);
+
+  // Clear a pending reset timer on unmount so it can't setState afterwards.
+  useEffect(
+    () => () => {
+      if (resetTimer.current) {
+        clearTimeout(resetTimer.current);
+      }
+    },
+    [],
+  );
+
+  // While open, close on outside click or Escape.
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+    const onMouseDown = (event) => {
+      if (containerRef.current && !containerRef.current.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  const handleCopy = async () => {
+    setOpen(false);
+    if (resetTimer.current) {
+      clearTimeout(resetTimer.current);
+      resetTimer.current = null;
+    }
+    try {
+      const response = await fetch(markdownUrl);
+      if (!response.ok) {
+        throw new Error(`Request failed: ${response.status}`);
+      }
+      await navigator.clipboard.writeText(await response.text());
+      setStatus('copied');
+    } catch {
+      setStatus('error');
+    }
+    resetTimer.current = setTimeout(() => {
+      setStatus('idle');
+      resetTimer.current = null;
+    }, RESET_MS);
+  };
+
+  const triggerLabel =
+    status === 'copied'
+      ? 'Copied!'
+      : status === 'error'
+        ? 'Copy failed'
+        : 'Copy page';
+
+  return (
+    <div className="copy-markdown" ref={containerRef}>
+      <button
+        type="button"
+        className="copy-markdown__trigger"
+        aria-haspopup="true"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}>
+        {status === 'copied' ? <CheckIcon /> : <CopyIcon />}
+        <span>{triggerLabel}</span>
+        <ChevronIcon open={open} />
+      </button>
+
+      {open && (
+        <div className="copy-markdown__menu">
+          <button
+            type="button"
+            className="copy-markdown__item"
+            onClick={handleCopy}>
+            <CopyIcon />
+            <span className="copy-markdown__item-text">
+              <span className="copy-markdown__item-title">Copy page</span>
+              <span className="copy-markdown__item-desc">
+                Copy this page as Markdown for LLMs
+              </span>
+            </span>
+          </button>
+          <a
+            className="copy-markdown__item"
+            href={markdownUrl}
+            target="_blank"
+            rel="noopener"
+            onClick={() => setOpen(false)}>
+            <FileIcon />
+            <span className="copy-markdown__item-text">
+              <span className="copy-markdown__item-title">View as Markdown</span>
+              <span className="copy-markdown__item-desc">
+                Open this page as plain text
+              </span>
+            </span>
+          </a>
+        </div>
+      )}
+
+      <span className="copy-markdown__status" aria-live="polite">
+        {status === 'copied'
+          ? 'Page markdown copied to clipboard.'
+          : status === 'error'
+            ? 'Could not copy page markdown.'
+            : ''}
+      </span>
+    </div>
+  );
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -383,3 +383,125 @@ div#faucetcontainer {
     display: none !important;
   }
 }
+
+/* "Copy page" dropdown in the docs breadcrumb row
+ * (rendered by src/theme/DocBreadcrumbs via src/components/CopyMarkdownActions) */
+.docbreadcrumbs-with-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.8rem;
+}
+
+/* The wrapped breadcrumb nav carries its own bottom margin; move it to the
+ * flex row above so the row spacing matches the unmodified layout. */
+.docbreadcrumbs-with-actions .theme-doc-breadcrumbs {
+  margin-bottom: 0;
+}
+
+.copy-markdown {
+  display: flex;
+  position: relative;
+  margin-left: auto;
+}
+
+.copy-markdown__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--ifm-font-color-base);
+  background-color: var(--site-color-surface);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.copy-markdown__trigger:hover {
+  background-color: var(--site-color-surface-hover);
+  border-color: var(--ifm-color-emphasis-400);
+}
+
+.copy-markdown__chevron {
+  transition: transform 0.15s ease;
+}
+
+.copy-markdown__chevron--open {
+  transform: rotate(180deg);
+}
+
+.copy-markdown__menu {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  min-width: 290px;
+  padding: 0.35rem;
+  background-color: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 0.6rem;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.14);
+}
+
+.copy-markdown__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.55rem 0.6rem;
+  text-align: left;
+  color: var(--ifm-font-color-base);
+  background-color: transparent;
+  border: 0;
+  border-radius: 0.4rem;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.copy-markdown__item:hover {
+  color: var(--ifm-font-color-base);
+  background-color: var(--site-color-surface-hover);
+  text-decoration: none;
+}
+
+.copy-markdown__item > svg {
+  flex: 0 0 auto;
+  margin-top: 0.15rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.copy-markdown__item-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.copy-markdown__item-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.copy-markdown__item-desc {
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+/* Visually-hidden live region announcing copy success/failure to screen readers */
+.copy-markdown__status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/theme/DocBreadcrumbs/index.js
+++ b/src/theme/DocBreadcrumbs/index.js
@@ -1,0 +1,17 @@
+// Wrapper swizzle of @docusaurus/theme-classic DocBreadcrumbs.
+// Renders the breadcrumb trail and the "Copy page" dropdown on one row, so the
+// dropdown uses the breadcrumb row's existing space instead of displacing the H1.
+// DocBreadcrumbs is an "unsafe" swizzle target — re-check on Docusaurus major
+// upgrades. Pure pass-through, so prop changes won't break it.
+import React from 'react';
+import OriginalDocBreadcrumbs from '@theme-original/DocBreadcrumbs';
+import CopyMarkdownActions from '@site/src/components/CopyMarkdownActions';
+
+export default function DocBreadcrumbsWrapper(props) {
+  return (
+    <div className="docbreadcrumbs-with-actions">
+      <OriginalDocBreadcrumbs {...props} />
+      <CopyMarkdownActions />
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

#1787 added `docusaurus-plugin-llms`, so every docs page now has a raw `.md` sibling. This PR surfaces that to readers: a control on docs pages to grab the page as Markdown for an LLM, or open the raw `.md` directly.

## What changes

A **Copy page** dropdown in the breadcrumb row of every docs page:

- **Copy page**: copies the page's Markdown to the clipboard

- **View as Markdown**: opens the raw `.md` in a new tab

It lives in the existing breadcrumb row, so it adds no layout shift.

Implemented as a wrapper swizzle of `DocBreadcrumbs` without any new dependencies or config changes.

| Collapsed | Expanded |
|--------|-------|
| <img width="1150" height="417" alt="Collapsed" src="https://github.com/user-attachments/assets/1af4c048-1d05-40fc-9cb0-1a3578868b05" /> | <img width="1149" height="424" alt="Expanded" src="https://github.com/user-attachments/assets/0a37ec0b-a9d8-4990-9d94-320918f6f65e" /> |

> Relevant to #1758, #1738 Pillar 4 (LLM-native).