### PR TITLE
Add arrivals, module handovers, and sub-tree exits across the curriculum

### DIFF
--- a/docs/developers/curriculum/dapps/ai-agents/mcp.md
+++ b/docs/developers/curriculum/dapps/ai-agents/mcp.md
@@ -45,4 +45,4 @@ The Cardano MCP ecosystem is early and moving quickly, with wallets and protocol
 
 - [Connect a wallet](/docs/developers/curriculum/dapps/connect-a-wallet): the CIP-30 signing boundary an MCP server relies on
 - [Set up your AI assistant](/docs/developers/curriculum/start-building/ai-assisted-development): give your coding assistant current Cardano context
-- [AI agents on Cardano](/docs/developers/curriculum/dapps/ai-agents/overview): autonomous agents that hold their own wallet
+- [IoT on Cardano](/docs/developers/curriculum/dapps/iot/): the module's hands-on hardware track, and the road to [Ship to Production](/docs/developers/curriculum/production/overview)

--- a/docs/developers/curriculum/dapps/iot/troubleshooting.md
+++ b/docs/developers/curriculum/dapps/iot/troubleshooting.md
@@ -57,6 +57,10 @@ Two likely causes:
 - **Baud rate mismatch.** The serial monitor's baud rate (bottom-right of the IDE's Serial Monitor) must match `Serial.begin(...)` in your sketch. The workshops all use **115200**.
 - **Bad USB cable.** Same as above - try a different one.
 
+## Next steps
+
+- [Ship to Production](/docs/developers/curriculum/production/overview): the curriculum's final module. Choose your chain access, harden the app, and scale.
+
 ---
 
 *Adapted from the [CardanoThings](https://cardanothings.io/troubleshooting) project, originally produced under [Project Catalyst Fund 11](https://projectcatalyst.io/funds/11). Source: [github.com/CardanoThings](https://github.com/CardanoThings).*

--- a/docs/developers/curriculum/dapps/oracles/overview.md
+++ b/docs/developers/curriculum/dapps/oracles/overview.md
@@ -227,3 +227,8 @@ The factors that actually differentiate oracles are concrete, and the sections a
 For most Cardano applications, **[Pyth](/docs/developers/curriculum/dapps/oracles/pyth)** is the recommended oracle: sub-second, high-frequency price feeds through a pull-based model, with on-chain verification handled by an Aiken library, so your contract reads verified updates directly from the transaction it validates.
 
 Contracts can also read **multiple** oracle feeds and reconcile them on-chain, as shown above, so a single feed failing or being manipulated does not compromise the result. See the [Pyth integration guide](/docs/developers/curriculum/dapps/oracles/pyth) to wire it into your validator and off-chain code.
+
+## Next steps
+
+- [Pyth](/docs/developers/curriculum/dapps/oracles/pyth): wire the recommended oracle into your validator and off-chain code
+- [Randomness](/docs/developers/curriculum/dapps/oracles/randomness): verifiable random values, the other hard data problem

--- a/docs/developers/curriculum/dapps/oracles/randomness.md
+++ b/docs/developers/curriculum/dapps/oracles/randomness.md
@@ -91,7 +91,7 @@ The honest bottom line: match the pattern to your threat model, and state the tr
 
 ## Next steps
 
-- [Oracles on Cardano](/docs/developers/curriculum/dapps/oracles/overview): the publication and trust machinery an oracle-delivered random value rides on
+- [AI agents on Cardano](/docs/developers/curriculum/dapps/ai-agents/overview): the next track, agents that hold wallets and act on-chain
 - [BLS signatures, VRFs & credentials](/docs/developers/curriculum/smart-contracts/advanced/bls-primitives#verifiable-random-functions): the mechanics of an ECVRF a validator can verify
 - [Verifiable Random Functions](/docs/developers/curriculum/fundamentals/cryptographic-primitives#what-are-verifiable-random-functions-vrfs): what a VRF is and why its output is verifiable
 - [Time handling](/docs/developers/curriculum/smart-contracts/advanced/security/vulnerabilities/time-handling): why a timestamp is not a source of randomness

--- a/docs/developers/curriculum/dapps/overview.md
+++ b/docs/developers/curriculum/dapps/overview.md
@@ -7,7 +7,7 @@ description: Connect Cardano to your application (wallets, payments, oracles, an
 
 ![Integrate Cardano](./img/card-integrate-cardano-title.svg)
 
-This module is about meeting users where they are: connecting Cardano to web apps, services, and protocols. Whether you're adding a "connect wallet" button, accepting ADA payments, feeding real-world prices into a contract, or building a full DeFi protocol, the building blocks live here.
+You arrive from [Smart Contracts](/docs/developers/curriculum/smart-contracts/overview) able to write and test validators. This module is about meeting users where they are: connecting Cardano to web apps, services, and protocols. Whether you're adding a "connect wallet" button, accepting ADA payments, feeding real-world prices into a contract, or building a full DeFi protocol, the building blocks live here.
 
 ## Build a dApp
 

--- a/docs/developers/curriculum/fundamentals/cardano-for-ethereum-developers.md
+++ b/docs/developers/curriculum/fundamentals/cardano-for-ethereum-developers.md
@@ -722,9 +722,7 @@ A few Solidity habits carry over, but the ones that matter are not one-to-one:
 - **The interface is a blueprint, not an ABI.** Tools read [`plutus.json`](https://cips.cardano.org/cip/CIP-0057) the way they read an ABI. Instead of view functions and events, you query UTxOs directly through a provider and use transaction metadata or an indexer for event-style history.
 
 ## Next steps
-1. **Learn Aiken**: Start with [aiken-lang.org](https://aiken-lang.org) for the language guide and tutorials. Check out the [Aiken Standard Library](https://aiken-lang.github.io/stdlib/) for more to help you build your validator.
-2. **Write a validator**: Work through [Write a Validator](/docs/developers/curriculum/smart-contracts/write-a-validator) for hands-on on-chain building
-3. **Set Up Off-chain**: Use [Client SDKs](/docs/developers/curriculum/start-building/choose-your-tools) for transaction building
-4. **Get Test ADA**: Use the [testnet faucet](https://docs.cardano.org/cardano-testnets/tools/faucet) to get tADA for [Preview or Preprod testnets](/docs/developers/curriculum/start-building/networks-and-test-ada)
-5. **Explore Core Concepts**: Read about the [eUTxO Model](/docs/developers/curriculum/fundamentals/core-concepts/eutxo) for deeper understanding
-6. **Join the Community**: Connect via the [Developer Community](/docs/community/cardano-developer-community)
+
+- [Start Building](/docs/developers/curriculum/start-building/overview): the next module. Pick your tools, get test ADA, and send your first transaction with the same SDKs used throughout this curriculum.
+- [eUTXO](/docs/developers/curriculum/fundamentals/core-concepts/eutxo): the model behind every difference on this page, if you jumped straight here.
+- [Write a validator](/docs/developers/curriculum/smart-contracts/write-a-validator): hands-on Aiken when you reach Module 5; [aiken-lang.org](https://aiken-lang.org) and the [standard library](https://aiken-lang.github.io/stdlib/) pair well with it.

--- a/docs/developers/curriculum/fundamentals/core-concepts/overview.md
+++ b/docs/developers/curriculum/fundamentals/core-concepts/overview.md
@@ -32,3 +32,8 @@ import DocCardList from '@theme/DocCardList';
 Cardano was designed with input from a global team of experts in programming languages, network design, and cryptography. If you haven't seen it, the 2017 whiteboard video is still a worthwhile primer on what Cardano is and where it came from (some details have since evolved).
 
 <iframe width="100%" height="325" src="https://www.youtube-nocookie.com/embed/Ja9D0kpksxw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+## Next steps
+
+- [Cardano for Ethereum developers](/docs/developers/curriculum/fundamentals/cardano-for-ethereum-developers): the concept-by-concept translation, if you come from the EVM
+- [Start Building](/docs/developers/curriculum/start-building/overview): Module 2, where these concepts become transactions

--- a/docs/developers/curriculum/native-tokens/authenticated-products.md
+++ b/docs/developers/curriculum/native-tokens/authenticated-products.md
@@ -40,3 +40,7 @@ Two things keep this a proof of concept rather than a trust-minimized product.
 **The NFTs use [CIP-25](/docs/developers/curriculum/native-tokens/metadata-registry#cip-25-nft-metadata-in-the-minting-transaction).** CIP-25 records metadata in the minting transaction, where a smart contract can neither read nor update it. A [CIP-68](/docs/developers/curriculum/native-tokens/metadata-registry#cip-68-datum-metadata-updatable-on-chain)-style design would let a contract manage ownership instead: the holder keeps a token that points at the contract, and ownership counts only when an inline datum listing the current owners points back to the asset. That turns the physical-to-digital link into a transferable, trustless one.
 
 The larger step is the chip itself. [Signing NFC chips](https://www.azuki.com/blog/pbt) can sign a challenge with their own private key, so no secret has to be shared with the backend at all. Removing that last shared secret opens the door to multi-signature ownership transfer, where handing over the physical good and its NFT becomes a signed, on-chain event.
+
+## Next steps
+
+- [Programmable tokens](/docs/developers/curriculum/native-tokens/programmable-tokens): where token rules move from the mint to every transfer

--- a/docs/developers/curriculum/native-tokens/overview.md
+++ b/docs/developers/curriculum/native-tokens/overview.md
@@ -8,7 +8,7 @@ description: How Cardano's multi-asset ledger handles native tokens and NFTs as 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-A Cardano native token is a custom asset the ledger tracks directly, alongside ADA, without a smart contract for basic transfers. Where Ethereum needs an ERC-20 or ERC-721 contract per token, Cardano treats your token the same way it treats ADA: it lives in UTXOs and moves through ordinary transactions.
+You can build and submit transactions; this module puts assets of your own inside them. A Cardano native token is a custom asset the ledger tracks directly, alongside ADA, without a smart contract for basic transfers. Where Ethereum needs an ERC-20 or ERC-721 contract per token, Cardano treats your token the same way it treats ADA: it lives in UTXOs and moves through ordinary transactions.
 
 :::note Quick summary
 Tokens are "native" because the protocol tracks them with the same UTXO machinery that tracks ADA. That means lower fees, no contract-execution risk on transfers, atomic multi-asset transactions, and the same ledger-level guarantees ADA has.
@@ -151,8 +151,18 @@ Native tokens move through: policy design, then policy creation (the script hash
 - A single UTXO holds ADA plus any number of tokens (the token bundle).
 - Every token-bearing UTXO carries min-ADA; it scales with size and shapes airdrop and consolidation design.
 
-## Next steps
+## In this module
 
 - [Minting policies](/docs/developers/curriculum/native-tokens/minting-policies): the rules that control creation and burning
-- [Mint a fungible token](/docs/developers/curriculum/native-tokens/mint-fungible) and [Mint an NFT](/docs/developers/curriculum/native-tokens/mint-nft)
-- [Token metadata & registry](/docs/developers/curriculum/native-tokens/metadata-registry): CIP-25, CIP-68, CIP-26, royalties
+- [Mint a fungible token](/docs/developers/curriculum/native-tokens/mint-fungible): your first token, minted end to end
+- [Mint an NFT](/docs/developers/curriculum/native-tokens/mint-nft): one-shot policies and NFT metadata
+- [Token metadata & registry](/docs/developers/curriculum/native-tokens/metadata-registry): how metadata works across CIP-25, CIP-68, and CIP-26
+- [Register an entry](/docs/developers/curriculum/native-tokens/token-registry/register-an-entry): submit your token to the Cardano Token Registry
+- [Token metadata server](/docs/developers/curriculum/native-tokens/token-registry/metadata-server): query registry metadata from your application
+- [Authenticated products](/docs/developers/curriculum/native-tokens/authenticated-products): a physical-goods case study with NFC chips
+- [Programmable tokens](/docs/developers/curriculum/native-tokens/programmable-tokens): where token rules move from the mint to every transfer
+
+## Next steps
+
+- Start with [Minting policies](/docs/developers/curriculum/native-tokens/minting-policies); the mint pages build directly on it
+- The module ends by handing over to [Staking & Governance](/docs/developers/curriculum/staking-governance/overview)

--- a/docs/developers/curriculum/native-tokens/token-registry/register-an-entry.md
+++ b/docs/developers/curriculum/native-tokens/token-registry/register-an-entry.md
@@ -160,3 +160,7 @@ Increment the `sequenceNumber` on `name` and `description` as with any update.
 **My pull request was closed.** Pull requests that fail the automated checks are closed after a while. Open the **Checks** tab and read the failing test for the reason. A pull request can also be rejected even when checks pass if it breaks the [Registry Terms of Use](https://github.com/cardano-foundation/cardano-token-registry/blob/master/Registry_Terms_of_Use.md). For questions about a submission, contact tokenregistry@cardanofoundation.org.
 
 **My pull request has not merged yet.** Review is done by humans, oldest first, and well-formed pull requests that pass every check are processed first. Make sure your checks are green (a red mark links to the failing detail) and be patient.
+
+## Next steps
+
+- [Token metadata server](/docs/developers/curriculum/native-tokens/token-registry/metadata-server): query the entry you just registered from your application

--- a/docs/developers/curriculum/smart-contracts/advanced/bls-primitives.md
+++ b/docs/developers/curriculum/smart-contracts/advanced/bls-primitives.md
@@ -181,3 +181,7 @@ The trust anchor (issuer key and attribute schema) sits in the datum; the proof 
 :::info Research-grade, and moving fast
 As with the ZK verifiers, the builtins themselves sit on an audited library, but every protocol library on this page (`ilap/bls`, the CF examples, `cardano-bbs`) is unaudited, experimental code. Prototype on testnets, read the code you depend on, and treat cost figures as measured snapshots, not guarantees.
 :::
+
+## Next steps
+
+- [Build a dApp](/docs/developers/curriculum/dapps/overview): the next module. Put your contracts in front of users: wallets, payments, oracles, and agents.

--- a/docs/developers/curriculum/smart-contracts/overview.md
+++ b/docs/developers/curriculum/smart-contracts/overview.md
@@ -7,6 +7,8 @@ description: How smart contracts work on Cardano, validators that approve or rej
 
 ![Smart Contracts](./img/card-smart-contracts-title.svg)
 
+You arrive able to build transactions, mint under policies you wrote, and delegate stake and votes. Until now most rules you enforced were the ledger's own; this module generalizes the policy idea into validator scripts that guard any UTXO with logic you define.
+
 ## What are smart contracts?
 
 Smart contracts are agreements defined in code that enforce their terms automatically, without intermediaries. On Cardano they work differently from account-based chains, and the key to understanding them is the [eUTXO](/docs/developers/curriculum/fundamentals/core-concepts/eutxo) model: a smart contract is a **validator script** that guards UTXOs locked at its address. You lock a UTXO at the script's address, and from then on it can only be spent by a transaction the script approves.
@@ -173,3 +175,4 @@ This module builds up from here:
 3. **[Lock and spend](/docs/developers/curriculum/smart-contracts/lock-and-spend)**: build the off-chain transactions that interact with a contract.
 4. **[Testing](/docs/developers/curriculum/smart-contracts/testing)**: verify validators with mock transactions before you deploy.
 5. **[Security](/docs/developers/curriculum/smart-contracts/security)**: the attack classes to defend against.
+6. **[Build a dApp](/docs/developers/curriculum/dapps/overview)**: the next module, where your contracts meet users.

--- a/docs/developers/curriculum/start-building/transaction-failures.md
+++ b/docs/developers/curriculum/start-building/transaction-failures.md
@@ -74,3 +74,4 @@ The important subtlety: `BadInputsUTxO` from indexer lag *looks* transient but a
 - [Resilient submission](/docs/developers/curriculum/start-building/transaction-building#resilient-submission-retry-safe): the retry-safe pattern in code
 - [Submitting transactions](/docs/developers/curriculum/start-building/query-the-chain#submitting-transactions): the full rejection-code reference
 - [Collateral](/docs/developers/curriculum/fundamentals/core-concepts/fees#collateral): how phase-2 failures are paid for
+- [Mint Tokens & NFTs](/docs/developers/curriculum/native-tokens/overview): the next module, custom assets in the transactions you can now debug


### PR DESCRIPTION
Four of six module overviews never said where the reader arrives from, four last pages ended without handing forward, and several sub-trees (core concepts, token registry, oracles, AI agents, IoT) simply stopped. The Ethereum bridge page scattered its Next steps in six directions, and the Module 3 overview named only half its module.

This closes the seams: arrival sentences on the Module 3, 5, and 6 overviews, forward handovers at every module boundary (fundamentals to start-building, transaction-failures to native tokens, smart contracts to dapps, IoT to production), exits on the sub-trees, and a full In-this-module enumeration on the native tokens overview. Reference leaves deliberately get no Next steps; only section boundaries do. 13 files, +51/−13.

Related to #1839