### PR TITLE
Label code blocks by tool

### DIFF
--- a/docs/developers/curriculum/dapps/connect-a-wallet.md
+++ b/docs/developers/curriculum/dapps/connect-a-wallet.md
@@ -206,6 +206,9 @@ Connecting a wallet in a frontend is the same CIP-30 flow shown above; a framewo
 
 Wrap your app once in `<MeshProvider>` and import the stylesheet, then drop the pre-built button in:
 
+<Tabs>
+<TabItem value="mesh" label="Mesh" default>
+
 ```tsx
 // app root (pages/_app.tsx or app/layout.tsx)
 import "@meshsdk/react/styles.css"
@@ -228,6 +231,9 @@ import { CardanoWallet } from "@meshsdk/react"
 <CardanoWallet label="Connect" isDark persist onConnected={() => {}} />
 ```
 
+</TabItem>
+</Tabs>
+
 `<CardanoWallet />` renders the wallet-selection modal and connection flow for you. From any component under the provider, the hooks read live wallet state:
 
 | Hook | Returns |
@@ -242,6 +248,9 @@ import { CardanoWallet } from "@meshsdk/react"
 ### Svelte
 
 Mesh ships the same `<CardanoWallet />` from `@meshsdk/svelte` (Svelte 5). Instead of hooks, you read the reactive `BrowserWalletState` runes, accessed directly inside an `$effect` so reactivity isn't lost:
+
+<Tabs>
+<TabItem value="mesh" label="Mesh" default>
 
 ```svelte
 <script lang="ts">
@@ -262,6 +271,9 @@ Mesh ships the same `<CardanoWallet />` from `@meshsdk/svelte` (Svelte 5). Inste
   <CardanoWallet />
 {/if}
 ```
+
+</TabItem>
+</Tabs>
 
 `BrowserWalletState` exposes `wallet`, `connected`, `name`, and `connecting`. Read its properties directly (don't destructure) or you lose reactivity.
 

--- a/docs/developers/curriculum/production/hydra.md
+++ b/docs/developers/curriculum/production/hydra.md
@@ -5,6 +5,9 @@ sidebar_label: Hydra
 description: Hydra is Cardano's Layer 2, a state channel where a known set of participants transact instantly with zero fees, settling back to Layer 1 only to open and close.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 Hydra is a Layer 2 scaling solution for Cardano that enables near-instant, low-cost transactions between participants. It operates as a **state channel**: a temporary off-chain ledger where a known set of parties transact as fast as their network connection allows while keeping the security guarantees of the Cardano main chain (Layer 1).
 
 Inside a Hydra Head, transactions use the same format as Cardano Layer 1. **Fees are configurable down to zero**, confirmation is instant (limited only by network latency between participants), and all parties must agree on every state transition.
@@ -104,7 +107,8 @@ This walkthrough follows the commit-phase flow of hydra-node 1.x. On Hydra 2.x t
 
 ### Connect, initialize, commit
 
-**Mesh**
+<Tabs>
+<TabItem value="mesh" label="Mesh" default>
 
 ```ts
 import { HydraProvider, HydraInstance } from "@meshsdk/hydra";
@@ -123,12 +127,15 @@ const signedCommit = await wallet.signTx(commitTx, true, false); // partial sign
 await wallet.submitTx(signedCommit);                              // -> "HeadIsOpen" once all commit
 ```
 
+</TabItem>
+</Tabs>
 
 ### Transact on Layer 2
 
 Once the Head is open, build with `MeshTxBuilder` using `isHydra: true` and the Head's (zero-fee) protocol parameters. `submitTx` goes to the Head, not Layer 1:
 
-**Mesh**
+<Tabs>
+<TabItem value="mesh" label="Mesh" default>
 
 ```ts
 import { MeshTxBuilder } from "@meshsdk/core";
@@ -148,12 +155,15 @@ const signedTx = await wallet.signTx(unsignedTx, false);
 await hydraProvider.submitTx(signedTx);   // instant, zero-fee; emits "TxValid" / "SnapshotConfirmed"
 ```
 
+</TabItem>
+</Tabs>
 
 Submit as many transactions as you need; each confirmed one updates the shared state via a new signed snapshot.
 
 ### Close and fanout
 
-**Mesh**
+<Tabs>
+<TabItem value="mesh" label="Mesh" default>
 
 ```ts
 await hydraProvider.close();   // posts the latest snapshot to L1, starts the contestation period
@@ -161,6 +171,8 @@ await hydraProvider.close();   // posts the latest snapshot to L1, starts the co
 await hydraProvider.fanout();  // distributes final balances back to L1 -> "HeadIsFinalized"
 ```
 
+</TabItem>
+</Tabs>
 
 `close()` posts the final state on-chain and opens a contestation window (any participant can dispute with a newer snapshot). After it passes, `fanout()` returns funds to their Layer 1 addresses.
 

--- a/docs/developers/curriculum/smart-contracts/advanced/design-patterns/stake-validator.md
+++ b/docs/developers/curriculum/smart-contracts/advanced/design-patterns/stake-validator.md
@@ -236,6 +236,9 @@ await wallet.submitTx(signedTx)
 
 Script control is not limited to the withdrawal trigger. In Evolution every staking operation accepts a `redeemer` and an attached script, so a script-held credential can also delegate:
 
+<Tabs>
+<TabItem value="evolution" label="Evolution" default>
+
 ```typescript
 import { Credential, Data } from "@evolution-sdk/evolution"
 
@@ -253,6 +256,9 @@ const tx = await client
   .attachScript({ script: stakeScript })
   .build()
 ```
+
+</TabItem>
+</Tabs>
 
 Mesh's builder takes a redeemer on a script **withdrawal** (the trigger above) but not on a stake **delegation** certificate, so script-controlled delegation is Evolution or cardano-cli only.
 

--- a/docs/developers/curriculum/smart-contracts/choose-a-language.md
+++ b/docs/developers/curriculum/smart-contracts/choose-a-language.md
@@ -2,12 +2,12 @@
 id: choose-a-language
 title: Choose a Smart Contract Language
 sidebar_label: Choose a smart contract language
-description: Pick a language for writing Cardano validators. Every language compiles to the same on-chain bytecode (UPLC), so the choice is about ergonomics, and Aiken is the recommended starting point.
+description: Pick a language for writing Cardano validators. Every language compiles to the same on-chain bytecode (UPLC), so the choice is about ergonomics rather than capability.
 ---
 
 You write a validator in a high-level language, and it compiles down to **UPLC** (Untyped Plutus Lambda Calculus), the one bytecode every Cardano node executes. Because the on-chain target is the same regardless of source language, choosing a language is mostly about **ergonomics**: which one lets your team write correct, efficient validators fastest.
 
-This page helps you pick. For most people starting out, the answer is **Aiken**.
+This page helps you pick.
 
 ## Everything compiles to UPLC
 
@@ -36,9 +36,9 @@ UPLC is a minimalist, lambda-calculus-based language: variables, functions, func
 
 The practical consequence: **your language choice does not change what's possible on-chain, only how pleasant it is to get there.**
 
-## Recommended: Aiken
+## Aiken
 
-[Aiken](https://aiken-lang.org) is a language purpose-built for Cardano validators, with syntax borrowed from Rust, Elm, and Gleam. In the [developer ecosystem survey](https://cardano-foundation.github.io/state-of-the-developer-ecosystem/2025/#what-do-you-use-or-plan-to-use-for-writing-plutus-script-validators-smart-contracts) it is the most-used language for writing validators, and it is where these docs point newcomers.
+[Aiken](https://aiken-lang.org) is a language purpose-built for Cardano validators, with syntax borrowed from Rust, Elm, and Gleam. In the [developer ecosystem survey](https://cardano-foundation.github.io/state-of-the-developer-ecosystem/2025/#what-do-you-use-or-plan-to-use-for-writing-plutus-script-validators-smart-contracts) it is the most-used language for writing validators, and it is the language the examples in this module are written in.
 
 Why Aiken:
 
@@ -48,8 +48,6 @@ Why Aiken:
 - **Built-in testing**: a test runner ships with the toolchain, so you write and run unit tests without extra tooling. (See [Testing](/docs/developers/curriculum/smart-contracts/testing).)
 - **Clean separation**: Aiken is on-chain only. Off-chain code stays in whatever language your app uses (TypeScript, Python, Rust), which reinforces the on-chain/off-chain split Cardano's architecture wants.
 - **Strong static typing**: full algebraic data types, pattern matching, generics, and inference, modern type safety with no runtime or garbage collector.
-
-If you have no strong reason to pick something else, start with Aiken.
 
 ## Getting started with Aiken
 
@@ -75,7 +73,7 @@ Cardano's language diversity is a strength: because UPLC is a clean compilation 
 
 | Language | Best for | Notes |
 |---|---|---|
-| **[Aiken](https://aiken-lang.org)** | Most new projects | Purpose-built, fast, small output, built-in tests. The default recommendation. |
+| **[Aiken](https://aiken-lang.org)** | Most new projects | Purpose-built, fast, small output, built-in tests. |
 | **[Plinth](https://plutus.cardano.intersectmbo.org/docs/)** (Plutus Tx) | Haskell teams | The original language; full Haskell type system, on- and off-chain code sharing. Steeper learning curve and larger scripts. |
 | **[Plutarch](https://github.com/Plutonomicon/plutarch-plutus)** | Performance-critical validators | Fine-grained control close to writing UPLC by hand; the most verbose path, aimed at minimizing execution costs. |
 | **[OpShin](https://opshin.dev)** | Python teams | Write validators in a subset of valid Python; pairs with PyCardano. |

--- a/docs/developers/curriculum/smart-contracts/datum-redeemer-context.md
+++ b/docs/developers/curriculum/smart-contracts/datum-redeemer-context.md
@@ -237,6 +237,9 @@ const cancel = mConStr1([])
 
 Writing raw `Data.constr` is error-prone for real contracts. Evolution's **`TSchema`** defines the shape once and gives a type-safe codec, so the off-chain types match the on-chain definitions in your validator:
 
+<Tabs>
+<TabItem value="evolution" label="Evolution" default>
+
 ```typescript
 import { Data, TSchema, Bytes } from "@evolution-sdk/evolution"
 
@@ -246,6 +249,9 @@ const Codec = Data.withSchema(VestingDatum)
 const datum = Codec.toData({ beneficiary: Bytes.fromHex("abc1...23de"), deadline: 1735689600000n })
 // Codec.toCBORHex(...) / Codec.fromData(...) round-trip too
 ```
+
+</TabItem>
+</Tabs>
 
 Mesh has no equivalent typed codec: you build the same datum with the raw `mConStr` constructors shown above, keeping field order and types aligned with your validator by hand.
 
@@ -292,6 +298,9 @@ const update = mConStr2(["def4...56ab", 1735776000000n])    // Update(new_benefi
 
 When a datum or redeemer holds a multi-asset value (a DEX order, locked escrow funds), both SDKs give you value helpers so you don't assemble nested asset maps by hand. In Mesh, `MeshValue` does the arithmetic:
 
+<Tabs>
+<TabItem value="mesh" label="Mesh" default>
+
 ```typescript
 import { MeshValue } from "@meshsdk/core"
 
@@ -304,6 +313,9 @@ offered.geq(required)          // true: covers what the swap needs
 offered.merge(required)        // combine two values
 const datumValue = offered.toData()   // → Mesh Data (nested Maps) for the datum field
 ```
+
+</TabItem>
+</Tabs>
 
 Evolution's equivalent is the `Value` schema from `@evolution-sdk/evolution/plutus`, a `Map` of policy → asset name → quantity that you drop straight into a `TSchema.Struct`.
 

--- a/docs/developers/curriculum/smart-contracts/overview.md
+++ b/docs/developers/curriculum/smart-contracts/overview.md
@@ -157,7 +157,7 @@ That permanence runs one way only. On-chain code keeps working unchanged for as 
 
 ## Choose a language
 
-Validators can be written in several languages that all compile to the same on-chain bytecode (UPLC). For most new projects, **[Aiken](https://aiken-lang.org)** is the recommended starting point. See **[Choose a language](/docs/developers/curriculum/smart-contracts/choose-a-language)** for the full comparison (Aiken, Plinth, Plutarch, OpShin, Scalus, Pebble, Marlowe).
+Validators can be written in several languages that all compile to the same on-chain bytecode (UPLC). The examples in this module are written in **[Aiken](https://aiken-lang.org)**. See **[Choose a language](/docs/developers/curriculum/smart-contracts/choose-a-language)** for the full comparison (Aiken, Plinth, Plutarch, OpShin, Scalus, Pebble, Marlowe).
 
 ## Key takeaways
 
@@ -172,7 +172,7 @@ Validators can be written in several languages that all compile to the same on-c
 This module builds up from here, in order:
 
 1. **[Datum, redeemer & context](/docs/developers/curriculum/smart-contracts/datum-redeemer-context)**: the three arguments every validator receives, in depth.
-2. **[Choose a language](/docs/developers/curriculum/smart-contracts/choose-a-language)**: pick how you'll write validators (Aiken-first).
+2. **[Choose a language](/docs/developers/curriculum/smart-contracts/choose-a-language)**: pick how you'll write validators.
 3. **[Write a validator](/docs/developers/curriculum/smart-contracts/write-a-validator)**: the on-chain code itself, purpose by purpose.
 4. **[Lock and spend](/docs/developers/curriculum/smart-contracts/lock-and-spend)**: build the off-chain transactions that interact with a contract.
 5. **[Testing](/docs/developers/curriculum/smart-contracts/testing)**: verify validators with mock transactions before you deploy.

--- a/docs/developers/curriculum/smart-contracts/write-a-validator.md
+++ b/docs/developers/curriculum/smart-contracts/write-a-validator.md
@@ -8,13 +8,11 @@ description: "Author the on-chain code: Aiken validator types (minting, spending
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-You've [picked a language](/docs/developers/curriculum/smart-contracts/choose-a-language) (Aiken, for most people). Now you write the on-chain code: the validator. Remember the mental model: a validator is a **gatekeeper** that receives a transaction and returns `True` or `False`. It never moves funds or mutates state; it only decides whether a transaction is allowed.
+You've [picked a language](/docs/developers/curriculum/smart-contracts/choose-a-language). Now you write the on-chain code: the validator. Remember the mental model: a validator is a **gatekeeper** that receives a transaction and returns `True` or `False`. It never moves funds or mutates state; it only decides whether a transaction is allowed.
 
 This page covers writing validators in Aiken, the simpler native-script alternative for multisig and time-locks, and the blueprint that connects your validator to off-chain code. The deep treatment of the three arguments a validator receives is in [Datum, redeemer & context](/docs/developers/curriculum/smart-contracts/datum-redeemer-context); this page focuses on authoring.
 
 If you have written web middleware, this is familiar: a validator is like route middleware or an auth guard, a pure function that returns allow or deny without mutating state. The redeemer is the request body it branches on (`MintToken` vs `BurnToken`), and the blueprint (`plutus.json`) is the contract's OpenAPI spec that tools read to generate a typed client.
-
-> Install Aiken from [aiken-lang.org](https://aiken-lang.org/installation-instructions); scaffold a project with `npx meshjs <name>` and pick the Aiken template.
 
 ## What a validator sees
 

--- a/docs/developers/curriculum/staking-governance/drep-and-delegation.md
+++ b/docs/developers/curriculum/staking-governance/drep-and-delegation.md
@@ -106,7 +106,8 @@ A DRep credential can also be a script hash instead of a key hash. The flow mirr
 
 For a **simple-script (multisig) DRep**, write a native script (for example `type: atLeast` over the members' DRep key hashes), hash it for the DRep ID, and register against that script hash:
 
-**cardano-cli**
+<Tabs>
+<TabItem value="cardano-cli" label="cardano-cli" default>
 
 ```bash
 cardano-cli hash script --script-file drep-multisig.json --out-file drep-multisig.id
@@ -117,7 +118,13 @@ cardano-cli latest governance drep registration-certificate \
   --out-file drep-multisig-reg.cert
 ```
 
+</TabItem>
+</Tabs>
+
 Build with `--certificate-script-file drep-multisig.json`, then collect one `transaction witness` per member and combine them with `transaction assemble`. A **Plutus-script DRep** registers the same way (`--drep-script-hash` from `cardano-cli hash script` on the `.plutus` file), but the transaction supplies collateral and a redeemer rather than script witnesses:
+
+<Tabs>
+<TabItem value="cardano-cli" label="cardano-cli" default>
 
 ```bash
 cardano-cli latest transaction build \
@@ -129,6 +136,9 @@ cardano-cli latest transaction build \
   --change-address $(< payment.addr) \
   --out-file tx.raw
 ```
+
+</TabItem>
+</Tabs>
 
 Only the payment key signs; script validity comes from the redeemer, not a DRep key signature.
 

--- a/docs/developers/curriculum/staking-governance/governance-operations.md
+++ b/docs/developers/curriculum/staking-governance/governance-operations.md
@@ -75,6 +75,9 @@ Script-based members use `--cold-script-hash` / `--hot-script-hash` instead of t
 
 To show proposals, DRep info, voting power, or committee state in a UI, query your node:
 
+<Tabs>
+<TabItem value="cardano-cli" label="cardano-cli" default>
+
 ```bash
 cardano-cli latest query gov-state                           # committee, constitution, params, proposals
 cardano-cli latest query drep-state --all-dreps              # DRep registration: deposit, expiry, anchor
@@ -82,6 +85,9 @@ cardano-cli latest query drep-stake-distribution --all-dreps # voting power per 
 cardano-cli latest query committee-state                     # members, hot-key auth, expiry, threshold
 cardano-cli latest query proposals --all-proposals           # actions eligible for ratification
 ```
+
+</TabItem>
+</Tabs>
 
 `query constitution` returns the current constitution anchor and guardrails script hash, and `query gov-state | jq -r .nextRatifyState.nextEnactState.prevGovActionIds` gives the last-enacted action IDs you need for the `--prev-governance-action-*` flags. Query APIs (Blockfrost, Koios, Maestro) expose the same data over HTTP; see [Use a provider](/docs/developers/curriculum/production/use-a-provider).
 

--- a/docs/developers/curriculum/start-building/development-networks.md
+++ b/docs/developers/curriculum/start-building/development-networks.md
@@ -42,13 +42,23 @@ Run it with Docker Compose, a standalone CLI zip (Linux x64, macOS arm64), or th
 
 Both SDKs drive a running Yaci devnet from code. Mesh has a first-class `YaciProvider` (`new YaciProvider("http://localhost:8080/api/v1/")`, or no argument for [Mesh's hosted devnet](https://cloud.meshjs.dev/yaci)); pass an admin URL and it can fund addresses and read devnet config programmatically (`addressTopup`, `getDevnetInfo`). Because Yaci's Store API is **Blockfrost-compatible**, Evolution points its Blockfrost provider straight at it:
 
-```typescript
-// Mesh
-const provider = new YaciProvider("http://localhost:8080/api/v1/")
+<Tabs groupId="sdk">
+<TabItem value="evolution" label="Evolution" default>
 
-// Evolution (Yaci's API speaks Blockfrost)
+```typescript
+// Yaci's API speaks Blockfrost
 const client = Client.make(preprod).withBlockfrost({ baseUrl: "http://localhost:8080/api/v1", projectId: "" })
 ```
+
+</TabItem>
+<TabItem value="mesh" label="Mesh">
+
+```typescript
+const provider = new YaciProvider("http://localhost:8080/api/v1/")
+```
+
+</TabItem>
+</Tabs>
 
 ### cardano-testnet
 
@@ -151,6 +161,9 @@ Mesh ships a dedicated tool for each, below. Evolution covers the same ground di
 
 `OfflineFetcher` is an in-memory provider you populate with fixtures, then build and query against exactly like a real one. Construct it with a network, seed it with `addUTxOs([...])`, `addProtocolParameters({...})`, and `addAccount(...)`, and pass it anywhere a provider goes:
 
+<Tabs>
+<TabItem value="mesh" label="Mesh" default>
+
 ```typescript
 import { OfflineFetcher, MeshTxBuilder } from "@meshsdk/core";
 import { MeshCardanoHeadlessWallet, AddressType } from "@meshsdk/wallet";
@@ -178,11 +191,17 @@ const tx = await new MeshTxBuilder({ fetcher })
   .complete();
 ```
 
+</TabItem>
+</Tabs>
+
 Persist a populated fetcher with `fetcher.toJSON()` and rebuild it with `OfflineFetcher.fromJSON(json)`, so a fixture is a checked-in file, not setup code.
 
 ### Evaluate script budgets offline (OfflineEvaluator)
 
 `OfflineEvaluator` computes Plutus execution units offline. Pair it with an `OfflineFetcher` that holds the script UTxO and collateral, then call `evaluateTx(txCbor)`. It returns one budget per redeemer:
+
+<Tabs>
+<TabItem value="mesh" label="Mesh" default>
 
 ```typescript
 import { OfflineEvaluator } from "@meshsdk/core-csl";
@@ -202,11 +221,17 @@ const costs = await evaluator.evaluateTx(unsignedTx);
 // [{ index: 0, tag: "SPEND", budget: { mem: 508703, steps: 164980381 } }]
 ```
 
+</TabItem>
+</Tabs>
+
 The same mock supplies both data and budgets, so script tests run with no node and assert on `mem`/`steps` in CI.
 
 ### Assert the shape of a built tx (TxTester)
 
 `TxTester` checks what a transaction *is* without submitting it. Parse a tx with `TxParser`, call `toTester()`, then chain filters and assertions and read the verdict with `success()` / `errors()`:
+
+<Tabs>
+<TabItem value="mesh" label="Mesh" default>
 
 ```typescript
 import { TxParser, MeshValue } from "@meshsdk/core";
@@ -225,6 +250,9 @@ txTester.keySigned(keyHash);
 
 console.log(txTester.success(), txTester.errors());
 ```
+
+</TabItem>
+</Tabs>
 
 You assert that your *builder* produced the outputs, mint, validity window, and signers you intended, without submitting anything.
 

--- a/docs/developers/curriculum/start-building/query-the-chain.md
+++ b/docs/developers/curriculum/start-building/query-the-chain.md
@@ -77,7 +77,10 @@ In Mesh the read methods live on the **provider** (an `IFetcher`/`ISubmitter`), 
 </TabItem>
 </Tabs>
 
-Use the matching network base URL for Preprod/Preview (e.g. `https://cardano-preprod.blockfrost.io/api/v0`). For a **hosted Kupmios** like [Demeter](https://demeter.run), pass the API keys through the connection. With Evolution that is the `headers` option on `withKupmios`:
+Use the matching network base URL for Preprod/Preview (e.g. `https://cardano-preprod.blockfrost.io/api/v0`). For a **hosted Kupmios** like [Demeter](https://demeter.run), pass the API keys through the connection with the `headers` option on `withKupmios`:
+
+<Tabs>
+<TabItem value="evolution" label="Evolution" default>
 
 ```typescript
 const client = Client.make(mainnet).withKupmios({
@@ -89,6 +92,9 @@ const client = Client.make(mainnet).withKupmios({
   }
 })
 ```
+
+</TabItem>
+</Tabs>
 
 Mesh has no single Kupmios provider; pair `OgmiosProvider` with Kupo and pass the Demeter keys through each provider's connection options.
 

--- a/docs/developers/curriculum/start-building/transaction-building.md
+++ b/docs/developers/curriculum/start-building/transaction-building.md
@@ -236,7 +236,10 @@ For **native-token** airdrops, give each output enough ADA for the min-UTXO (tok
 
 ## Chaining transactions
 
-Normally you can't build transaction #2 until #1 confirms, because #1's new UTXOs don't exist from the provider's view yet, a 10-30 s wait per step. **Chaining** removes it: once you have built transaction #1, you feed the UTXOs you still hold **plus** its new outputs (already tagged with its pre-computed hash) into the build of transaction #2. For the concept beneath this, why an unconfirmed output is safe to spend and where chaining fits among Cardano's scaling options, see [transaction chaining](/docs/developers/curriculum/production/transaction-chaining). With Evolution:
+Normally you can't build transaction #2 until #1 confirms, because #1's new UTXOs don't exist from the provider's view yet, a 10-30 s wait per step. **Chaining** removes it: once you have built transaction #1, you feed the UTXOs you still hold **plus** its new outputs (already tagged with its pre-computed hash) into the build of transaction #2. For the concept beneath this, why an unconfirmed output is safe to spend and where chaining fits among Cardano's scaling options, see [transaction chaining](/docs/developers/curriculum/production/transaction-chaining).
+
+<Tabs>
+<TabItem value="evolution" label="Evolution" default>
 
 ```typescript
 import { Address, Assets } from "@evolution-sdk/evolution"
@@ -259,6 +262,9 @@ const tx2 = await client
 await (await tx1.sign()).submit()
 await (await tx2.sign()).submit()
 ```
+
+</TabItem>
+</Tabs>
 
 :::warning Submit in order
 Each chained transaction spends an output of the previous one. If tx2 reaches the node before tx1, the node sees inputs that don't exist and rejects it. A sequential loop guarantees ordering. The `available` outputs are **not on-chain yet**. Don't pass them to a provider query.
@@ -345,6 +351,9 @@ This is what powers the withdraw-zero coordinator: the [Stake Validator design p
 
 SDKs build a transaction against a live provider. `cardano-cli` can also build one **fully offline**, where you calculate the fee and balance the transaction yourself, for air-gapped signing and reproducible builds. Of its three build commands, `transaction build` is the everyday node-connected one, `build-raw` is the offline one, and `build-estimate` sizes a fee offline without balancing.
 
+<Tabs>
+<TabItem value="cardano-cli" label="cardano-cli" default>
+
 ```bash
 # 1. Protocol parameters (needs a node, once)
 cardano-cli query protocol-parameters --out-file pparams.json
@@ -369,12 +378,17 @@ cardano-cli latest transaction build-raw \
   --fee 173993 --protocol-params-file pparams.json --out-file tx.raw
 ```
 
+</TabItem>
+</Tabs>
 
 `--witness-count` is how many signatures the transaction will carry. It affects the fee. Inspect any draft with `cardano-cli debug transaction view --tx-body-file tx.draft`.
 
 ## Spending from several keys
 
 To spend UTXOs owned by *different* keys in one transaction (combining two wallets, or a multisig), list each `--tx-in`, set the witness count to the number of signers, and pass every signing key at sign time.
+
+<Tabs>
+<TabItem value="cardano-cli" label="cardano-cli" default>
 
 ```bash
 cardano-cli latest transaction build-raw \
@@ -389,6 +403,8 @@ cardano-cli latest transaction sign \
   --out-file tx.signed
 ```
 
+</TabItem>
+</Tabs>
 
 Then `submit` as usual. Parse CLI output with `jq` for scripted workflows, e.g. pick the first UTXO: `--tx-in $(cardano-cli query utxo --address $(< payment.addr) --output-json | jq -r 'keys[0]')`. The full command reference lives in the [cardano-cli repository](https://github.com/IntersectMBO/cardano-cli).
 


### PR DESCRIPTION
Two things from reading the live curriculum, both cases of prose doing a job that structure should do.

Code blocks on tabbed pages didn't always say which tool they were for. Some named it in the sentence above, some in a bold line acting as an unstyled tab label, and one held both SDKs in a single fence under comment headers. The rule now: if a page teaches with SDK tabs, every tool-specific block on it wears the same chrome, single implementation or not. A label isn't dead chrome, the label is the information.

The smart contracts module also argued for Aiken in ten places, including a parenthetical restating the recommendation from the page it links to. Every example in the module is already written in Aiken, which says what we recommend without saying it. Each site now states a fact or nothing.

Two follow-ups left as decisions rather than made here: the curriculum no longer mentions `aiken new` anywhere, so nothing introduces a project's shape before the examples assume it; and the oracles overview recommends Pyth with the same construction, which is a different call for a third-party data provider than for an open-source toolchain.

Related to #1839