### PR TITLE
Repo hygiene and metadata cleanup

### DIFF
--- a/.github/actions/yarn-build/README.md
+++ b/.github/actions/yarn-build/README.md
@@ -1,28 +1,27 @@
-# Build Yarn Action
+# Yarn Build action
 
-This github actions provides arbirary actions for the yarn cli command.
-The main reason for writing this was that i needed to add a fix for gits
-safe directory thing, see entrypoint.sh.
+Composite Docker action that runs a single `yarn` command (for example `install` or `build`) in CI.
 
-The code mostly is taken from https://github.com/Borales/actions-yarn
-but simplified. Mostly removed the npm auth token stuff, which we wont need
-in the near future. And then the original action might have a fix for
-the git safedir issue built in so we might want to remove this action
-alltogether.
+It exists to work around git's `safe.directory` ownership check on the Actions runner before
+invoking yarn; see `entrypoint.sh`. Adapted from
+[Borales/actions-yarn](https://github.com/Borales/actions-yarn) and trimmed to what this repo
+needs (the npm auth-token handling was removed).
 
+## Inputs
 
-To use this action
-    name: CI
-    on: [push]
-    jobs:
-        build:
-            name: Test
-            runs-on: ubuntu-latest
-            steps:
-                - uses: actions/checkout@v2
-                - uses: ./.github/actions/yarn-build
-                  with:
-                    cmd: install   # will run `yarn install` command
-                - uses: ./.github/actions/yarn-build
-                  with:
-                    cmd: build # will run `yarn build` command
+| Input | Required | Description |
+| ----- | -------- | ----------- |
+| `cmd` | yes      | The yarn command to run, e.g. `install` or `build`. |
+
+## Usage
+
+```yaml
+steps:
+  - uses: actions/checkout@v7
+  - uses: ./.github/actions/yarn-build
+    with:
+      cmd: install   # runs `yarn install`
+  - uses: ./.github/actions/yarn-build
+    with:
+      cmd: build     # runs `yarn build`
+```

--- a/.github/actions/yarn-build/README.md
+++ b/.github/actions/yarn-build/README.md
@@ -1,19 +1,15 @@
-# Yarn Build action
+# Build Yarn Action
 
-Composite Docker action that runs a single `yarn` command (for example `install` or `build`) in CI.
+This GitHub Action provides arbitrary actions for the yarn CLI command.
+The main reason for writing this was to add a fix for git's safe.directory
+check; see entrypoint.sh.
 
-It exists to work around git's `safe.directory` ownership check on the Actions runner before
-invoking yarn; see `entrypoint.sh`. Adapted from
-[Borales/actions-yarn](https://github.com/Borales/actions-yarn) and trimmed to what this repo
-needs (the npm auth-token handling was removed).
+The code is mostly taken from https://github.com/Borales/actions-yarn but
+simplified. It removes the npm auth-token handling, which we don't need. The
+original action may now have that safe.directory fix built in, so we might
+want to remove this action altogether.
 
-## Inputs
-
-| Input | Required | Description |
-| ----- | -------- | ----------- |
-| `cmd` | yes      | The yarn command to run, e.g. `install` or `build`. |
-
-## Usage
+To use this action:
 
 ```yaml
 steps:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Cardano Foundation
+Copyright (c) 2021-2026 Cardano Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2026 Cardano Foundation
+Copyright (c) 2021 Cardano Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -210,7 +210,7 @@ module.exports = {
               href: "https://www.cardanofoundation.org",
             },
             {
-              label: "Development Updates",
+              label: "Developer Activity",
               href: "https://cardanoupdates.com",
             },
             {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,14 @@
 {
-  "name": "devportal",
+  "name": "cardano-developer-portal",
   "version": "0.0.0",
   "private": true,
+  "description": "Source for developers.cardano.org: documentation, the developer curriculum, and curated builder tools for building on Cardano.",
+  "homepage": "https://developers.cardano.org",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cardano-foundation/developer-portal.git"
+  },
+  "license": "MIT",
   "scripts": {
     "build-stats": "node scripts/generate-stats.js",
     "docusaurus": "docusaurus",

--- a/searchconfig.json
+++ b/searchconfig.json
@@ -42,9 +42,5 @@
       "url_without_anchor",
       "type"
     ]
-  },
-  "conversation_id": [
-    "1417357410"
-  ],
-  "nb_hits": 900
+  }
 }

--- a/src/data/navbar.js
+++ b/src/data/navbar.js
@@ -80,7 +80,7 @@ function getNavbarItems(repository) {
       label: 'Ecosystem',
       position: 'left',
       items: [
-        {to: "blog/", label: "Dev Blog"},
+        {to: "/blog/", label: "Dev Blog"},
         {href: "https://www.addevent.com/calendar/TG807216", label: "Developer Office Hours"},
         {href: "https://cardanoupdates.com/", label: "Developer Activity"},
         {href: "https://cips.cardano.org/", label: "CIPs"},
@@ -118,6 +118,7 @@ function getNavbarItems(repository) {
       href: repository,
       position: "right",
       className: "header-github-link",
+      "aria-label": "GitHub repository",
     },
   ];
 }


### PR DESCRIPTION
Repo hygiene and metadata cleanup. No site content or build behavior changes.

`package.json` still carried the `devportal` scaffold default and no description, homepage, repository, or license. It now identifies the project properly, matching the MIT license already in the repo.

`searchconfig.json` held two DocSearch crawler *output* artifacts pasted in back in 2021, `nb_hits` and `conversation_id`, which the scraper never reads. Removed.

The rest is small consistency work: the footer and navbar called the same link two different names, the Dev Blog entry used a relative path where its mega-menu twin used an absolute one, the GitHub icon link had no accessible name, and the yarn-build action's scratch-note README had typos and an unfenced usage example. That README keeps its original wording, including the standing note that the action may be removable, since its substance was accurate.

Related to #1839