### PR TITLE
Add stake credential global state pattern and UPLC page notes

### DIFF
--- a/docs/developers/curriculum/smart-contracts/advanced/design-patterns/stake-validator.md
+++ b/docs/developers/curriculum/smart-contracts/advanced/design-patterns/stake-validator.md
@@ -206,3 +206,17 @@ Library implementation: [stake_validator module](https://github.com/Anastasia-La
 - Processing multiple UTxOs in single transactions
 - Validation logic is expensive (CPU/memory)
 - You need transaction-level validation rather than per-UTxO validation
+
+## Registration state as global state
+
+The withdraw zero trick uses a stake credential for its logic, but the credential carries a second, often overlooked property: its registration status. Whether a credential is currently registered is tracked on the account-based side of the ledger, outside the UTxO set. That makes it one bit of global state that any transaction can set, unset, or test:
+
+- Registering the credential sets the bit. Registration fails if the credential is already registered, so a successful registration also proves the bit was unset.
+- Deregistering the credential unsets the bit, and proves it was set.
+- Registering and then deregistering in the same transaction tests that the bit is unset without leaving it set.
+
+The interesting consequence is proving that an event has *not* happened. The usual proof-of-occurrence technique mints a token when an event occurs; anyone can later prove the event happened by referencing the UTxO holding that token. It cannot prove the opposite, because no validator can force another transaction to include that UTxO as a reference input. If the event instead requires registering a stake credential, absence becomes checkable: a transaction that registers the credential only succeeds while the event has not occurred.
+
+Because this state lives on the account side of the ledger, reading or flipping it spends no UTxO. There is no contention: many transactions can interact with the same credential within one block without competing for an input.
+
+Two caveats. The certificate operations that make this work are exactly the ones covered in [Unconstrained Certificate Operations](../../security/vulnerabilities/certificate-deregistration): an unguarded certificate path lets anyone flip the bit and claim the registration deposit. And while several credentials give several bits, treating them as an integer reintroduces the concurrency problems the technique avoids; the [global state write-up](https://github.com/Anastasia-Labs/design-patterns/blob/main/stake-validator/GLOBAL-STATE.md) in the design patterns repository demonstrates multi-bit counters but labels them a proof of concept.

--- a/docs/developers/curriculum/smart-contracts/advanced/uplc.md
+++ b/docs/developers/curriculum/smart-contracts/advanced/uplc.md
@@ -92,11 +92,11 @@ On-chain, UPLC programs are stored as compact binary data using the "flat" encod
 
 **Size Implications**: UPLC programs can be large, which is why transaction size limits (16KB) become important for complex smart contracts. Recent improvements like reference scripts help mitigate this.
 
-**Execution Costs**: Every UPLC operation has precise memory and CPU costs defined by the protocol's cost model. These costs enable predictable fee calculation and execution budgets.
+**Execution Costs**: Every UPLC operation has precise memory and CPU costs defined by the protocol's cost model. These costs enable predictable fee calculation and execution budgets. The charged costs are deliberately conservative: each built-in is costed for its worst case, and much of the charge covers the interpreter machinery around the operation rather than the operation itself. Even so, a built-in call is far cheaper than expressing the same logic as plain UPLC terms, which is why compilers push as much work as possible into built-ins.
 
 ### Why This Matters for Developers
 
-- When smart contracts fail, understanding UPLC helps interpret low-level error messages and execution traces for debugging.
+- When smart contracts fail, understanding UPLC helps interpret low-level error messages and execution traces for debugging. Stepping debuggers such as [Gastronomy](https://github.com/SundaeSwap-finance/gastronomy) replay a script's execution state by state, forward and backward.
 
 - Knowing how high-level constructs compile to UPLC helps write more efficient smart contracts.
 


### PR DESCRIPTION
The curriculum covers stake credentials from scripts only as the withdraw-zero coordinator and as an attack surface. That the registration status itself is readable global state, and the only mechanism that can prove an event has not occurred, was missing. The UPLC page also said nothing about why built-in costs look the way they do or where to find a debugger.

- Design patterns: new section on the stake validator page explaining registration state as a one-bit global signal, why it can prove non-occurrence where token proofs cannot, its no-contention property, and its limits. Links the certificate operations vulnerability page and the Anastasia Labs global state write-up.
- UPLC: notes that built-in costs are worst-case and mostly interpreter overhead, and that built-ins are far cheaper than equivalent raw UPLC terms. Adds a pointer to the Gastronomy stepping debugger next to the debugging bullet.

Related to #1839