### PR TITLE
Fix template env setup instructions and prerequisites

### DIFF
--- a/docs/developers/curriculum/dapps/your-first-dapp.md
+++ b/docs/developers/curriculum/dapps/your-first-dapp.md
@@ -55,8 +55,8 @@ npm run dev            # http://localhost:5173
 npx giget@latest gh:cardano-foundation/developer-portal/examples/templates/mesh-nextjs my-app
 cd my-app
 npm install
-cp .env.example .env.local   # set NEXT_PUBLIC_BLOCKFROST_API_KEY
-npm run dev                  # http://localhost:3000
+cp .env.example .env   # set NEXT_PUBLIC_BLOCKFROST_API_KEY
+npm run dev            # http://localhost:3000
 ```
 
 [Browse the template on GitHub](https://github.com/cardano-foundation/developer-portal/tree/staging/examples/templates/mesh-nextjs). It is Next.js. Mesh ships React components and hooks, so the connect button and wallet state come built in.

--- a/examples/templates/evolution-vite-react/README.md
+++ b/examples/templates/evolution-vite-react/README.md
@@ -19,7 +19,7 @@ npx giget@latest gh:cardano-foundation/developer-portal/examples/templates/evolu
 
 ## Prerequisites
 
-- Node.js 18+ and npm.
+- Node.js 20.19+ and npm.
 - A Cardano wallet browser extension (Eternl, Lace, Nami, and so on).
 - A free Blockfrost project ID from [blockfrost.io](https://blockfrost.io), matching your network.
 
@@ -35,7 +35,7 @@ npm install
 npm run dev
 ```
 
-The app runs at `http://localhost:5173`. Connect a wallet, then send test ADA.
+The app runs at `http://localhost:5173`. Connect a wallet, then send some [test ADA](https://developers.cardano.org/docs/developers/curriculum/start-building/networks-and-test-ada#get-test-ada).
 
 ## The Evolution SDK pieces
 

--- a/examples/templates/evolution-vite-react/src/components/WalletConnect.tsx
+++ b/examples/templates/evolution-vite-react/src/components/WalletConnect.tsx
@@ -5,7 +5,7 @@ import { useState } from "react"
 export default function WalletConnect() {
   const [isModalOpen, setIsModalOpen] = useState(false)
 
-  const network = import.meta.env.MODE === "development" ? NetworkType.TESTNET : NetworkType.MAINNET
+  const network = import.meta.env.VITE_NETWORK === "mainnet" ? NetworkType.MAINNET : NetworkType.TESTNET
 
   const { accountBalance, connect, disconnect, installedExtensions, isConnected, stakeAddress } = useCardano({
     limitNetwork: network

--- a/examples/templates/mesh-nextjs/.env.example
+++ b/examples/templates/mesh-nextjs/.env.example
@@ -1,0 +1,4 @@
+# Blockfrost API Configuration
+# Get your free API key from https://blockfrost.io
+# Use a preprod project ID for testnet, a mainnet project ID for mainnet
+NEXT_PUBLIC_BLOCKFROST_API_KEY=your_blockfrost_project_id_here

--- a/examples/templates/mesh-nextjs/.gitignore
+++ b/examples/templates/mesh-nextjs/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/examples/templates/mesh-nextjs/README.md
+++ b/examples/templates/mesh-nextjs/README.md
@@ -18,7 +18,7 @@ npx giget@latest gh:cardano-foundation/developer-portal/examples/templates/mesh-
 
 ## Prerequisites
 
-- Node.js 18+ and npm.
+- Node.js 20.19+ and npm.
 - A Cardano wallet browser extension (Eternl, Lace, and so on).
 - A free Blockfrost project ID from [blockfrost.io](https://blockfrost.io), matching your network.
 
@@ -26,15 +26,15 @@ npx giget@latest gh:cardano-foundation/developer-portal/examples/templates/mesh-
 
 ```bash
 # 1. Set your Blockfrost key (used to build transactions)
-cp .env.example .env.local
-# edit .env.local: set NEXT_PUBLIC_BLOCKFROST_API_KEY (use a preprod key for testnet)
+cp .env.example .env
+# edit .env: set NEXT_PUBLIC_BLOCKFROST_API_KEY (use a preprod key for testnet)
 
 # 2. Install and run
 npm install
 npm run dev
 ```
 
-The app runs at `http://localhost:3000`. Connect a wallet, then send test ADA.
+The app runs at `http://localhost:3000`. Connect a wallet, then send some [test ADA](https://developers.cardano.org/docs/developers/curriculum/start-building/networks-and-test-ada#get-test-ada).
 
 ## The Mesh pieces
 

--- a/src/components/TemplateDetail/index.js
+++ b/src/components/TemplateDetail/index.js
@@ -135,6 +135,15 @@ export default function TemplateDetail({ slug }) {
             </p>
 
             <h2 className={styles.sectionHeading}>Get started</h2>
+            <p className={styles.guideNote}>
+              You need Node.js 20.19+, a Cardano wallet browser extension, and a
+              free <Link href="https://blockfrost.io">Blockfrost</Link> project
+              ID. Get test ADA from the{" "}
+              <Link to="/docs/developers/curriculum/start-building/networks-and-test-ada#get-test-ada">
+                faucet
+              </Link>
+              .
+            </p>
             <ol className={styles.steps}>
               <li>
                 Scaffold the project into a new <code>my-app</code> folder:


### PR DESCRIPTION
Setting up either template from a clean scaffold currently breaks: the mesh instructions tell you to copy a `.env.example` that doesn't exist in the template, and the evolution wallet connector picks its network from the build mode instead of the documented `VITE_NETWORK`.

This adds the env file, aligns all instructions on `cp .env.example .env`, makes the wallet connector follow `VITE_NETWORK`, sets Node 20.19+ as the requirement (Vite 8's floor), and adds a prerequisites line plus a faucet link to the template pages.

Verified from scratch on both templates: scaffold, install, env step, dev server, styled render. Docs site builds green.

Related to #1839