### PR TITLE
Move onBrokenMarkdownLinks to markdown.hooks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -67,7 +67,6 @@ module.exports = {
   baseUrl: "/",
   trailingSlash: true,
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "throw",
   onBrokenAnchors: "warn",
   favicon: "img/favicon.ico",
   organizationName: "cardano-foundation",
@@ -78,6 +77,9 @@ module.exports = {
   },
   markdown: {
     mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: "throw",
+    },
   },
   themes: ['@docusaurus/theme-mermaid'],
   themeConfig: {


### PR DESCRIPTION
Docusaurus deprecated the top-level `onBrokenMarkdownLinks` option and removes it in v4, so every build currently logs a deprecation warning. This moves the setting to its new home under `markdown.hooks`, keeping the same `throw` value.

Verified that the check still guards the build from the new location: a deliberately broken markdown link fails `yarn build` exactly as before.

Related to #1839