### PR TITLE
Fix factual errors flagged in a docs review

### DIFF
--- a/docs/developers/curriculum/fundamentals/cardano-components.md
+++ b/docs/developers/curriculum/fundamentals/cardano-components.md
@@ -77,7 +77,7 @@ Cardano has evolved through multiple ledger eras, each introducing new capabilit
 
 | Era | Key addition |
 |-----|-------------|
-| Byron | Initial PoS chain |
+| Byron | Federated launch (Ouroboros BFT) |
 | Shelley | Decentralized block production, staking |
 | Allegra | Token locking |
 | Mary | Native tokens and NFTs |

--- a/docs/developers/curriculum/fundamentals/consensus-and-ouroboros.md
+++ b/docs/developers/curriculum/fundamentals/consensus-and-ouroboros.md
@@ -89,7 +89,7 @@ The stake used for election is a **snapshot from two epochs ago**. This delay st
 
 ### How does chain selection handle forks?
 
-When multiple valid chains exist, nodes follow the **longest chain rule** (with recent chain density as a tiebreaker in Praos). Blocks on abandoned forks are discarded and their transactions return to the mempool, which is why transactions need a few confirmations before they are settled.
+When multiple valid chains exist, nodes follow the **longest chain rule**, and Praos breaks equal-length ties by the block's leader VRF value. (The recent-chain-density rule is a feature of Ouroboros Genesis, which lets newly joining nodes bootstrap safely.) Blocks on abandoned forks are discarded and their transactions return to the mempool, which is why transactions need a few confirmations before they are settled.
 
 ### Block diffusion and the security parameter k
 

--- a/docs/developers/curriculum/fundamentals/core-concepts/fees.md
+++ b/docs/developers/curriculum/fundamentals/core-concepts/fees.md
@@ -62,7 +62,7 @@ Transactions that execute scripts must provide **collateral**: ADA-only UTXOs th
 Rules:
 
 - Must contain **only ADA** (no native tokens).
-- Must cover the potential script cost (typically 150-200% of expected fees).
+- Must be at least 150% of the transaction fee (the `collateralPercentage` protocol parameter, currently 150).
 - **Returned untouched** if the transaction succeeds.
 - **Consumed only** if phase-2 validation fails.
 - **Collateral return (CIP-40):** since Vasil, a transaction can specify a collateral return address so only the required amount is taken, not the entire UTXO.

--- a/docs/developers/curriculum/native-tokens/metadata-registry.md
+++ b/docs/developers/curriculum/native-tokens/metadata-registry.md
@@ -48,7 +48,7 @@ CIP-68 stores metadata in an inline datum on a **reference NFT**, which means it
 | Simplicity matters | A contract must read the metadata on-chain |
 | Standard collectibles or art | Dynamic NFTs, evolving game assets |
 
-## CIP-26: the off-chain registry (fungible tokens)
+## CIP-26: the off-chain metadata registry
 
 CIP-26 is an **off-chain registry** where projects publish human-readable info for a token, name, ticker, **decimals**, and logo, that wallets and explorers read to display it. The metadata lives in a public GitHub repo, [cardano-foundation/cardano-token-registry](https://github.com/cardano-foundation/cardano-token-registry), and is served over a REST API at `https://tokens.cardano.org`.
 

--- a/docs/developers/curriculum/production/api-providers/overview.md
+++ b/docs/developers/curriculum/production/api-providers/overview.md
@@ -47,7 +47,7 @@ To **choose** a provider for your SDK, see [Choosing a provider](/docs/developer
 | Provider | API | Access |
 | --- | --- | --- |
 | **[Blockfrost](/docs/developers/curriculum/production/api-providers/blockfrost)** | REST | Managed, API key (free tier) |
-| **[Koios](/docs/developers/curriculum/production/api-providers/koios)** | REST, GraphQL | Community-run or self-hosted, key optional |
+| **[Koios](/docs/developers/curriculum/production/api-providers/koios)** | REST | Community-run or self-hosted, key optional |
 | **[Ogmios](/docs/developers/curriculum/production/api-providers/ogmios)** | WebSocket, JSON-RPC | Self-hosted against your own node (paired with Kupo as the "Kupmios" stack), or hosted via [Demeter](/docs/developers/curriculum/production/demeter) |
 
 ## Next steps

--- a/docs/developers/curriculum/smart-contracts/advanced/debug-cbor.md
+++ b/docs/developers/curriculum/smart-contracts/advanced/debug-cbor.md
@@ -20,7 +20,7 @@ The first thing to know about the specification, is that transactions are define
 
 As Cardano has passed through different eras, the specification is splitted into several documents, one for each era, describing incrementally the modifications and additions that each era introduced. For each era there is also as part of the specification a text file that precisely defines the CBOR schema used for blocks and transactions. For this, the CDDL (Concise Data Definition Language) format is used, a notational convention defined in [RFC 8610](https://www.rfc-editor.org/rfc/rfc8610) that is used to describe CBOR data structures.
 
-This page covers the Conway era specification, the one that introduced all the smart contract functionality through Plutus.
+This page covers the Conway era specification, the current ledger era. Smart contract support through Plutus was introduced earlier, in the Alonzo era; Conway added Cardano's on-chain governance.
 
 ## A simple smart contract
 
@@ -191,7 +191,7 @@ Transaction outputs (field 1) are a bit more complex than inputs, as they are ne
 transaction_output =  [ address  , amount : value  , ? datum_hash : $hash32 ]
 ```
 
-The components are: the raw value of the address where the UTxO is paid to, the value it will contain and an optional datum hash it can also carry. The datum hash can be used to encode data in the UTxO, and was introduced in Conway to store “state” information for script UTxOs. While not forbidden, datum hashes are rarely used in wallet UTxOs.
+The components are: the raw value of the address where the UTxO is paid to, the value it will contain and an optional datum hash it can also carry. The datum hash can be used to encode data in the UTxO, and was introduced in Alonzo to store “state” information for script UTxOs (Babbage later added inline datums, CIP-32). While not forbidden, datum hashes are rarely used in wallet UTxOs.
 
 In the example we have two outputs:
 
@@ -298,13 +298,13 @@ redeemers =
 
 So, a redeemer is a 4-uple with the following components:
 
-- tag: It specifies the type of redeemer, and has four possible values. Value 0 is used for spending a script UTxO, value 1 for minting/burning with a Plutus minting policy. Don’t worry about values 2 and 3 as they has to do with staking.
+- tag: It specifies the type of redeemer. In the Conway era there are six values: 0 spend (a script UTxO), 1 mint (minting/burning with a Plutus policy), 2 cert (certificates), 3 reward (stake reward withdrawals), 4 vote (governance votes), and 5 propose (governance proposals). This example uses tags 0 and 1.
 
 - index: It is an integer with a different meaning depending on the tag. For the spending tag (value 0), the index refers to the position in the inputs list after ordering it lexicographically according to the TxId and TxIdx. For the minting tag (value 1), the index refers to the position in the lexicographically ordered list of policy IDs present in the minting field.
 
 - data: This is arbitrary data that is passed as a parameter to the script. Most times this data is what is actually called the “redeemer”, instead of the complete 4-uple.
 
-- ex_units: The budget for the script execution in memory and CPU units. These numbers are used to compute the fee and must be higher or equal to the actual units used by the script execution. Execution units are computed according to the cost model, part of the protocol parameters of the Cardano blockchain. There is also a limit of the total memory and CPU units that all redeemers of a transaction can use. Also defined in the protocol parameters, Alonzo started with limits of 10.000 million units for CPU, and 10 million units for memory. However it was soon noticed that the memory limit was too low and was later raised to 16 million units. Execution units and their limits are a big issue in Cardano, as they impose important restrictions to smart contracts and developers must pay special attention to on-chain code optimization.
+- ex_units: The budget for the script execution in memory and CPU units. These numbers are used to compute the fee and must be higher or equal to the actual units used by the script execution. Execution units are computed according to the cost model, part of the protocol parameters of the Cardano blockchain. There is also a limit of the total memory and CPU units that all redeemers of a transaction can use. Also defined in the protocol parameters, Alonzo started with limits of 10,000,000,000 steps for CPU and 10,000,000 units for memory. The per-transaction memory limit has since been raised in stages to the current mainnet value of 16,500,000 (steps remain 10,000,000,000). Execution units and their limits are a big issue in Cardano, as they impose important restrictions to smart contracts and developers must pay special attention to on-chain code optimization.
 
 In our example, we have only one redeemer for spending the script UTxO that is the first input according to the lexicographic order:
 

--- a/docs/developers/curriculum/staking-governance/governance.md
+++ b/docs/developers/curriculum/staking-governance/governance.md
@@ -204,7 +204,7 @@ Only the payment key signs; script validity comes from the redeemer, not a DRep 
 
 ## Delegate your vote
 
-Voting power delegation is **separate from and independent of stake delegation**. You can delegate stake to one pool and your vote to a different DRep, and change either without affecting the other. There are also two built-in options for holders who don't want to pick a DRep: **Abstain** (not counted) and **No Confidence** (counts against the committee). In the Conway era, every holder must choose a governance delegation to remain eligible for staking rewards.
+Voting power delegation is **separate from and independent of stake delegation**. You can delegate stake to one pool and your vote to a different DRep, and change either without affecting the other. There are also two built-in options for holders who don't want to pick a DRep: **Abstain** (not counted) and **No Confidence** (counts against the committee). In the Conway era, staking rewards keep accruing, but you cannot withdraw them until your stake credential has delegated its vote, to a DRep or to a predefined option (Abstain or No Confidence).
 
 Both delegations attach to your **stake credential**, the part of your address separate from the payment credential. See [Addresses](/docs/developers/curriculum/fundamentals/core-concepts/addresses) for how the two combine.
 

--- a/docs/operators/block-producer/block-producer-keys.md
+++ b/docs/operators/block-producer/block-producer-keys.md
@@ -72,7 +72,7 @@ Next, follow [Deployment](/docs/operators/block-producer/deployment) to issue th
 
 ## KES key rotation
 
-KES keys expire after 90 days on mainnet (62 days on preprod). When they expire the node stops minting blocks. Set a calendar reminder well before expiry.
+KES keys expire after about 90 days on both mainnet and preprod, which share the same KES parameters (62 evolutions of 36 hours each). When they expire the node stops minting blocks. Set a calendar reminder well before expiry.
 
 To rotate:
 

--- a/docs/operators/block-producer/register-stake-pool.md
+++ b/docs/operators/block-producer/register-stake-pool.md
@@ -137,7 +137,7 @@ For eg, to specify access to your Cardano node relays, there should be a _cardan
 Also on the **air-gapped machine**, create a delegation certificate that pledges your stake to your pool:
 
 ```bash
-cardano-cli stake-address delegation-certificate \
+cardano-cli latest stake-address stake-delegation-certificate \
     --stake-verification-key-file stake.vkey \
     --cold-verification-key-file cold.vkey \
     --out-file deleg.cert

--- a/docs/operators/governance/spo-governance.md
+++ b/docs/operators/governance/spo-governance.md
@@ -19,11 +19,11 @@ SPOs vote with their **cold verification key** and require **>51% of active stak
 | Hard-fork initiation | 51% | Triggers a protocol upgrade |
 | Info | 100% | Advisory only — no on-chain effect |
 
-SPOs **do not** vote on protocol parameter changes, treasury withdrawals, or constitutional amendments — those require DRep and CC approval.
+SPOs **do not** vote on treasury withdrawals or constitutional amendments; those require DRep and CC approval. They also do not vote on most protocol-parameter changes, with one exception: the security-relevant parameters (block and transaction sizes, `maxBlockExecutionUnits`, fee parameters, `utxoCostPerByte`, `govActionDeposit`, and similar) need an additional SPO vote to change.
 
 Find out more about the different roles at this dedicated [Governance Actions insight page](https://cardano.org/insights/governance-actions/).
 
-Hard-fork initiation is the most common action requiring SPO votes. When the community is ready to upgrade the network, a hard fork proposal is submitted on-chain and SPOs must cast an explicit yes vote with their cold key to signal readiness. Running the upgraded node software is also required, but does not substitute for the on-chain vote.
+Hard-fork initiation is the most common action requiring SPO votes. When the community is ready to upgrade the network, a hard fork proposal is submitted on-chain and SPOs cast an explicit on-chain vote (Yes, No, or Abstain) with their cold key; a Yes signals readiness. Running the upgraded node software is also required, but does not substitute for the on-chain vote.
 
 ## Step 1 — Find active proposals
 
@@ -156,7 +156,7 @@ By default, an SPO who does not vote on a proposal has their stake counted again
 If you do not intend to follow governance closely, you can change this behaviour by delegating your reward account to the `alwaysAbstain` DRep. This removes your stake from both the numerator and denominator of the ratification calculation, turning your non-participation into a genuine abstain rather than an implicit no.
 
 :::warning Hard-fork votes still require an explicit on-chain vote
-Hard-fork initiation requires SPOs to cast an explicit yes vote with their cold key — the `alwaysAbstain` delegation does not cover it. If you delegate to `alwaysAbstain` and do not vote on a hard-fork proposal, your stake counts as a no vote on that action.
+Hard-fork initiation requires SPOs to cast an explicit on-chain vote (Yes, No, or Abstain) with their cold key; the `alwaysAbstain` delegation does not cover it. If you delegate to `alwaysAbstain` and do not vote on a hard-fork proposal, your stake counts as a no vote on that action.
 :::
 
 This delegation must be made with the **reward account stake key** — the key registered as `--pool-reward-account-verification-key-file` in your pool registration certificate. Delegating owner stake keys changes the DRep delegation for the stake associated with your pledge, but has no effect on the pool's governance default behaviour.


### PR DESCRIPTION
A review flagged a set of technical inaccuracies across the docs. Each was verified against primary sources (Conway CDDL, the CIP registry, live protocol parameters, cardano-cli) and corrected:

- **debug-cbor**: Plutus and datum-hash era (Alonzo, not Conway), the six Conway redeemer tags, and the current exec-unit limits (16,500,000 memory).
- **api-providers**: Koios is REST only, not REST plus GraphQL.
- **block-producer-keys**: KES keys last about 90 days on both mainnet and preprod (the old "62 days on preprod" confused maxKESEvolutions with days).
- **register-stake-pool**: `stake-address stake-delegation-certificate` (the `delegation-certificate` name is deprecated), with the `latest` era prefix.
- **cardano-components**: Byron was a federated launch (Ouroboros BFT), not an initial PoS chain.
- **consensus-and-ouroboros**: recent-chain-density selection is Ouroboros Genesis, not Praos.
- **metadata-registry**: CIP-26 is general off-chain metadata, not fungible-token-only.
- **fees**: collateral must be at least 150% of the fee (collateralPercentage), not "150 to 200%".
- **spo-governance**: SPOs do vote on security-relevant protocol parameters, and hard-fork votes are Yes/No/Abstain.
- **governance**: rewards keep accruing under Conway; the gate is on withdrawing them until you delegate your vote.

Related to #1839