### PR TITLE
Frame Cardano Dev Skills as agent-agnostic, not Claude Code only

### DIFF
--- a/docs/developers/curriculum/02-start-building/ai-assisted-development.md
+++ b/docs/developers/curriculum/02-start-building/ai-assisted-development.md
@@ -12,7 +12,7 @@ AI coding assistants are fast, but their training data on Cardano drifts: APIs c
 
 ## Cardano Dev Skills
 
-[Cardano Dev Skills](https://github.com/cardano-foundation/cardano-dev-skills) is the go-to plugin for this today. It bundles authoritative Cardano documentation and behavioral "skills" for AI coding agents, refreshed weekly from upstream project repositories, so your assistant answers from current sources rather than guessing from training data.
+[Cardano Dev Skills](https://github.com/cardano-foundation/cardano-dev-skills) is the go-to option for this today. It works with any AI coding agent that reads Markdown, bundling authoritative Cardano documentation and behavioral "skills" refreshed weekly from upstream project repositories, so your assistant answers from current sources rather than guessing from training data.
 
 It ships:
 
@@ -22,13 +22,15 @@ It ships:
 
 Its scope is the developer toolchain (SDKs, validator libraries, design patterns, language tooling, protocol specs, and reference implementations), not the product docs of specific deployed apps.
 
-### Use it with Claude Code
+### Add it to your agent
+
+The skills are plain Markdown, so any agent that reads Markdown can use them. In Claude Code, add it from the plugin marketplace:
 
 ```bash
 /plugin marketplace add cardano-foundation/cardano-dev-skills
 ```
 
-Then run `/cardano-context` once per project to wire the directive into your `CLAUDE.md`. For other agents, clone the repo and symlink the skills into your project's `.agents/skills` directory. See the [repository](https://github.com/cardano-foundation/cardano-dev-skills) for the full list of skills and setup details.
+Then run `/cardano-context` once per project to wire the directive into your `CLAUDE.md`. For Codex or other agents, clone the repo and symlink the skills into your project's `.agents/skills` directory, or point the agent at the Markdown directly. See the [repository](https://github.com/cardano-foundation/cardano-dev-skills) for the full list of skills and setup details.
 
 ## Going deeper on a specific SDK
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -239,7 +239,7 @@ function DeveloperSection() {
           {/* Quickstart */}
           <div className={styles.devQuickstartCard}>
             <div className={styles.quickstartLeft}>
-              <span className={styles.quickstartBadge}>Claude Code</span>
+              <span className={styles.quickstartBadge}>AI agents</span>
               <span className={styles.quickstartText}>Current Cardano context for your AI assistant</span>
             </div>
             <div className={styles.quickstartRight}>


### PR DESCRIPTION
Cardano Dev Skills works with any AI coding agent that reads Markdown (Claude Code, Codex, or standalone), but the portal presented it as Claude Code only.

- Landing page: the quickstart badge now reads "AI agents" instead of "Claude Code". The command stays the Claude Code one-liner, with the doc link covering other agents.
- Docs (`ai-assisted-development`): the setup section moves from "Use it with Claude Code" to "Add it to your agent", noting the skills are plain Markdown that any agent can use, with clone-and-symlink for Codex and others.
