### PR TITLE
Hide default emoji icons on doc cards

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -81,6 +81,10 @@ html[data-theme="dark"] {
   transform: translateY(-5px);
 }
 
+.theme-doc-card-icon {
+  display: none;
+}
+
 .footer--dark {
   background-color: #232323 !important;
 }


### PR DESCRIPTION
The doc cards rendered by DocCardList on the curriculum overview pages come with Docusaurus' hardcoded emoji icons: a paper sheet for docs, a card box for categories. They add no meaning and on macOS the paper glyph renders as a grey smudge that makes the cards look unfinished.

Docusaurus 3.10 gave the icon slot a stable class name, so this hides it with a single CSS rule in custom.css instead of swizzling DocCard. Cards now show title and description only. Checked the three overview pages that use DocCardList locally.

Related to #1847