### PR TITLE
Drop the header illustrations from the module overviews

### DIFF
--- a/docs/developers/curriculum/dapps/overview.md
+++ b/docs/developers/curriculum/dapps/overview.md
@@ -5,8 +5,6 @@ sidebar_label: Overview
 description: Connect Cardano to your application (wallets, payments, oracles, and AI agents) and build DeFi protocols on the eUTXO model.
 ---
 
-![Integrate Cardano](./img/card-integrate-cardano-title.svg)
-
 You arrive from [Smart Contracts](/docs/developers/curriculum/smart-contracts/overview) able to write and test validators. This module is about meeting users where they are: connecting Cardano to web apps, services, and protocols.
 
 It runs as two arcs. The first puts an application in front of users; the second builds the protocols underneath. Two side-tracks branch off, and you can skip both without losing the thread.

--- a/docs/developers/curriculum/smart-contracts/overview.md
+++ b/docs/developers/curriculum/smart-contracts/overview.md
@@ -5,8 +5,6 @@ sidebar_label: Overview
 description: How smart contracts work on Cardano, validators that approve or reject transactions on the eUTXO model.
 ---
 
-![Smart Contracts](./img/card-smart-contracts-title.svg)
-
 You arrive able to build transactions, mint under policies you wrote, and delegate stake and votes. Until now most rules you enforced were the ledger's own; this module generalizes the policy idea into validator scripts that guard any UTXO with logic you define.
 
 ## What are smart contracts?


### PR DESCRIPTION
Build a dApp and Smart Contracts each opened with a wide illustration before the first line of text, pushing the module's actual introduction down the page. They were the only two module overviews carrying one, so the curriculum was inconsistent about it anyway.

Both SVGs stay in the repo, unreferenced, alongside the matching landing page illustration.

Related to #1847