### PR TITLE
Make the landing code sample internally consistent

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -339,27 +339,31 @@ function DeveloperSection() {
                 <span className={styles.codeKeyword}>await</span>{" "}
                 <span className={styles.codeVariable}>txBuilder</span>
                 <br />
-                {"  "}.
-                <span className={styles.codeFunction}>newTx</span>()
-                <br />
-                {"  "}.
+                {"  "}.
                 <span className={styles.codeFunction}>payToAddress</span>(
                 <span className={styles.codeVariable}>address</span>,{" "}
                 <span className={styles.codeFunction}>lovelace</span>(
                 <span className={styles.codeVariable}>2_000_000n</span>))
                 <br />
-                {"  "}.
+                {"  "}.
                 <span className={styles.codeFunction}>build</span>();
                 <br />
                 <br />
                 <span className={styles.codeComment}>// Sign and submit</span>
                 <br />
                 <span className={styles.codeKeyword}>const</span>{" "}
+                <span className={styles.codeVariable}>signedTx</span> ={" "}
+                <span className={styles.codeKeyword}>await</span>{" "}
+                <span className={styles.codeVariable}>wallet</span>.
+                <span className={styles.codeFunction}>sign</span>(
+                <span className={styles.codeVariable}>tx</span>);
+                <br />
+                <span className={styles.codeKeyword}>const</span>{" "}
                 <span className={styles.codeVariable}>txHash</span> ={" "}
                 <span className={styles.codeKeyword}>await</span>{" "}
                 <span className={styles.codeVariable}>wallet</span>.
-                <span className={styles.codeFunction}>sign</span>().
-                <span className={styles.codeFunction}>submit</span>();
+                <span className={styles.codeFunction}>submit</span>(
+                <span className={styles.codeVariable}>signedTx</span>);
               </code>
             </div>
           </div>


### PR DESCRIPTION
The decorative transaction.ts snippet in Start Building built a transaction and never used it: wallet.sign().submit() signed nothing, and the newTx() line added ceremony without meaning. Developers reading the landing page notice that kind of thing.

The snippet keeps its generic pseudo-SDK vocabulary but now flows honestly through the real lifecycle: build produces tx, sign takes tx, submit takes the signed result. Same rendered height. Also makes the chained-call indentation actually render (the JSX spaces were collapsing in HTML).

Related to #1847