### PR TITLE
Docs, templates, and CI Node version accuracy

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Page or section
       description: Which page, path, or section needs an update?
-      placeholder: contributor-beginner/docs/tutorial-basics/directive-kickoff.md
+      placeholder: https://developers.cardano.org/docs/developers/
     validations:
       required: true
 

--- a/.github/PULL_REQUEST_TEMPLATE/builder-tool.md
+++ b/.github/PULL_REQUEST_TEMPLATE/builder-tool.md
@@ -9,7 +9,7 @@
  <-- Please fill the boxes with [x] before submitting a pull request --> 
 
 - [ ] I have read the [Contributing Guidelines](https://github.com/cardano-foundation/developer-portal/blob/staging/CONTRIBUTING.md).
-- [ ] I have read the [Builder Tool Requirements](https://github.com/cardano-foundation/developer-portal/edit/staging/src/data/builder-tools/tools.js)
+- [ ] I have read the [Builder Tool Requirements](https://github.com/cardano-foundation/developer-portal/blob/staging/CONTRIBUTING.md#adding-a-builder-tool)
 - [ ] I have run `yarn build` after adding my changes **without getting any errors**.
 - [ ] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://github.com/cardano-foundation/developer-portal/blob/staging/CONTRIBUTING.md#faq)).
 
@@ -21,7 +21,7 @@
 * Description: *One or two factual sentences ending with a period; no superlatives; say what it does and how it differs from similar tools*
 * Category (pick exactly ONE): `smart-contracts` | `sdk` | `api` | `indexer` | `node` | `node-access` | `wallet` | `dev-env` | `testing` | `operations` | `governance` | `integration`
 * Properties (language + interface):
-  * Language: `typescript` `javascript` `python` `rust` `haskell` `java` `net` `golang` `scala` `c` `purescript` `elm` `php`
+  * Language: `typescript` `javascript` `python` `rust` `haskell` `java` `net` `golang` `scala` `c` `purescript` `elm` `php` `swift`
   * Interface: `rest` `graphql` `grpc` `websocket`
 * Website: <link to the tool's home page>
 * Repository: <link to your public source repo, or `null` for a closed/hosted service>

--- a/.github/actions/yarn-build/Dockerfile
+++ b/.github/actions/yarn-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:22-alpine
 
 RUN apk add --no-cache git
 RUN npm i -g --force yarn

--- a/.github/actions/yarn-build/Dockerfile
+++ b/.github/actions/yarn-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:lts-alpine
 
 RUN apk add --no-cache git
 RUN npm i -g --force yarn

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions generally fall into three categories: fixing content (typos, broke
 
 For small fixes, you can always use the GitHub web editor directly on any file or click the pencil icon at the bottom on portal pages without any setup.
 
-For anything that needs a local build, see the [local development setup](./README.md#contribute) in the README.
+For anything that needs a local build, see the [local development setup](./README.md#local-development-setup) in the README.
 
 ## Adding a builder tool
 
@@ -25,13 +25,13 @@ This is the most common external contribution. You add a tool entry and open a P
 2. Run `yarn build` and confirm it passes with no errors (it validates your entry).
 3. Open a pull request using the "Add Builder Tool" template. Builder tool PRs require 3 approvals.
 
-Don't set `maintainerPick` yourself (maintainers choose those). Categories and properties are defined in `src/data/builder-tools/tags.js`. For the full guide, including what belongs here and how tools are curated, see the [portal contribution guide](https://developers.cardano.org/docs/portal-contribute/).
+Don't set `maintainerPick` yourself (maintainers choose those). Categories and properties are defined in `src/data/builder-tools/tags.js`. For the full guide, including what belongs here and how tools are curated, see the [portal contribution guide](https://developers.cardano.org/docs/contribute/portal-contribute/).
 
 ## Before you open a PR
 
 - Run `yarn build` and make sure it passes. It checks for broken links and validates builder tool entries.
-- Don't commit `yarn.lock`. It's gitignored. If you accidentally commit it, see the FAQ below.
-- Follow the [style guide](https://developers.cardano.org/docs/portal-style-guide/). Write clearly, describe what your project does, skip the marketing language.
+- Don't include `yarn.lock` changes in your PR. We pin it as a baseline; if some slipped in, see the FAQ below.
+- Follow the [style guide](https://developers.cardano.org/docs/contribute/portal-style-guide/). Write clearly, describe what your project does, skip the marketing language.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ yarn build           # also validates builder tools and links
 yarn start           # dev server on localhost:3000
 ```
 
-Requires [Node.js](https://nodejs.org/) 20+ and [Yarn](https://classic.yarnpkg.com/) 1.20+. Built with [Docusaurus](https://docusaurus.io/).
+Requires [Node.js](https://nodejs.org/) 22 (see `.nvmrc`) and [Yarn](https://classic.yarnpkg.com/) 1.20+. Built with [Docusaurus](https://docusaurus.io/).
 
 All pull requests should target the `staging` branch. Changes are merged from `staging` into `main` for production periodically by the maintainers.
 


### PR DESCRIPTION
Tightens docs and templates that were stale or pointed the wrong way. Docs and templates only; no build or CI behavior changes.

## Changes

**CONTRIBUTING.md**
- `yarn.lock` is tracked, not gitignored. Reworded that line to match reality (the FAQ right below it only makes sense because the file is tracked).
- Linked the canonical `/docs/contribute/portal-contribute/` and `/docs/contribute/portal-style-guide/` paths instead of the `/docs/portal-*` redirect aliases (both return 200, no redirect hop).
- Fixed the "local development setup" link to anchor `#local-development-setup` instead of the parent `#contribute` section.

**README.md**
- Requirement now reads Node 22 (matches `.nvmrc` `22.11.0`, which Netlify uses for the deploy), not "20+".

**builder-tool.md (PR template)**
- Added `swift` to the language list (it is in `tags.js` `LanguageProperties` but was missing from the template).
- "Builder Tool Requirements" now links to `CONTRIBUTING.md#adding-a-builder-tool` instead of the `/edit/` web editor of `tools.js`.

**documentation.yml (issue template)**
- Replaced the leftover Docusaurus init placeholder (`contributor-beginner/docs/tutorial-basics/...`) with a real page URL.

Related to #1839

