### PR TITLE
Fix PR template comments rendering as visible text

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/builder-tool.md
+++ b/.github/PULL_REQUEST_TEMPLATE/builder-tool.md
@@ -6,7 +6,7 @@
 
 ## Checklist
 
- <-- Please fill the boxes with [x] before submitting a pull request --> 
+ <!-- Please fill the boxes with [x] before submitting a pull request --> 
 
 - [ ] I have read the [Contributing Guidelines](https://github.com/cardano-foundation/developer-portal/blob/staging/CONTRIBUTING.md).
 - [ ] I have read the [Builder Tool Requirements](https://github.com/cardano-foundation/developer-portal/edit/staging/src/data/builder-tools/tools.js)
@@ -15,7 +15,7 @@
 
 ## Builder Tool addition
 
-<-- Provide information for every bullet below. Category + properties must match your changes to tools.js (full definitions in src/data/builder-tools/tags.js). -->
+<!-- Provide information for every bullet below. Category + properties must match your changes to tools.js (full definitions in src/data/builder-tools/tags.js). -->
 
 * Title: *The project's own name, styled how the project styles it (don't add descriptors/parentheticals or re-case it)*
 * Description: *One or two factual sentences ending with a period; no superlatives; say what it does and how it differs from similar tools*

--- a/.github/PULL_REQUEST_TEMPLATE/standard-change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/standard-change.md
@@ -6,7 +6,7 @@
 
 ## Checklist
 
- <-- Please fill the boxes with [x] before submitting a pull request --> 
+ <!-- Please fill the boxes with [x] before submitting a pull request --> 
 
 - [ ] I have read the [Contributing Guidelines](https://github.com/cardano-foundation/developer-portal/blob/staging/CONTRIBUTING.md).
 - [ ] I have run `yarn build` after adding my changes **without getting any errors**. 
@@ -14,4 +14,4 @@
 
 ## Updating documentation or Bugfix
 
-<-- Help us understand your motivation by explaining why you decided to make this change. We must be able to understand the purpose of your change from this description.  Does this fix a bug? Does it close an issue? If so please mention it.  -->
+<!-- Help us understand your motivation by explaining why you decided to make this change. We must be able to understand the purpose of your change from this description.  Does this fix a bug? Does it close an issue? If so please mention it.  -->


### PR DESCRIPTION
Both PR templates opened their guidance comments with `<--` instead of `<!--`, so the text showed as visible text in every PR description. Changes the opening `<--` to `<!--` in:

- .github/PULL_REQUEST_TEMPLATE/builder-tool.md (2 spots)
- .github/PULL_REQUEST_TEMPLATE/standard-change.md (2 spots)

The closing `-->` was already correct. Nothing else changed.

Verification: grep confirms no `<--` remains in .github/. The four lines are now valid `<!-- ... -->` comments and stay hidden in rendered PR descriptions.

Related to #1839
