### PR TITLE
Modernize security headers (low-risk subset)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,14 +9,14 @@
   [headers.values]
     # Prevents the site from being framed by other sites, protecting against clickjacking.
     X-Frame-Options = "DENY"
-    # Activates the browser's built-in cross-site scripting (XSS) filter and blocks responses if an attack is detected.
-    X-XSS-Protection = "1; mode=block"
+    # Explicitly disabled: this header is deprecated and non-standard, and can itself introduce XSS vulnerabilities. The Content-Security-Policy below is the actual XSS defense.
+    X-XSS-Protection = "0"
     # Ensures that only trusted content is executed and styled.
-    Content-Security-Policy = "default-src 'self'; script-src 'self' blob: 'unsafe-inline' https://cardano.org https://developers.cardano.org https://www.googletagmanager.com https://js.hsforms.net https://js-eu1.hsforms.net https://forms.hsforms.com https://www.google.com https://www.gstatic.com; img-src 'self' https://cardano.org https://developers.cardano.org https://forms.hsforms.com https://forms-eu1.hsforms.com data: https://*.ytimg.com; style-src 'self' 'unsafe-inline'; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://www.google.com https://*.hsforms.net; media-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self' https://*.algolianet.com https://hubspot-forms-static-embed.s3.amazonaws.com https://*.hsforms.com https://*.google-analytics.com;"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' blob: 'unsafe-inline' https://cardano.org https://developers.cardano.org https://www.googletagmanager.com https://js.hsforms.net https://js-eu1.hsforms.net https://forms.hsforms.com https://www.google.com https://www.gstatic.com; img-src 'self' https://cardano.org https://developers.cardano.org https://forms.hsforms.com https://forms-eu1.hsforms.com data: https://*.ytimg.com; style-src 'self' 'unsafe-inline'; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://www.google.com https://*.hsforms.net; media-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self' https://*.algolia.net https://*.algolianet.com https://hubspot-forms-static-embed.s3.amazonaws.com https://*.hsforms.com https://*.google-analytics.com; frame-ancestors 'none';"
     # Enforces secure connections via HTTPS, protecting against certain types of man-in-the-middle attacks.
     Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
     # Controls information provided as the HTTP Referer header when navigating from your site, enhancing privacy and security.
-    Referrer-Policy = "no-referrer-when-downgrade"
+    Referrer-Policy = "strict-origin-when-cross-origin"
     # Allows you to explicitly enable or disable various browser features and APIs for your site, enhancing security.
     Feature-Policy = "geolocation 'none'; microphone 'none';"
 


### PR DESCRIPTION
Modernizes the response headers in `netlify.toml`. Four changes, each doc-backed or unable to reduce functionality.

The one that matters: search has been half-broken since the CSP was written. The Algolia client hits `*-dsn.algolia.net` first, but `connect-src` only allowed the `*.algolianet.com` fallback hosts, so every query was CSP-blocked on the primary and only succeeded through the retry. Adding the host clears it.

The other three are hygiene. `frame-ancestors 'none'` is the CSP-native equivalent of the `X-Frame-Options: DENY` already set above it. `Referrer-Policy` moves to the current browser default from the pre-2020 one. And `X-XSS-Protection` goes to `0`, which is what MDN recommends now that the header is deprecated and can itself introduce XSS.

The CSP is a strict superset: nothing removed, only the two tokens added.

CSP is a runtime header, so CI cannot catch a regression here. Verified on the staging deploy:

| Before | After |
| --- | --- |
| `Refused to connect to …-dsn.algolia.net` | `ALGOLIA OK, hits: 293`, no CSP error |
| <img width="689" alt="before: CSP blocks dsn.algolia.net" src="https://github.com/user-attachments/assets/7f34188a-1d60-444c-b400-e6a3cdc5d173" /> | <img width="675" alt="after: ALGOLIA OK 293 hits" src="https://github.com/user-attachments/assets/d523045c-41ce-4db2-9fc4-9a4f857187a7" /> |

`Feature-Policy` left untouched, since its successor is still flagged experimental. `object-src` and `base-uri` hardening held for a separate call.

Related to #1839