### PR TITLE
Stop leaking mega/customProps config keys to the navbar DOM

### DIFF
--- a/src/theme/NavbarItem/DropdownNavbarItem/index.js
+++ b/src/theme/NavbarItem/DropdownNavbarItem/index.js
@@ -19,12 +19,10 @@ export default function DropdownNavbarItem({mobile = false, ...props}) {
     Array.isArray(props.customProps.columns);
 
   // On mobile or when not marked as mega, fall back to the original behavior.
-  // Strip our custom config keys first: the original component forwards
-  // unknown props all the way to the <a> element, where React warns about
-  // non-DOM attributes like `mega` and `customProps`.
+  // Strip mega-specific props so they don't leak onto DOM elements.
   if (!mega || isMobile) {
-    const {mega: _mega, customProps: _customProps, ...rest} = props;
-    return <OriginalDropdownNavbarItem mobile={mobile} {...rest} />;
+    const {customProps, mega: _mega, ...passthroughProps} = props;
+    return <OriginalDropdownNavbarItem mobile={mobile} {...passthroughProps} />;
   }
 
   const columns = props.customProps.columns;

--- a/src/theme/NavbarItem/DropdownNavbarItem/index.js
+++ b/src/theme/NavbarItem/DropdownNavbarItem/index.js
@@ -18,9 +18,13 @@ export default function DropdownNavbarItem({mobile = false, ...props}) {
     props.customProps &&
     Array.isArray(props.customProps.columns);
 
-  // On mobile or when not marked as mega, fall back to the original behavior
+  // On mobile or when not marked as mega, fall back to the original behavior.
+  // Strip our custom config keys first: the original component forwards
+  // unknown props all the way to the <a> element, where React warns about
+  // non-DOM attributes like `mega` and `customProps`.
   if (!mega || isMobile) {
-    return <OriginalDropdownNavbarItem mobile={mobile} {...props} />;
+    const {mega: _mega, customProps: _customProps, ...rest} = props;
+    return <OriginalDropdownNavbarItem mobile={mobile} {...rest} />;
   }
 
   const columns = props.customProps.columns;


### PR DESCRIPTION
The mega menu swizzle falls back to the original DropdownNavbarItem below the desktop breakpoint and spreads all props into it, including our custom config keys mega and customProps from src/data/navbar.js. The original component forwards unknown props to the anchor element, so React logs two warnings on every page in dev and the invalid attributes reach the rendered HTML.

This strips the two keys before delegating, the same way the cardano-org copy of this component already does, so the two swizzles stay in sync. Verified locally: the warnings reproduce at widths under 996px without the change and are gone with it at 390, 900, and 1400px; mega menus still render all three panels with every column and link, and the mobile drawer is unaffected.

Related to #1839