### PR TITLE
Fix unstyled rendering in the mesh-nextjs template

### DIFF
--- a/examples/templates/mesh-nextjs/src/pages/_app.tsx
+++ b/examples/templates/mesh-nextjs/src/pages/_app.tsx
@@ -1,5 +1,4 @@
 import "@/styles/globals.css";
-import "@meshsdk/react/styles.css";
 import type { AppProps } from "next/app";
 import { MeshProvider } from "@meshsdk/react";
 

--- a/examples/templates/mesh-nextjs/src/pages/index.tsx
+++ b/examples/templates/mesh-nextjs/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import Head from "next/head";
 import type { NextPage } from "next";
 import { CardanoWallet, useWallet, useLovelace } from "@meshsdk/react";
 import { BlockfrostProvider, MeshTxBuilder } from "@meshsdk/core";
@@ -49,6 +50,9 @@ const Home: NextPage = () => {
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-12">
+      <Head>
+        <title>My Cardano dApp</title>
+      </Head>
       <h1 className="text-3xl font-bold">My Cardano dApp</h1>
 
       <CardanoWallet />

--- a/examples/templates/mesh-nextjs/src/styles/globals.css
+++ b/examples/templates/mesh-nextjs/src/styles/globals.css
@@ -1,3 +1,5 @@
+/* Mesh ships unlayered CSS; import it into a layer so our Tailwind utilities keep cascade priority. */
+@import "@meshsdk/react/styles.css" layer(mesh);
 @import "tailwindcss";
 
 :root {


### PR DESCRIPTION
The mesh-nextjs template builds and runs but renders without its typography styles: the heading shows up as plain 16px text even though the Tailwind classes are compiled into the bundle. Mesh's styles.css ships as unlayered compiled CSS while the template's own utilities sit in layer utilities, and unlayered rules win the cascade before specificity is considered. 

Importing the Mesh stylesheet from globals.css into a named layer puts it behind the template's utilities in the cascade. The wallet button and modal keep their styling. Also adds the missing page title.

Related to #1839