### PR TITLE
Stop leaking mega/customProps config keys to the navbar DOM

### DIFF
--- a/src/theme/NavbarItem/DropdownNavbarItem/index.js
+++ b/src/theme/NavbarItem/DropdownNavbarItem/index.js
@@ -18,9 +18,11 @@ export default function DropdownNavbarItem({mobile = false, ...props}) {
     props.customProps &&
     Array.isArray(props.customProps.columns);
 
-  // On mobile or when not marked as mega, fall back to the original behavior
+  // On mobile or when not marked as mega, fall back to the original behavior.
+  // Strip mega-specific props so they don't leak onto DOM elements.
   if (!mega || isMobile) {
-    return <OriginalDropdownNavbarItem mobile={mobile} {...props} />;
+    const {customProps, mega: _mega, ...passthroughProps} = props;
+    return <OriginalDropdownNavbarItem mobile={mobile} {...passthroughProps} />;
   }
 
   const columns = props.customProps.columns;


### PR DESCRIPTION
The mega menu swizzle falls back to the original DropdownNavbarItem below the desktop breakpoint and spreads all props into it, including the custom config keys mega and customProps from src/data/navbar.js. The original component forwards unknown props to the anchor element, so React logs two warnings on every page in dev and the invalid attributes reach the rendered HTML.

This strips the two keys before delegating. Verified locally: the warnings reproduce at widths under 996px without the change and are gone with it at 390, 900, and 1400px; mega menus still render all three panels with every column and link, and the mobile drawer is unaffected.

Related to #1839