### PR TITLE
Add an overview page at /docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,32 @@
+---
+id: index
+title: Documentation
+description: Find your way around the Cardano Developer Portal. The developer curriculum, the stake pool operator handbook, community resources, and contribution guides.
+---
+
+The Cardano Developer Portal documentation is organized by what you want to do. Pick your path below.
+
+## Build on Cardano
+
+**[Start here](/docs/developers/)** if you want to build applications on Cardano. The docs are a curriculum of seven modules that build on each other, from blockchain fundamentals through transactions, tokens, staking and governance, and smart contracts to production dApps. There is also a standalone [Exchange integrations](/docs/developers/exchange-integrations) guide for custodial platforms.
+
+## Operate a stake pool
+
+**[The operator handbook](/docs/operators/)** covers the full lifecycle of running a Cardano stake pool: hardware and key management basics, installing and running the node, registering your pool, monitoring, security hardening, and your role in on-chain governance.
+
+## Community
+
+- [Developer community](/docs/community/cardano-developer-community) lists the forums, chats, and weekly office hours where Cardano developers gather.
+- [Funding and grants](/docs/community/funding) maps the ways to fund your project, from community grants to the on-chain treasury.
+
+## Contribute
+
+The portal is open source and evolved by the community. [How to contribute](/docs/contribute/portal-contribute) explains the workflow, and the [style guide](/docs/contribute/portal-style-guide) covers writing conventions.
+
+## More on the portal
+
+Beyond the documentation:
+
+- [Builder Tools](/tools) is a curated directory of the tools, SDKs, and APIs the ecosystem builds with.
+- [Templates](/templates) offers starter templates to clone and build on.
+- [Developer Blog](/blog) carries announcements, technical deep dives, and community spotlights.

--- a/src/components/CopyMarkdownActions/index.js
+++ b/src/components/CopyMarkdownActions/index.js
@@ -76,8 +76,10 @@ export default function CopyMarkdownActions() {
   // pages, which have no DocProvider and would make useDoc() throw.
   const {pathname} = useLocation();
   // The .md sibling lives at the current route with the trailing slash
-  // replaced by the extension.
-  const markdownUrl = pathname.replace(/\/$/, '') + '.md';
+  // replaced by the extension. The docs root is the exception: its sibling
+  // is emitted at /docs/index.md, and /docs.md does not exist.
+  const base = pathname.replace(/\/$/, '');
+  const markdownUrl = base === '/docs' ? '/docs/index.md' : base + '.md';
 
   const [open, setOpen] = useState(false);
   const [status, setStatus] = useState('idle'); // 'idle' | 'copied' | 'error'


### PR DESCRIPTION
https://developers.cardano.org/docs/ was a 404 while every child path under it resolved. That breaks the expectation that URL prefixes resolve and leaves crawlers without an entry point into the docs.

This adds an overview page at /docs that maps the documentation: the developer curriculum, the operator handbook, community and contribution pages, plus pointers to tools, templates and the blog. The page uses the Docusaurus root index convention (docs/index.md, no slug), so sidebars and build scripts stay untouched. The Copy page dropdown gets a special case because the markdown twin of the root page is emitted at /docs/index.md rather than /docs.md.

Related to #1839