### PR TITLE
Document Genesis-mode operations: small networks, IPv6, sync tracing

### DIFF
--- a/docs/operators/monitoring/new-tracing-system/quick-start.md
+++ b/docs/operators/monitoring/new-tracing-system/quick-start.md
@@ -283,7 +283,7 @@ Please make sure to enable the `PrometheusSimple` backend **if and only if** you
 
 #### 5. Example: tracing Ouroboros Genesis sync
 
-To debug a Genesis-mode sync (a node stuck in `PreSyncing` or `Syncing`), raise the Genesis component namespaces to `Debug`. They are silent at the default `Notice` severity:
+To debug a Genesis-mode sync (a node stuck in `PreSyncing` or `Syncing`), raise the Genesis component namespaces to `Debug`. The GSM transition events already appear at the default `Notice` severity; the CSJ jump events and per-peer BlockFetch decisions are `Info` or `Debug` and stay hidden until you raise them:
 
 ```yaml
 Consensus.GSM:               { severity: Debug }

--- a/docs/operators/monitoring/new-tracing-system/quick-start.md
+++ b/docs/operators/monitoring/new-tracing-system/quick-start.md
@@ -281,6 +281,35 @@ Please make sure to enable the `PrometheusSimple` backend **if and only if** you
 
 ---
 
+#### 5. Example: tracing Ouroboros Genesis sync
+
+To debug a Genesis-mode sync (a node stuck in `PreSyncing` or `Syncing`), raise the Genesis component namespaces to `Debug`. They are silent at the default `Notice` severity:
+
+```yaml
+Consensus.GSM:               { severity: Debug }
+Consensus.CSJ:               { severity: Debug }
+Consensus.GDD:               { severity: Debug }
+Consensus.DevotedBlockFetch: { severity: Debug }
+BlockFetch.Decision:         { severity: Debug, detail: DMaximum }
+ChainSync.Client:            { severity: Debug }
+Net.PeerSelection:           { severity: Debug }
+Net.ConnectionManager:       { severity: Debug }
+```
+
+Debug-level Genesis tracers are noisy. Rate-limit the high-volume namespaces and silence the low-signal ones:
+
+```yaml
+BlockFetch.Decision.PeersFetch:                          { maxFrequency: 1.0 }
+ChainSync.Client.DownloadedHeader:                       { maxFrequency: 1.0 }
+ChainSync.Client.ValidatedHeader:                        { maxFrequency: 1.0 }
+ChainDB.AddBlockEvent.TrySwitchToAFork:                  { severity: Silence }
+Net.ConnectionManager.Remote.ConnectionManagerCounters:  { severity: Silence }
+```
+
+For what these events mean and how to read a Genesis sync stall against the components that emit them, see the consensus reference [Observing and Debugging Genesis Sync](https://ouroboros-consensus.cardano.intersectmbo.org/docs/references/miscellaneous/genesis_observability).
+
+---
+
 ### Node-side configuration of new tracing: other fields
 
 In addition to providing a `TraceOptions` entry, the new tracing system introduces additional configuration values in the node configuration file:

--- a/docs/operators/node/topology.md
+++ b/docs/operators/node/topology.md
@@ -201,3 +201,43 @@ During sync, the node bulk-downloads and validates blocks from big ledger peers.
 The sync targets must independently satisfy `known >= established >= active >= 0`. Additionally, `SyncTargetNumberOfActivePeers` must not exceed `TargetNumberOfEstablishedPeers` from the deadline set.
 
 Once the node deems itself caught up, it transitions back to the deadline targets.
+
+:::note Small or private networks
+The sync targets above are mainnet-scale.
+On a small or private network (for example a testnet with a handful of relays) they cannot be met, and the node stays in `PreSyncing`: `MinBigLedgerPeersForTrustedState` (default 5) is never reached, so the node never enters the trusted state that releases sync.
+
+Lower `MinBigLedgerPeersForTrustedState` to at most the number of big ledger peers the network has, and lower the big-ledger sync targets to match.
+Lowering `SyncTargetNumberOfActiveBigLedgerPeers` alone is not enough: `MinBigLedgerPeersForTrustedState` is the gate.
+
+```json
+{
+  "MinBigLedgerPeersForTrustedState": 1,
+  "SyncTargetNumberOfActiveBigLedgerPeers": 1,
+  "SyncTargetNumberOfEstablishedBigLedgerPeers": 1,
+  "SyncTargetNumberOfKnownBigLedgerPeers": 1
+}
+```
+
+This weakens the Genesis guarantee, which relies on a larger active big-ledger set, so use it only on networks you control.
+Keep `known >= established >= active >= 0`, and raise the values to match your real peer pool.
+:::
+
+### Binding addresses and IPv6 reachability
+
+`--host-addr` and `--host-ipv6-addr` are command-line options, not `config.json` fields:
+
+```bash
+cardano-node run --host-addr 0.0.0.0 --host-ipv6-addr ::
+```
+
+They set the local addresses the node binds its listening sockets to.
+`--host-ipv6-addr` also selects the DNS lookup family: without it the node resolves only A records, so peers given as domain names never yield IPv6 addresses.
+
+Neither option gates outbound connections to literal IPv6 addresses.
+If a Genesis peer snapshot lists a peer by its IPv6 address, the node dials it whether or not `--host-ipv6-addr` is set.
+On a host with no IPv6 route that dial fails with `Network is unreachable`.
+
+:::tip Diagnostic
+Repeated `Net.ConnectionManager.Remote.ConnectError` against IPv6 addresses, while every `HandshakeSuccess` is IPv4, means the host has no IPv6 route to those peers.
+Give the host an IPv6 route, or remove the IPv6 peers from the snapshot.
+:::


### PR DESCRIPTION
## Summary

Three additions for operators running nodes in Ouroboros Genesis mode.

- `topology.md`: tuning the Genesis sync targets for small or private networks, where the mainnet-scale defaults leave the node stuck in `PreSyncing`.
- `topology.md`: how `--host-addr` and `--host-ipv6-addr` affect binding and IPv6 reachability, with a diagnostic for the common "no IPv6 route" stall.
- Tracing quick start: a `TraceOptions` block for tracing a Genesis sync, with rate limits for the noisy namespaces.

## Context

The portal already documents Genesis configuration in `topology.md`.
These additions cover the small-network case, the host and IPv6 behaviour, and the trace setup, none of which were documented.

Each addition links to the consensus reference "Observing and Debugging Genesis Sync" for the component model behind the trace events.
That page is in review (IntersectMBO/ouroboros-consensus#2103).
The cross-links here go live only once it merges and deploys, so this PR depends on #2103 and should merge after it.

Draft for now: I could not run `yarn build` locally, so I am relying on the PR build check for link validation.
