### PR TITLE
Add the plugin install step to the AI assistant setup page

### DIFF
--- a/docs/developers/curriculum/start-building/ai-assisted-development.md
+++ b/docs/developers/curriculum/start-building/ai-assisted-development.md
@@ -23,10 +23,11 @@ Its scope is the developer toolchain (SDKs, validator libraries, design patterns
 
 ### Add it to your agent
 
-The skills are plain Markdown, so any agent that reads Markdown can use them. In Claude Code, add it from the plugin marketplace:
+The skills are plain Markdown, so any agent that reads Markdown can use them. In Claude Code, add the marketplace and install the plugin:
 
-```bash
+```
 /plugin marketplace add cardano-foundation/cardano-dev-skills
+/plugin install cardano-dev-skills@cardano-dev-skills
 ```
 
 Then run `/cardano-context` once per project to wire the directive into your `CLAUDE.md`. For Codex or other agents, clone the repo and symlink the skills into your project's `.agents/skills` directory, or point the agent at the Markdown directly. See the [repository](https://github.com/cardano-foundation/cardano-dev-skills) for the full list of skills and setup details.


### PR DESCRIPTION
The Claude Code walkthrough on the AI assistant setup page stopped after `/plugin marketplace add`, which only registers the marketplace and doesn't install the plugin. It then jumped straight to `/cardano-context`, so following the steps left you with nothing installed.

Adds the missing `/plugin install cardano-dev-skills@cardano-dev-skills` step. Also drops the `bash` tag on that block, since these are Claude Code slash commands, not shell.

Related to #1839