### PR TITLE
Hero: svh units for mobile browsers, missing -webkit-backdrop-filter

### DIFF
--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -10,6 +10,10 @@
      width (it only ever trims the navy side-padding, never the arch/circle).
      min-height stays a floor for narrow/mobile viewports. */
   aspect-ratio: 3024 / 1080;
+  /* The clamp keeps WebKit from deriving the width from min-height via the
+     aspect ratio, which widens the hero past the viewport in Safari */
+  width: 100%;
+  max-width: 100%;
   /* svh keeps mobile browsers from over-sizing the hero and resizing it when
      the toolbar collapses on scroll; the vh line is the older-browser fallback */
   min-height: 65vh;

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -10,7 +10,10 @@
      width (it only ever trims the navy side-padding, never the arch/circle).
      min-height stays a floor for narrow/mobile viewports. */
   aspect-ratio: 3024 / 1080;
+  /* svh keeps mobile browsers from over-sizing the hero and resizing it when
+     the toolbar collapses on scroll; the vh line is the older-browser fallback */
   min-height: 65vh;
+  min-height: 65svh;
   display: flex;
   align-items: center;
   overflow: hidden;
@@ -52,6 +55,7 @@
   justify-content: center;
   text-align: center;
   min-height: 45vh;
+  min-height: 45svh;
   max-width: 48rem;
   margin: 0 auto;
 }
@@ -101,10 +105,12 @@
 @media screen and (max-width: 768px) {
   .hero {
     min-height: 55vh;
+    min-height: 55svh;
   }
 
   .heroContent {
     min-height: 40vh;
+    min-height: 40svh;
   }
 }
 
@@ -1115,6 +1121,7 @@ html[data-theme="dark"] .scLearnOverlay {
   text-decoration: none !important;
   transition: all 0.2s ease;
   background: rgba(255, 255, 255, 0.15);
+  -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
   color: #fff;
 }


### PR DESCRIPTION
The landing hero sizes itself with vh units. Mobile Safari and Chrome on iOS measure vh as if the collapsible toolbar weren't there, so the hero renders taller than designed and visibly resizes when the toolbar collapses on scroll. This adds svh values after each vh line, the standard fallback pattern: modern mobile browsers use the stable small-viewport height, older browsers keep the vh behavior, desktop is unchanged.

Safari also renders the whole page horizontally scrollable, at any window size: WebKit resolves the hero's aspect-ratio against the min-height and derives the width from it, so a 900px-tall window gets a 1638px-wide hero that pushes past the viewport. Chrome resolves the same conflict by keeping the width and stretching the height, which is why only Safari shows it. Clamping the hero with width and max-width at 100% makes both engines agree; measured in WebKit, page width goes from 1638px to 1500px at a 1500px window and the min-height floors are unaffected.

Also adds the -webkit-backdrop-filter companion to the Smart Contracts learn links: unprefixed backdrop-filter only works from Safari 18 on, and the build does not add the prefix, so the glass blur does not render on Safari 17 and older.

Worth a quick check on an actual iPhone once this reaches staging, since the toolbar behavior cannot be reproduced in emulators.

Related to #1847