### PR TITLE
Link curriculum to operator security where key custody matters

### DIFF
--- a/docs/developers/curriculum/fundamentals/core-concepts/wallets-and-keys.md
+++ b/docs/developers/curriculum/fundamentals/core-concepts/wallets-and-keys.md
@@ -168,6 +168,7 @@ Never bundle a mnemonic or private key into frontend code, and never commit one.
 - **Key isolation**: hardware wallets keep keys in a secure element; extensions encrypt with a spending password.
 - **Address hygiene**: let the wallet generate fresh addresses; reuse links your history.
 - **Verify on-device**: confirm transaction details on the hardware wallet screen, not just the app.
+- **Cold-key custody**: for keys that sign high-value or governance transactions, keep them off internet-connected machines. See the operator guides on [air-gapped signing](/docs/operators/security/air-gap) and the [secure transaction workflow](/docs/operators/security/secure-workflow).
 
 ## Key takeaways
 

--- a/docs/developers/curriculum/production/going-to-production.md
+++ b/docs/developers/curriculum/production/going-to-production.md
@@ -21,7 +21,7 @@ Working on a testnet is not the same as being production-ready. Mainnet has real
 
 - **Guard the vulnerability classes**: datum hijacking, double satisfaction, token forgery, resource exhaustion. See [Smart contract security](/docs/developers/curriculum/smart-contracts/security), and sharpen your eye on the [CTF](/docs/developers/curriculum/smart-contracts/advanced/security/ctf).
 - **Get an audit**: for any contract holding meaningful value, a professional audit is standard practice before mainnet. Testing finds the bugs you thought of; audits find the ones you didn't.
-- **Keep keys and secrets safe**: the frontend should only sign; build and submit on a backend ([frontend signs, backend submits](/docs/developers/curriculum/dapps/connect-a-wallet#frontend-signs-backend-builds-and-submits)). Never ship provider API keys in client-side code. Review [key & wallet security](/docs/developers/curriculum/fundamentals/core-concepts/wallets-and-keys#working-with-wallets-in-code).
+- **Keep keys and secrets safe**: the frontend should only sign; build and submit on a backend ([frontend signs, backend submits](/docs/developers/curriculum/dapps/connect-a-wallet#frontend-signs-backend-builds-and-submits)). Never ship provider API keys in client-side code. Review [key & wallet security](/docs/developers/curriculum/fundamentals/core-concepts/wallets-and-keys#working-with-wallets-in-code). For backends that custody keys controlling real value, the operator cold-key playbook applies too: see the [secure transaction workflow](/docs/operators/security/secure-workflow) (build online, sign offline, submit online) and an [air-gapped environment](/docs/operators/security/air-gap).
 
 ## 3. Make transactions reliable
 


### PR DESCRIPTION
A developer following the curriculum from zero to mainnet does not properly get exposed to see the security guidance that matters for handling keys. Cold-key custody and air-gapped signing live under `/docs/operators/security`, and the curriculum needs to point to them more. This came up on #1639, where rphair noted security should be more front-of-mind.

The curriculum is already security-rich on its own (a key-management section in Wallets & Keys, the Smart Contract Security module, security callouts in the dApp tutorials, a key-safety item in Going to Production). The one gap was that none of it reached out to the operator security pages, even though those are exactly what a developer running a key-custody backend needs.

This adds two cross-links at the points where cold-key custody is actually relevant to a developer:

- **Going to Production** key-safety item now points to the secure transaction workflow and air-gapped environment guides, for backends that custody keys controlling real value.
- **Wallets & Keys** fundamentals gains a cold-key-custody bullet linking the same guides, where key custody is first introduced.

No pages moved and no callouts were scattered. The operator pages stay the single source of truth; the curriculum just bridges to them. This keeps air-gap and secure-workflow in the operator audience where they belong while making them reachable from the developer journey, which fits the audience-first rule in Pillar 3.

> Relevant to #1809