### PR TITLE
Correct the van Rossem date and how UPLC is described

### DIFF
--- a/docs/developers/curriculum/fundamentals/cardano-components.md
+++ b/docs/developers/curriculum/fundamentals/cardano-components.md
@@ -51,7 +51,7 @@ The networking layer handles peer topology and connection management. Both relay
 
 ### Scripting layer
 
-The scripting layer is the smart-contract execution engine embedded in the ledger. At its core it is a typed lambda calculus, a minimal formally-verified computation model; smart contracts compiled from Aiken, Plinth, Plutarch, or any other high-level language ultimately compile down to Untyped Plutus Core (UPLC) for on-chain execution (reference implementation: [Plutus Core](https://github.com/IntersectMBO/plutus)).
+The scripting layer is the smart-contract execution engine embedded in the ledger. At its core it is a lambda calculus, a minimal formally-verified computation model. Compilers work through a typed form, Typed Plutus Core, but the language the ledger executes is untyped: smart contracts compiled from Aiken, Plinth, Plutarch, or any other high-level language ultimately become [Untyped Plutus Core (UPLC)](/docs/developers/curriculum/smart-contracts/advanced/uplc) for on-chain execution (reference implementation: [Plutus Core](https://github.com/IntersectMBO/plutus)).
 
 Execution happens within the ledger layer during transaction validation. Every script execution is bounded by an execution unit budget (CPU steps and memory units) that must be declared in the transaction. The declared budget is consumed during validation; both per-transaction and per-block execution unit limits are enforced by the protocol parameters, preventing unbounded computation.
 

--- a/docs/developers/curriculum/smart-contracts/advanced/zero-knowledge.md
+++ b/docs/developers/curriculum/smart-contracts/advanced/zero-knowledge.md
@@ -55,7 +55,7 @@ Because Plutus evaluation is deterministic, verification cost is known before th
 On-chain verification is built on two protocol upgrades:
 
 - **Chang (September 2024, Plutus V3)** shipped [CIP-0381](https://cips.cardano.org/cip/CIP-0381): 17 builtins for the pairing-friendly **BLS12-381** curve, group operations (`bls12_381_G1_add`, `bls12_381_G1_scalarMul`, and their G2 counterparts), the pairing (`bls12_381_millerLoop`, `bls12_381_mulMlResult`, `bls12_381_finalVerify`), plus compression, hashing-to-group, and equality. They are backed by the independently audited `blst` library, so the *primitives* are production-grade even where the verifiers built on them are not. This made pairing-based SNARK verification possible on Cardano.
-- **van Rossem (June 2026, protocol version 11)** made it cheaper: [CIP-0133](https://cips.cardano.org/cip/CIP-0133) added multi-scalar multiplication builtins (`bls12_381_G1_multiScalarMul`, `bls12_381_G2_multiScalarMul`), the operation that dominates PLONK and Halo2 verification, and [CIP-0109](https://cips.cardano.org/cip/CIP-0109) added `expModInteger` for modular field arithmetic.
+- **van Rossem (July 2026, protocol version 11)** made it cheaper: [CIP-0133](https://cips.cardano.org/cip/CIP-0133) added multi-scalar multiplication builtins (`bls12_381_G1_multiScalarMul`, `bls12_381_G2_multiScalarMul`), the operation that dominates PLONK and Halo2 verification, and [CIP-0109](https://cips.cardano.org/cip/CIP-0109) added `expModInteger` for modular field arithmetic.
 
 Two practical constraints follow from the builtin design:
 

--- a/docs/developers/curriculum/smart-contracts/choose-a-language.md
+++ b/docs/developers/curriculum/smart-contracts/choose-a-language.md
@@ -5,7 +5,7 @@ sidebar_label: Choose a smart contract language
 description: Pick a language for writing Cardano validators. Every language compiles to the same on-chain bytecode (UPLC), so the choice is about ergonomics rather than capability.
 ---
 
-You write a validator in a high-level language, and it compiles down to **UPLC** (Untyped Plutus Lambda Calculus), the one bytecode every Cardano node executes. Because the on-chain target is the same regardless of source language, choosing a language is mostly about **ergonomics**: which one lets your team write correct, efficient validators fastest.
+You write a validator in a high-level language, and it compiles down to **UPLC** (Untyped Plutus Core), the one bytecode every Cardano node executes. Because the on-chain target is the same regardless of source language, choosing a language is mostly about **ergonomics**: which one lets your team write correct, efficient validators fastest.
 
 This page helps you pick.
 


### PR DESCRIPTION
Three factual corrections in the curriculum, found while checking coursework against the portal.

The ZK page dated van Rossem to June 2026. It was ratified on 13 July and enacted on mainnet on 18 July 2026. That page is the one everything else cites for when the BLS builtins got cheaper, so the wrong month propagates: it had already been picked up in draft material elsewhere.

The other two are about UPLC. `choose-a-language.md` expanded the acronym as "Untyped Plutus Lambda Calculus" where it is Untyped Plutus Core, which the same page's prose and `advanced/uplc.md` both get right. And `cardano-components.md` called the scripting layer "a typed lambda calculus" before correctly noting that everything compiles to UPLC for on-chain execution. Typed Plutus Core is real, but it lives inside the compiler; the language the ledger executes is the untyped one. Saying both, in that order, is what stops the distinction collapsing, and this page is where a beginner meets the scripting layer for the first time.

Related to #1839