### PR TITLE
Fix mobile horizontal page overflow from the AI agents command pill

### DIFF
--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -719,6 +719,7 @@ html[data-theme="dark"] .devLinkCard:hover .devLinkArrow {
   padding: 1rem 1.25rem;
   border-radius: 16px;
   background: linear-gradient(135deg, var(--site-color-brand-blue) 0%, var(--site-color-brand-blue-light) 100%);
+  min-width: 0;
 }
 
 .quickstartLeft {
@@ -748,6 +749,7 @@ html[data-theme="dark"] .devLinkCard:hover .devLinkArrow {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  min-width: 0;
 }
 
 .quickstartDocBtn {
@@ -782,6 +784,7 @@ html[data-theme="dark"] .devLinkCard:hover .devLinkArrow {
   padding: 1rem 1.25rem;
   border-radius: 16px;
   background: linear-gradient(135deg, var(--site-color-brand-blue) 0%, var(--site-color-brand-blue-light) 100%);
+  min-width: 0;
 }
 
 .quickstartBadge2 {
@@ -859,6 +862,7 @@ html[data-theme="dark"] .devLinkCard:hover .devLinkArrow {
   flex: 1;
   white-space: nowrap;
   border: none;
+  min-width: 0;
 }
 
 .cliPrompt {
@@ -872,6 +876,12 @@ html[data-theme="dark"] .devLinkCard:hover .devLinkArrow {
   flex: 1;
   border: none;
   box-shadow: none;
+  /* Long commands scroll inside the pill instead of widening the page on
+     narrow viewports (grid/flex items otherwise refuse to shrink below the
+     nowrap command's width and force horizontal page scroll). The copy
+     button stays pinned outside the scroll area. */
+  min-width: 0;
+  overflow-x: auto;
 }
 
 .copyBtn {


### PR DESCRIPTION
On phones the whole landing page scrolls horizontally: the AI agents quickstart card renders its /plugin marketplace command in a nowrap pill, and since grid and flex items refuse to shrink below their content width, that one pill pushes the document to about 611px on a 390px screen. Every section paints its background only viewport-wide, so the page shows an empty right-hand column. This shipped with the card in #1810 and is live on production today.

The fix lets the layout chain shrink (min-width: 0 on the quickstart cards, the pill row, and the pill) and makes the command itself scrollable inside the pill. The copy button stays pinned and still copies the full command. Measured at a 390px viewport: document width goes from 611px to 390px. On desktop the command now truncates its last word behind the in-pill scroll instead of stretching the grid; the copy button is unaffected.

Related to #1839