### PR TITLE
Render the portal in Chivo and fix the Arial fallback

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -81,6 +81,20 @@ module.exports = {
       onBrokenMarkdownLinks: "throw",
     },
   },
+  headTags: [
+    {
+      // Regular carries nearly all text, so fetching it early shortens the
+      // window where the page renders in the fallback font.
+      tagName: "link",
+      attributes: {
+        rel: "preload",
+        href: "/fonts/Chivo-400.ttf",
+        as: "font",
+        type: "font/ttf",
+        crossorigin: "anonymous",
+      },
+    },
+  ],
   themes: ['@docusaurus/theme-mermaid'],
   themeConfig: {
     // Toggle display of icons in the mega menu. Icons need to be added to /static/img/icons/ as svg files

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,9 +6,33 @@
  * work well for content-centric websites.
  */
 
+/* Brand font. scripts/generate-og.js reads the same two files at build time for
+   the OG cards, so pages and the cards that link to them share one typeface. */
+@font-face {
+  font-family: "Chivo";
+  src: url("/fonts/Chivo-400.ttf") format("truetype");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Chivo";
+  src: url("/fonts/Chivo-700.ttf") format("truetype");
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
 /* You can override the default Infima variables here. */
 
 :root {
+  /* Chivo ships 400 and 700 only, so the weight scale has two steps. Anything
+     above 500 renders bold, anything at or below renders regular. The rest of
+     the stack stays as the fallback for glyphs Chivo does not carry. */
+  --ifm-font-family-base: "Chivo", system-ui, -apple-system, "Segoe UI", Roboto,
+    Ubuntu, Cantarell, "Noto Sans", sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol";
   --ifm-color-primary: #0033AD;
   --ifm-color-primary-dark: #002E9C;
   --ifm-color-primary-darker: #002B93;
@@ -48,6 +72,16 @@ html[data-theme="dark"] {
   --site-color-surface-hover: #3a3a3d;
   --site-color-bg-dark: #1b1b1d;
   --docusaurus-highlighted-code-line-bg: rgb(72, 77, 91);
+}
+
+/* Form controls do not inherit font-family: the browser's own stylesheet sets
+   them to Arial. Without this, every button and input on the portal opts out of
+   the site font. */
+button,
+input,
+select,
+textarea {
+  font-family: inherit;
 }
 
 .button {
@@ -201,7 +235,7 @@ div#faucetcontainer {
   align-items: center;
   color: var(--ifm-navbar-link-color);
   font-size: var(--ifm-font-size-base);
-  font-weight: 550;
+  font-weight: 400;
   text-decoration: none;
 }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -65,7 +65,7 @@ function Hero() {
           <h1 className={styles.heroTitle}>Cardano Developer Portal</h1>
           <p className={styles.heroSubtitle}>
             From the first transaction to the production dApp and everything in
-            between. Docs, tools, and SDKs for everything Cardano.
+            between. Docs, tools, and SDKs for Cardano.
           </p>
           <div className={styles.heroActions}>
             <Link to={useBaseUrl("docs/developers/")} className={styles.heroCta}>


### PR DESCRIPTION
The portal has never rendered in a brand font. Chivo has been sitting in `static/fonts/` all along, read at build time by the OG card generator and by nothing else, which meant the cards and the pages they link to disagreed with each other. It is now registered as a webfont and set as the base family, so the portal and its social cards share one typeface.

Getting there meant fixing a second problem, because the two are really the same bug. Browsers do not inherit `font-family` into form controls, they pin them to Arial. Any component that set a size and a weight but not a family opted out of the site font without meaning to: the three navbar labels on every page, the Builder Tools intent chips and filters, three search inputs, the copy-markdown trigger, the sticky Contribute button. Setting a base family alone would have left every one of those in Arial, so one rule now makes form controls inherit like the rest of the page. The navbar labels were the loudest case: they asked for weight 550, Arial has no such weight, and CSS rounds upward, so they rendered Bold. They are 400 now.

Two things worth knowing. Chivo ships 400 and 700 only, so the weight scale has two steps, and 52 of the portal's 93 weight declarations name a value it cannot serve. Those are left as written rather than rewritten to match, so they begin rendering as intended if a fuller Chivo is ever added. And Chivo runs wider than the system stack it replaces, which pushed the homepage hero subtitle onto a third line, so one redundant word comes out of that sentence to bring it back to two.

Related to #1847
