### PR TITLE
Point announcement bar link at /talent/

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -108,7 +108,7 @@ module.exports = {
     announcementBar: isAnnouncementActive ? {
       id: "announcement_index11", // Any value that will identify this message + increment the number every time to be unique
       content:
-        `<strong>Join the Cardano developer talent pool and stay in the loop on upcoming hackathons. <a href="/hackathons/">Sign up here!</a></strong>`,
+        `<strong>Join the Cardano developer talent pool and stay in the loop on upcoming hackathons. <a href="/talent/">Sign up here!</a></strong>`,
       backgroundColor: "#2AA18A",
       textColor: "#FFFFFF", // Use #FFFFFF
       isCloseable: true, // Use true


### PR DESCRIPTION
Points the announcement bar "Sign up here" link directly at `/talent/` instead of `/hackathons/`.

`/hackathons/` is not broken: it serves a client-side redirect stub (`<meta http-equiv="refresh" url=/talent/>` + a JS `window.location`) that sends the browser to `/talent/` (redirects.js: `/hackathons` -> `/talent`, after the page was renamed). So this is a small tidy, not a bug fix: linking straight to `/talent/` points at the canonical Talent Pool page and drops one redirect hop.

`/talent/` is a real page (`src/pages/talent/index.js`, 200 live). The announcement is raw HTML so it is not subject to `onBrokenLinks`; the Build documentation check stays green.

Related to #1839
