### PR TITLE
Reorganize the contract library by use case

### DIFF
--- a/docs/developers/curriculum/05-smart-contracts/contracts-library.md
+++ b/docs/developers/curriculum/05-smart-contracts/contracts-library.md
@@ -2,21 +2,35 @@
 id: contracts-library
 title: Contract Library
 sidebar_label: Contract library
-description: A catalog of open-source Cardano smart contracts with live demos and end-to-end source, from Hello World to escrow and marketplaces.
+description: Open-source Cardano smart contracts organized by use case, with reference implementations across on-chain and off-chain languages.
+image: /img/og/og-developer-portal.png
 ---
 
-Here's a list of open-source smart contracts, complete with live demos and end-to-end source code.
+Open-source Cardano smart contracts you can read, fork, or build on, organized by what you are building. Pick a use case, then a source that fits your stack.
 
-| Contract | Description | Links |
+Starting a frontend instead? The [templates gallery](https://developers.cardano.org/templates) has runnable dApp starters.
+
+## Reference implementations across languages
+
+[cardano-template-and-ecosystem-monitoring](https://github.com/cardano-foundation/cardano-template-and-ecosystem-monitoring) implements common use cases (escrow, vesting, auction, payment splitter, HTLC, vault, crowdfund, lottery, and more) with both the on-chain validator (Aiken, sometimes Scalus) and off-chain code in several languages (MeshJS, Evolution, PyCardano, CCL). It is the best place to compare how the same contract looks across stacks.
+
+## By use case
+
+| Use case | What it does | Sources |
 | --- | --- | --- |
-| Hello World | A simple lock-and-unlock assets contract, providing a hands-on introduction to end-to-end smart contract validation and transaction building | [[docs](https://meshjs.dev/smart-contracts/hello-world)] [[source](https://github.com/MeshJS/mesh/tree/main/packages/mesh-contract/src/hello-world)] |
-| Content Ownership | Create a content registry and users can create content that is stored in the registry | [[docs](https://meshjs.dev/smart-contracts/content-ownership)] [[source](https://github.com/MeshJS/mesh/tree/main/packages/mesh-contract/src/content-ownership)] |
-| Escrow | Facilitates the secure exchange of assets between two parties by acting as a trusted intermediary that holds the assets until the conditions of the agreement are met | [[docs](https://meshjs.dev/smart-contracts/escrow)] [[source](https://github.com/MeshJS/mesh/tree/main/packages/mesh-contract/src/escrow)] |
-| Giftcard | Allows users to create a transactions to lock assets into the smart contract, which can be redeemed by any user | [[docs](https://meshjs.dev/smart-contracts/giftcard)] [[source](https://github.com/MeshJS/mesh/tree/main/packages/mesh-contract/src/giftcard)] |
-| Marketplace | Allows anyone to buy and sell native assets such as NFTs | [[docs](https://meshjs.dev/smart-contracts/marketplace)] [[source](https://github.com/MeshJS/mesh/tree/main/packages/mesh-contract/src/marketplace)] |
-| NFT Minting Machine | Mint NFTs with an automatically incremented index, which increases by one for each newly minted NFT | [[docs](https://meshjs.dev/smart-contracts/plutus-nft)] [[source](https://github.com/MeshJS/mesh/tree/main/packages/mesh-contract/src/plutus-nft)] |
-| Payment Splitter | Allows users to split incoming payments among a group of accounts | [[docs](https://meshjs.dev/smart-contracts/payment-splitter)] [[source](https://github.com/MeshJS/mesh/tree/main/packages/mesh-contract/src/payment-splitter)] |
-| Swap | Facilitates the exchange of assets between two parties | [[docs](https://meshjs.dev/smart-contracts/swap)] [[source](https://github.com/MeshJS/mesh/tree/main/packages/mesh-contract/src/swap)] |
-| Vesting | Allows users to lock tokens for a period of time and withdraw the funds after the lockup period | [[docs](https://meshjs.dev/smart-contracts/vesting)] [[source](https://github.com/MeshJS/mesh/tree/main/packages/mesh-contract/src/vesting)] |
-| Upgradable Multi-Signature | Multi-signature contract designed for secure and collaborative management of funds on the Cardano blockchain. Allows multiple authorized signers to collectively authorize transactions, ensuring that funds can only be moved with the required approvals | [[on-chain](https://github.com/Anastasia-Labs/aiken-upgradable-multisig)] [[off-chain](https://github.com/Anastasia-Labs/aiken-multisig-offchain)] |
-| Payment Subscription | Designed to facilitate automated recurring payments between subscribers and merchants on the Cardano blockchain. This contract enables users to seamlessly set up, manage, and cancel their subscriptions directly from their wallets. It ensures secure and efficient transactions by automating the payment of subscription fees, updating service metadata, and handling cancellations, all within a decentralized framework | [[on-chain](https://github.com/Anastasia-Labs/payment-subscription)] [[off-chain](https://github.com/Anastasia-Labs/payment-subscription-offchain)] |
+| Hello World | Lock and unlock assets, a hands-on intro to validation and transaction building | [MeshJS](https://meshjs.dev/smart-contracts/hello-world) |
+| Escrow | Holds assets until two parties meet the agreed conditions | [Multi-language](https://github.com/cardano-foundation/cardano-template-and-ecosystem-monitoring/tree/main/escrow), [MeshJS](https://meshjs.dev/smart-contracts/escrow) |
+| Vesting | Locks tokens for a period, then releases them | [Multi-language](https://github.com/cardano-foundation/cardano-template-and-ecosystem-monitoring/tree/main/vesting), [MeshJS](https://meshjs.dev/smart-contracts/vesting) |
+| Payment Splitter | Splits incoming payments among a group of accounts | [Multi-language](https://github.com/cardano-foundation/cardano-template-and-ecosystem-monitoring/tree/main/payment-splitter), [MeshJS](https://meshjs.dev/smart-contracts/payment-splitter) |
+| Swap | Exchanges assets between two parties | [MeshJS](https://meshjs.dev/smart-contracts/swap) |
+| Marketplace | Buy and sell native assets such as NFTs | [MeshJS](https://meshjs.dev/smart-contracts/marketplace) |
+| Giftcard | Locks assets into a card that anyone can redeem | [MeshJS](https://meshjs.dev/smart-contracts/giftcard) |
+| NFT Minting Machine | Mints NFTs with an automatically incremented index | [MeshJS](https://meshjs.dev/smart-contracts/plutus-nft) |
+| Content Ownership | A registry where users create and own content | [MeshJS](https://meshjs.dev/smart-contracts/content-ownership) |
+| Auction | Runs an on-chain auction | [Multi-language](https://github.com/cardano-foundation/cardano-template-and-ecosystem-monitoring/tree/main/auction) |
+| Crowdfund | Pools contributions toward a funding goal | [Multi-language](https://github.com/cardano-foundation/cardano-template-and-ecosystem-monitoring/tree/main/crowdfund) |
+| HTLC | Hashed timelock contract for conditional, time-bound transfers | [Multi-language](https://github.com/cardano-foundation/cardano-template-and-ecosystem-monitoring/tree/main/htlc) |
+| Vault | Holds and controls assets under a spending policy | [Multi-language](https://github.com/cardano-foundation/cardano-template-and-ecosystem-monitoring/tree/main/vault) |
+| Lottery | An on-chain lottery and random draw | [Multi-language](https://github.com/cardano-foundation/cardano-template-and-ecosystem-monitoring/tree/main/lottery) |
+| Upgradable Multi-Signature | Collective fund management requiring multiple approvals | [On-chain](https://github.com/Anastasia-Labs/aiken-upgradable-multisig), [Off-chain](https://github.com/Anastasia-Labs/aiken-multisig-offchain) |
+| Payment Subscription | Automated recurring payments between subscribers and merchants | [On-chain](https://github.com/Anastasia-Labs/payment-subscription), [Off-chain](https://github.com/Anastasia-Labs/payment-subscription-offchain) |


### PR DESCRIPTION
The contract library page is a MeshJS-only table that never surfaced the CF cardano-template-and-ecosystem-monitoring use-cases. This reorganizes it into a use-case index: each pattern (escrow, vesting, swap, payment splitter...) lists the best sources, including the ecosystem-monitoring multi-language reference (Aiken on-chain + MeshJS / Evolution / PyCardano / CCL off-chain), plus use cases that were missing (auction, crowdfund, HTLC, vault, lottery).

It stays a curated index, not another browser; the portal points at the sources rather than hosting contracts, and cross-links the templates gallery (#1816), the "start an app" sibling to this "find a contract" page.

Stacked on #1810. Part of Portal 2026 (#1758).
