### PR TITLE
docs: document preprod Token Metadata Server (preprod.tokens.cardano.org)

### DIFF
--- a/docs/build/native-tokens/token-registry/Where-do-I-register-my-metadata-for-assets-that-exist-on-one-of-the-publicly-available-testnets-e.g.-preview%2C-preprod-environments-only%3F.md
+++ b/docs/build/native-tokens/token-registry/Where-do-I-register-my-metadata-for-assets-that-exist-on-one-of-the-publicly-available-testnets-e.g.-preview%2C-preprod-environments-only%3F.md
@@ -5,5 +5,10 @@ title: Where do I register my metadata for assets that exist on one of the publi
 description: "How to register token metadata for assets on Cardano testnets like preview and preprod."
 ---
 This repository is the metadata registry for **mainnet** assets only. If you intend to register any metadata for on-chain assets that exist on the publicly available testnets only (e.g. preview and preprod environments) please use the [metadata-registry from IOHK](https://github.com/input-output-hk/metadata-registry-testnet).
+
+## Querying testnet metadata
+
+The Cardano Foundation also runs a Token Metadata Server for **preprod** at `https://preprod.tokens.cardano.org`. It serves CIP-68 metadata sourced on-chain from the preprod testnet and CIP-26 metadata sourced from the [IOHK metadata-registry-testnet](https://github.com/input-output-hk/metadata-registry-testnet) repository. See the [Token Registry Server](./cardano-token-registry-server) page for the available endpoints and query parameters.
+
 ## Token Registry Information  
 This page was generated automatically from: [https://github.com/cardano-foundation/cardano-token-registry/wiki](https://github.com/cardano-foundation/cardano-token-registry/wiki/Where-do-I-register-my-metadata-for-assets-that-exist-on-one-of-the-publicly-available-testnets-%28e.g.-preview%2C-preprod-environments%29-only%3F).

--- a/docs/build/native-tokens/token-registry/cardano-token-registry-server.md
+++ b/docs/build/native-tokens/token-registry/cardano-token-registry-server.md
@@ -13,6 +13,22 @@ The Cardano Token Metadata Server provides a robust API for querying metadata as
 
 The API is accessible at `https://tokens.cardano.org` and is subject to the [API Terms of Use](https://github.com/cardano-foundation/cardano-token-registry/blob/master/API_Terms_of_Use.md). The OpenAPI documentation is available at [https://tokens.cardano.org/apidocs](https://tokens.cardano.org/apidocs), providing detailed specifications for endpoints, parameters, and response formats.
 
+## Network Environments
+
+The Cardano Foundation runs the Token Metadata Server for both **mainnet** and the **preprod** testnet, so developers can resolve metadata while building and testing before going live.
+
+| Network | API base URL | OpenAPI docs |
+| --- | --- | --- |
+| Mainnet | `https://tokens.cardano.org` | [`https://tokens.cardano.org/apidocs`](https://tokens.cardano.org/apidocs) |
+| Preprod | `https://preprod.tokens.cardano.org` | [`https://preprod.tokens.cardano.org/apidocs`](https://preprod.tokens.cardano.org/apidocs) |
+
+Both instances expose the same API v2 surface (the endpoints and parameters described below) and combine the two metadata standards in the same way:
+
+- **CIP-68 (on-chain)**: metadata is sourced directly from the chain of the corresponding network. The preprod instance reads CIP-68 reference NFTs minted on the preprod testnet.
+- **CIP-26 (off-chain)**: on mainnet, metadata comes from the [cardano-token-registry](https://github.com/cardano-foundation/cardano-token-registry) repository. On preprod, CIP-26 metadata is sourced from the [IOHK metadata-registry-testnet](https://github.com/input-output-hk/metadata-registry-testnet) repository.
+
+To query preprod metadata, use the same requests shown in this page with the `https://preprod.tokens.cardano.org` base URL.
+
 ## Key Features of API v2
 
 - **Dual Standard Support**: Retrieves metadata for tokens using CIP-26 (off-chain, stored in the Cardano Token Registry) or CIP-68 (on-chain, stored in datums).


### PR DESCRIPTION
## Summary

Documents that the Cardano Foundation also runs a **preprod** instance of the Token Metadata Server at `https://preprod.tokens.cardano.org`, alongside the existing mainnet instance.

The preprod server exposes the same API v2 surface and combines the two metadata standards as follows:
- **CIP-68 (on-chain)** — sourced directly from the preprod chain.
- **CIP-26 (off-chain)** — sourced from the [IOHK metadata-registry-testnet](https://github.com/input-output-hk/metadata-registry-testnet) repository (vs. `cardano-token-registry` on mainnet).

## Changes

- `cardano-token-registry-server.md` — new **Network Environments** section with a mainnet vs. preprod base-URL / OpenAPI-docs table and an explanation of how each network sources CIP-26 and CIP-68 metadata.
- The testnet registration FAQ page — new **Querying testnet metadata** section pointing developers at the preprod server and cross-linking to the server page.

## Notes

- Documentation-only change; no functional code touched.
- Full `yarn build` link-check was not run locally (deps not installed); relative links follow the existing cross-link convention used in this folder.