### PR TITLE
Quick fixes: landing hero title and hydra-sdk docs link

### DIFF
--- a/src/data/builder-tools/tools.js
+++ b/src/data/builder-tools/tools.js
@@ -927,7 +927,7 @@ export const BuilderTools = [
     icon: "/img/tools/vtechcom.png",
     description: "TypeScript SDK for building wallet apps on Hydra, with Head lifecycle management, transaction building inside a Head, and WASM bindings for browser and Node.",
     website: "https://hydrasdk.com",
-    docs: "https://hydrasdk.com",
+    docs: "https://sdk.hydrawallet.app/getting-started",
     repository: "https://github.com/Vtechcom/hydra-sdk",
     category: "sdk",
     properties: ["typescript"],

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -62,7 +62,7 @@ function Hero() {
       </div>
       <div className="container">
         <div className={styles.heroContent}>
-          <h1 className={styles.heroTitle}>Developer Portal</h1>
+          <h1 className={styles.heroTitle}>Cardano Developer Portal</h1>
           <p className={styles.heroSubtitle}>
             From the first transaction to the production dApp and everything in
             between. Docs, tools, and SDKs for everything Cardano.


### PR DESCRIPTION
Two small fixes:

- Landing hero now reads "Cardano Developer Portal" instead of "Developer Portal".
- hydra-sdk's docs link points to its actual documentation at sdk.hydrawallet.app/getting-started instead of duplicating the website field.

Related to #1839