### PR TITLE
chore: point Algolia search to new application

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -126,8 +126,8 @@ module.exports = {
 
     // Algolia Search
     algolia: {
-      appId: "6QH8YVQXAE",
-      apiKey: "6033c09f3af6454c8c25efce0460b84a",
+      appId: "SM73IGPCDU",
+      apiKey: "7e5c27bffb971566ac4aa7d23cb8faaf",
       indexName: "developer-portal",
       contextualSearch: true,
     },


### PR DESCRIPTION
- Switch the site search to the new Algolia application (new app ID and public search key), keeping the same index name