### PR TITLE
Fix Builder Tools faceted filter logic

### DIFF
--- a/src/components/AppFilterPanel/index.js
+++ b/src/components/AppFilterPanel/index.js
@@ -49,7 +49,7 @@ export default function AppFilterPanel() {
     (cat) => {
       const others = selectedTags.filter((t) => !CategoryList.includes(t));
       const nextTags = activeCategory === cat ? others : [cat, ...others];
-      history.push({ ...location, search: replaceSearchTags(location.search, nextTags) });
+      history.replace({ ...location, search: replaceSearchTags(location.search, nextTags) });
     },
     [selectedTags, activeCategory, location, history]
   );
@@ -60,13 +60,13 @@ export default function AppFilterPanel() {
       const nextTags = has
         ? selectedTags.filter((t) => t !== prop)
         : [...selectedTags, prop];
-      history.push({ ...location, search: replaceSearchTags(location.search, nextTags) });
+      history.replace({ ...location, search: replaceSearchTags(location.search, nextTags) });
     },
     [selectedTags, location, history]
   );
 
   const clearAll = useCallback(() => {
-    history.push({ ...location, search: replaceSearchTags(location.search, []) });
+    history.replace({ ...location, search: replaceSearchTags(location.search, []) });
   }, [location, history]);
 
   const buttonLabel = activeCount ? `Filter (${activeCount})` : "Filter";

--- a/src/components/showcase/IntentChips/index.js
+++ b/src/components/showcase/IntentChips/index.js
@@ -47,7 +47,7 @@ export default function IntentChips() {
         location.search,
         isActive ? [] : intent.tags
       );
-      history.push({ ...location, search });
+      history.replace({ ...location, search });
     },
     [activeId, location, history]
   );

--- a/src/components/showcase/ShowcaseSort/index.js
+++ b/src/components/showcase/ShowcaseSort/index.js
@@ -37,7 +37,7 @@ export default function ShowcaseSort() {
       } else {
         next.set(SortQueryStringKey, e.target.value);
       }
-      history.push({ ...location, search: next.toString() });
+      history.replace({ ...location, search: next.toString() });
     },
     [location, history]
   );

--- a/src/pages/tools/index.js
+++ b/src/pages/tools/index.js
@@ -215,13 +215,15 @@ function SearchBar() {
 
 function SearchControls() {
   return (
-    <section className={clsx("container", styles.controls)}>
-      <SearchBar />
-      <div className={styles.controlsRight}>
-        <AppFilterPanel />
-        <ShowcaseSort />
-      </div>
-    </section>
+    <div className={styles.controlsSticky}>
+      <section className={clsx("container", styles.controls)}>
+        <SearchBar />
+        <div className={styles.controlsRight}>
+          <AppFilterPanel />
+          <ShowcaseSort />
+        </div>
+      </section>
+    </div>
   );
 }
 

--- a/src/pages/tools/index.js
+++ b/src/pages/tools/index.js
@@ -28,8 +28,10 @@ import {
   Showcases,
   RECENT_APPS_COUNT,
   Categories,
+  CategoryList,
+  LanguageList,
+  InterfaceList,
 } from "@site/src/data/builder-tools/showcase";
-import { appHasTag } from "@site/src/utils/toolStats";
 
 import styles from "./styles.module.css";
 
@@ -101,8 +103,20 @@ function filterProjects(projects, selectedTags, searchName) {
     );
   }
   if (selectedTags.length === 0) return result;
-  // OR matching: a tool matches if any selected tag is its category or property.
-  return result.filter((p) => selectedTags.some((tag) => appHasTag(p, tag)));
+
+  // Faceted matching: AND across groups (category / language / interface),
+  // OR within a group. Category=SDK + Language=TypeScript returns SDKs that use TypeScript.
+  const category = selectedTags.find((t) => CategoryList.includes(t));
+  const languages = selectedTags.filter((t) => LanguageList.includes(t));
+  const interfaces = selectedTags.filter((t) => InterfaceList.includes(t));
+
+  return result.filter((p) => {
+    if (category && p.category !== category) return false;
+    const props = p.properties || [];
+    if (languages.length && !languages.some((l) => props.includes(l))) return false;
+    if (interfaces.length && !interfaces.some((i) => props.includes(i))) return false;
+    return true;
+  });
 }
 
 function useFilteredProjects() {

--- a/src/pages/tools/styles.module.css
+++ b/src/pages/tools/styles.module.css
@@ -1,3 +1,5 @@
+/* Sticky so the controls stay visible when applying a filter collapses the
+   page height (the browse -> filtered layout swap clamps scroll toward top). */
 .controlsSticky {
   position: sticky;
   top: var(--ifm-navbar-height);

--- a/src/pages/tools/styles.module.css
+++ b/src/pages/tools/styles.module.css
@@ -1,3 +1,10 @@
+.controlsSticky {
+  position: sticky;
+  top: var(--ifm-navbar-height);
+  z-index: 50;
+  background: var(--ifm-background-color);
+}
+
 .controls {
   display: flex;
   gap: 0.75rem;


### PR DESCRIPTION
The faceted filter shipped in #1802 combined every selected pill with OR, so picking a category plus a language returned everything in that category plus everything in that language instead of the overlap. Selecting SDK and TypeScript showed all SDKs and all TypeScript tools, not SDKs written in TypeScript.

This switches filterProjects to faceted matching: OR within a group (two languages still widen the results), AND across groups (category, language, interface narrow each other). It matches what the filter UI already implies.

### Filter controls UX

Applying a filter swaps the page from the tall "browse" layout to a short "filtered" one; the document collapses and the browser clamps scroll toward the top, which reads as a jump-to-top. (Docusaurus itself does not scroll on query-only URL changes, so this is content reflow, not navigation.)

- Pin the search/filter/sort bar (`position: sticky`) so the controls stay in view through the reflow instead of disappearing.
- Switch the filter / sort / intent controls from `history.push` to `history.replace` so toggling filters no longer floods the browser back button.

>Relevant to #1773