### PR TITLE
Adopt the rebrand weight scale and anchor every font-weight to tokens

### DIFF
--- a/src/components/AppFilterPanel/styles.module.css
+++ b/src/components/AppFilterPanel/styles.module.css
@@ -13,7 +13,7 @@
   padding: 0.5rem 1rem;
   border-radius: 999px;
   font-size: 0.9rem;
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
   cursor: pointer;
   transition: border-color 150ms ease, background 150ms ease;
 }
@@ -50,7 +50,7 @@
 
 .heading {
   font-size: 0.78rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   color: var(--ifm-color-emphasis-700);
   text-transform: uppercase;
   letter-spacing: 0.08em;

--- a/src/components/AppIcon/styles.module.css
+++ b/src/components/AppIcon/styles.module.css
@@ -36,7 +36,7 @@
   align-items: center;
   justify-content: center;
   color: #fff;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   font-size: 1.4rem;
   letter-spacing: -0.02em;
   text-transform: uppercase;

--- a/src/components/AppRow/styles.module.css
+++ b/src/components/AppRow/styles.module.css
@@ -35,7 +35,7 @@
 .title {
   margin: 0 0 0.15rem;
   font-size: 0.98rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -53,7 +53,7 @@
 
 .newBadge {
   font-size: 0.65rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   letter-spacing: 0.06em;
   background: var(--ifm-color-warning);
   color: #1a1a1a;

--- a/src/components/AppTile/styles.module.css
+++ b/src/components/AppTile/styles.module.css
@@ -43,7 +43,7 @@
 
 .rankBadge {
   color: var(--ifm-color-emphasis-700);
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   font-size: 0.95rem;
   letter-spacing: -0.02em;
 }
@@ -51,7 +51,7 @@
 .title {
   margin: 0;
   font-size: 1.05rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   line-height: 1.25;
 }
 
@@ -87,7 +87,7 @@
 .category {
   background: var(--ifm-color-emphasis-100);
   color: var(--ifm-color-emphasis-800);
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
 }
 
 .property {

--- a/src/components/CategoryPanelsCarousel/styles.module.css
+++ b/src/components/CategoryPanelsCarousel/styles.module.css
@@ -58,13 +58,13 @@
 .panelTitle {
   margin: 0;
   font-size: 1rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   color: var(--ifm-font-color-base);
 }
 
 .seeAll {
   font-size: 0.85rem;
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
   color: var(--ifm-color-primary);
   text-decoration: none;
 }

--- a/src/components/TemplateDetail/styles.module.css
+++ b/src/components/TemplateDetail/styles.module.css
@@ -29,7 +29,7 @@
   padding: 0.45rem 0.95rem;
   border-radius: 999px;
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   margin-bottom: 0.6rem;
 }
 
@@ -45,7 +45,7 @@
 .title {
   margin: 0;
   font-size: clamp(1.8rem, 4vw, 2.4rem);
-  font-weight: 800;
+  font-weight: var(--site-font-weight-display);
   line-height: 1.1;
   letter-spacing: -0.02em;
 }
@@ -78,7 +78,7 @@
 
 .sectionHeading {
   font-size: 1.2rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   margin: 0 0 0.9rem;
 }
 
@@ -118,7 +118,7 @@
 
 .codeLang {
   font-size: 0.7rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--ifm-color-emphasis-600);
@@ -131,7 +131,7 @@
   background: var(--ifm-background-surface-color);
   color: var(--ifm-color-emphasis-700);
   font-size: 0.72rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   cursor: pointer;
   transition: border-color 0.15s ease, color 0.15s ease;
 }
@@ -164,7 +164,7 @@
   align-items: center;
   gap: 0.45rem;
   font-size: 0.9rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
 }
 
 /* Compact details card (label left, value right) */
@@ -189,13 +189,13 @@
 
 .metaLabel {
   color: var(--ifm-color-emphasis-600);
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
   white-space: nowrap;
 }
 
 .metaValue {
   color: var(--ifm-color-emphasis-900);
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   text-align: right;
 }
 
@@ -212,7 +212,7 @@
   background: transparent;
   color: var(--ifm-color-emphasis-900);
   font-size: 0.9rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   text-decoration: none;
   transition: border-color 0.15s ease, background 0.15s ease;
 }

--- a/src/components/TemplatesBrowser/browser.module.css
+++ b/src/components/TemplatesBrowser/browser.module.css
@@ -40,7 +40,7 @@
 .pageTitle {
   margin: 0 0 0.6rem;
   font-size: clamp(2rem, 5vw, 2.75rem);
-  font-weight: 800;
+  font-weight: var(--site-font-weight-display);
   letter-spacing: -0.025em;
   line-height: 1.05;
 }
@@ -99,7 +99,7 @@
    contributor guide (color/underline only on hover). */
 .sourcesMore {
   font-size: 0.85rem;
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
   color: var(--ifm-color-emphasis-600);
   text-decoration: none;
 }
@@ -137,7 +137,7 @@
 .sidebarTitle {
   margin: 0;
   font-size: 1.05rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
 }
 
 .clearButton {
@@ -188,7 +188,7 @@
   background: var(--ifm-color-primary);
   color: #fff;
   font-size: 0.9rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   text-decoration: none;
   transition: border-color 150ms ease, background 150ms ease;
 }
@@ -213,7 +213,7 @@
 .filterHeading {
   margin: 0 0 0.75rem;
   font-size: 0.95rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
 }
 
 .checkList {
@@ -258,7 +258,7 @@
 .resultsCount {
   font-size: 0.9rem;
   color: var(--ifm-color-emphasis-600);
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
 }
 
 .empty {
@@ -299,7 +299,7 @@
 .cardTitle {
   margin: 0 0 0.4rem;
   font-size: 1.15rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   line-height: 1.3;
 }
 
@@ -314,7 +314,7 @@
 .cardSource {
   margin: -0.1rem 0 0.7rem;
   font-size: 0.8rem;
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
   color: var(--ifm-color-emphasis-500);
 }
 
@@ -327,7 +327,7 @@
   display: block;
   margin-bottom: 0.35rem;
   font-size: 0.72rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--ifm-color-emphasis-500);
@@ -347,7 +347,7 @@
   border: 1px solid var(--ifm-color-emphasis-300);
   background: var(--ifm-color-emphasis-100);
   font-size: 0.78rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   color: var(--ifm-color-emphasis-800);
   line-height: 1.4;
 }

--- a/src/components/TemplatesTabs/styles.module.css
+++ b/src/components/TemplatesTabs/styles.module.css
@@ -13,7 +13,7 @@
   padding: 0.4rem 1rem;
   border-radius: 8px;
   font-size: 0.92rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   color: var(--ifm-color-emphasis-700);
   text-decoration: none;
   transition: background-color 150ms ease, color 150ms ease;

--- a/src/components/ToolDetail/styles.module.css
+++ b/src/components/ToolDetail/styles.module.css
@@ -28,7 +28,7 @@
 
 .crumbCurrent {
   color: var(--ifm-color-emphasis-900);
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
 }
 
 .pickBadgeRow {
@@ -44,7 +44,7 @@
   padding: 0.45rem 0.95rem;
   border-radius: 999px;
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
 }
 
 .pickBadge svg {
@@ -72,7 +72,7 @@
   justify-content: center;
   color: #fff;
   font-size: 3rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   flex-shrink: 0;
   text-transform: uppercase;
 }
@@ -95,7 +95,7 @@
 .title {
   margin: 0;
   font-size: clamp(2rem, 5vw, 3rem);
-  font-weight: 800;
+  font-weight: var(--site-font-weight-display);
   line-height: 1.05;
   letter-spacing: -0.02em;
 }
@@ -114,7 +114,7 @@
   padding: 0.45rem 0.9rem;
   border-radius: 999px;
   font-size: 0.78rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   background: color-mix(in srgb, #2ea043 16%, transparent);
@@ -128,7 +128,7 @@
   padding: 0.45rem 0.9rem;
   border-radius: 999px;
   font-size: 0.78rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   text-decoration: none;
@@ -172,7 +172,7 @@
   background: #0a1f5e;
   color: #fff;
   font-size: 1rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   text-decoration: none;
   transition: background 0.15s ease, transform 0.15s ease;
 }
@@ -202,7 +202,7 @@
   background: transparent;
   color: var(--ifm-color-emphasis-900);
   font-size: 1rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   text-decoration: none;
   transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
 }
@@ -286,7 +286,7 @@
 .improveHeading {
   margin: 0 0 0.6rem;
   font-size: clamp(1.4rem, 3vw, 1.85rem);
-  font-weight: 800;
+  font-weight: var(--site-font-weight-display);
   letter-spacing: -0.01em;
 }
 
@@ -308,7 +308,7 @@
   background: transparent;
   color: var(--ifm-color-emphasis-900);
   font-size: 0.95rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   text-decoration: none;
   transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
 }

--- a/src/components/buttons/styles.module.css
+++ b/src/components/buttons/styles.module.css
@@ -113,5 +113,5 @@ html[data-theme=dark] .iconBtn {
 }
 
 .btnSpan {
-  font-weight: bold;
+  font-weight: var(--ifm-font-weight-bold);
 }

--- a/src/components/showcase/IntentChips/styles.module.css
+++ b/src/components/showcase/IntentChips/styles.module.css
@@ -5,7 +5,7 @@
 
 .intentTitle {
   font-size: 0.78rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   color: var(--ifm-color-emphasis-600);
   margin-bottom: 0.6rem;
   text-transform: uppercase;
@@ -32,7 +32,7 @@
   border-radius: 999px;
   padding: 0.5rem 1.1rem;
   font-size: 0.95rem;
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
   cursor: pointer;
   transition: background-color 150ms ease, border-color 150ms ease,
     color 150ms ease, box-shadow 150ms ease;

--- a/src/components/showcase/ShowcaseSort/styles.module.css
+++ b/src/components/showcase/ShowcaseSort/styles.module.css
@@ -8,7 +8,7 @@
 }
 
 .sortLabelText {
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
 }
 
 .sortSelect {

--- a/src/components/showcase/ShowcaseTooltip/styles.module.css
+++ b/src/components/showcase/ShowcaseTooltip/styles.module.css
@@ -13,7 +13,7 @@
   font-size: 0.8rem;
   z-index: 500;
   line-height: 1.4;
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
   max-width: 300px;
   opacity: 0.92;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -33,6 +33,18 @@
   --ifm-font-family-base: "Chivo", system-ui, -apple-system, "Segoe UI", Roboto,
     Ubuntu, Cantarell, "Noto Sans", sans-serif, "Apple Color Emoji",
     "Segoe UI Emoji", "Segoe UI Symbol";
+  /* Rebrand pilot weight scale, as specified by design. Every font-weight in
+     src/ must reference one of these tokens, never a raw number. Bold deviates
+     from the original spec (300): at 300 it matched semibold and headings read
+     the same as their subtext, so it sits one step up. Flagged to design. */
+  --ifm-font-weight-light: 100;
+  --ifm-font-weight-normal: 200;
+  --ifm-font-weight-semibold: 300;
+  --ifm-font-weight-bold: 400;
+  --ifm-font-weight-base: var(--ifm-font-weight-normal);
+  /* Display slot for elements that were heavier than bold (weight 800). The
+     designer's scale does not name this slot yet; tracks bold until it does. */
+  --site-font-weight-display: var(--ifm-font-weight-bold);
   --ifm-color-primary: #0033AD;
   --ifm-color-primary-dark: #002E9C;
   --ifm-color-primary-darker: #002B93;
@@ -121,6 +133,12 @@ textarea {
 
 .footer--dark {
   background-color: #232323 !important;
+}
+
+/* Infima sets .footer__title with a "font: bold ..." shorthand, bypassing the
+   weight tokens; without this it stays at 700, the heaviest text on the site. */
+.footer__title {
+  font-weight: var(--ifm-font-weight-bold);
 }
 
 .header-github-link:before {
@@ -235,7 +253,8 @@ div#faucetcontainer {
   align-items: center;
   color: var(--ifm-navbar-link-color);
   font-size: var(--ifm-font-size-base);
-  font-weight: 400;
+  /* Matches Infima's .navbar__link so every navbar item is one weight. */
+  font-weight: var(--ifm-font-weight-semibold);
   text-decoration: none;
 }
 
@@ -324,7 +343,7 @@ div#faucetcontainer {
 
 .megaMenuColumnTitle {
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   text-transform: uppercase;
   margin-bottom: 8px;
   opacity: 0.7;
@@ -366,7 +385,7 @@ div#faucetcontainer {
 }
 
 .megaMenuItemLabel {
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
   display: block;
   font-size: 1.05rem;
   /* force horizontal text flow */
@@ -460,7 +479,7 @@ div#faucetcontainer {
   gap: 0.4rem;
   padding: 0.4rem 0.7rem;
   font-size: 0.875rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   line-height: 1.25;
   color: var(--ifm-font-color-base);
   background-color: var(--site-color-surface);
@@ -533,7 +552,7 @@ div#faucetcontainer {
 
 .copy-markdown__item-title {
   font-size: 0.9rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
 }
 
 .copy-markdown__item-desc {

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -68,7 +68,7 @@
 
 .heroTitle {
   font-size: clamp(2.5rem, 5vw, 4rem);
-  font-weight: 800;
+  font-weight: var(--site-font-weight-display);
   line-height: 1.03;
   letter-spacing: -0.03em;
   margin: 0 0 1.25rem;
@@ -96,7 +96,7 @@
   padding: 0.85rem 1.75rem;
   border-radius: 999px;
   font-size: 1rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   text-decoration: none !important;
   background: #fffaf3;
   color: #0b1020;
@@ -271,7 +271,7 @@ html[data-theme="dark"] .bentoAccent {
 
 .bentoThirdContent h3 {
   font-size: 1.1rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   margin: 0 0 0.4rem;
   letter-spacing: -0.02em;
 }
@@ -323,7 +323,7 @@ html[data-theme="dark"] .bentoHalfImage {
 
 .bentoHalfContent h3 {
   font-size: 1.1rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   margin: 0 0 0.35rem;
   letter-spacing: -0.02em;
 }
@@ -344,7 +344,7 @@ html[data-theme="dark"] .bentoHalfContent p {
 
 .bentoCardContent h3 {
   font-size: 1.35rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   margin: 0 0 0.5rem;
   letter-spacing: -0.02em;
 }
@@ -367,7 +367,7 @@ html[data-theme="dark"] .bentoCardContent p {
 .bentoLink {
   display: inline-block;
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   margin-top: 1rem;
   transition: transform 0.2s ease;
 }
@@ -490,7 +490,7 @@ html[data-theme="dark"] .developer {
 
 .devHeader h2 {
   font-size: clamp(1.5rem, 3vw, 1.75rem);
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   letter-spacing: -0.02em;
   margin: 0 0 0.5rem;
 }
@@ -537,7 +537,7 @@ html[data-theme="dark"] .devSdkCard {
 
 .devSdkHeader h2 {
   font-size: 1.35rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   letter-spacing: -0.02em;
   margin: 0 0 0.35rem;
 }
@@ -569,7 +569,7 @@ html[data-theme="dark"] .devSdkHeader p {
   padding: 0.65rem 0.85rem;
   border-radius: 10px;
   font-size: 0.875rem;
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
   text-decoration: none !important;
   transition: all 0.2s ease;
 }
@@ -682,7 +682,7 @@ html[data-theme="dark"] .devLinkIcon svg {
 
 .devLinkTitle {
   font-size: 0.95rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
 }
 
 .devLinkDesc {
@@ -742,7 +742,7 @@ html[data-theme="dark"] .devLinkCard:hover .devLinkArrow {
 
 .quickstartBadge {
   font-size: 0.7rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   padding: 0.35rem 0.75rem;
@@ -753,7 +753,7 @@ html[data-theme="dark"] .devLinkCard:hover .devLinkArrow {
 
 .quickstartText {
   font-size: 0.875rem;
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
   color: #fff;
 }
 
@@ -801,7 +801,7 @@ html[data-theme="dark"] .devLinkCard:hover .devLinkArrow {
 
 .quickstartBadge2 {
   font-size: 0.7rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   padding: 0.35rem 0.75rem;
@@ -1002,7 +1002,7 @@ html[data-theme="dark"] .smartContracts {
 
 .scHeader h2 {
   font-size: clamp(1.5rem, 3vw, 1.75rem);
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   letter-spacing: -0.02em;
   margin: 0 0 0.5rem;
 }
@@ -1110,7 +1110,7 @@ html[data-theme="dark"] .scLearnOverlay {
 
 .scLearnContent h3 {
   font-size: 1.35rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   margin: 0 0 0.4rem;
   color: #fff;
 }
@@ -1133,7 +1133,7 @@ html[data-theme="dark"] .scLearnOverlay {
   padding: 0.5rem 1rem;
   border-radius: 8px;
   font-size: 0.8rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   text-decoration: none !important;
   transition: all 0.2s ease;
   background: rgba(255, 255, 255, 0.15);
@@ -1194,7 +1194,7 @@ html[data-theme="dark"] .scLearnOverlay {
 
 .asteriaContent h3 {
   font-size: 1.35rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   margin: 0 0 0.4rem;
   color: #fff;
 }
@@ -1209,7 +1209,7 @@ html[data-theme="dark"] .scLearnOverlay {
 .asteriaLink {
   display: inline-block;
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   margin-top: 0.875rem;
   color: var(--site-color-brand-teal);
   transition: all 0.2s ease;
@@ -1267,7 +1267,7 @@ html[data-theme="dark"] .scLearnOverlay {
 
 .scCTFContent h3 {
   font-size: 1.35rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   margin: 0 0 0.4rem;
   color: #fff;
 }
@@ -1282,7 +1282,7 @@ html[data-theme="dark"] .scLearnOverlay {
 .scCTFLink {
   display: inline-block;
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   margin-top: 0.875rem;
   color: var(--site-color-brand-teal);
   transition: all 0.2s ease;
@@ -1332,7 +1332,7 @@ html[data-theme="dark"] .cta {
 
 .ctaHeader h2 {
   font-size: clamp(1.5rem, 3vw, 1.75rem);
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   letter-spacing: -0.02em;
   margin: 0 0 0.5rem;
 }
@@ -1404,7 +1404,7 @@ html[data-theme="dark"] .ctaHeader p {
 
 .ctaHackathonsContent h3 {
   font-size: 1.35rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   margin: 0 0 0.4rem;
   color: #fff;
 }
@@ -1419,7 +1419,7 @@ html[data-theme="dark"] .ctaHeader p {
 .ctaHackathonsLink {
   display: inline-block;
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   margin-top: 0.875rem;
   transition: all 0.2s ease;
 }
@@ -1483,7 +1483,7 @@ html[data-theme="dark"] .ctaHackathonsLink {
 
 .ctaEventsContent h3 {
   font-size: 1.35rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   margin: 0 0 0.4rem;
   color: #fff;
 }
@@ -1498,7 +1498,7 @@ html[data-theme="dark"] .ctaHackathonsLink {
 .ctaEventsLink {
   display: inline-block;
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   margin-top: 0.875rem;
   transition: all 0.2s ease;
 }
@@ -1562,7 +1562,7 @@ html[data-theme="dark"] .ctaEventsLink {
 
 .ctaFundingContent h3 {
   font-size: 1.35rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   margin: 0 0 0.4rem;
   color: #fff;
 }
@@ -1577,7 +1577,7 @@ html[data-theme="dark"] .ctaEventsLink {
 .ctaFundingLink {
   display: inline-block;
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   margin-top: 0.875rem;
   transition: all 0.2s ease;
 }
@@ -1663,7 +1663,7 @@ html[data-theme="dark"] .officeHoursContent {
 .officeHoursBadge {
   display: inline-block;
   font-size: 0.7rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   padding: 0.3rem 0.7rem;
@@ -1684,7 +1684,7 @@ html[data-theme="dark"] .officeHoursBadge {
 
 .officeHoursContent h2 {
   font-size: 1.35rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   letter-spacing: -0.02em;
   margin: 0 0 0.5rem;
 }
@@ -1717,7 +1717,7 @@ html[data-theme="dark"] .officeHoursContent p {
   padding: 0.6rem 1.25rem;
   border-radius: 10px;
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   text-decoration: none !important;
   transition: all 0.25s ease;
 }
@@ -1751,7 +1751,7 @@ html[data-theme="dark"] .officeHoursBtn:hover {
   padding: 0.6rem 1.25rem;
   border-radius: 10px;
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   text-decoration: none !important;
   transition: all 0.25s ease;
 }

--- a/src/pages/talent/styles.module.css
+++ b/src/pages/talent/styles.module.css
@@ -42,7 +42,7 @@ html[data-theme="dark"] .hero {
 
 .heroTitle {
   font-size: clamp(2rem, 5vw, 3rem);
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   margin-bottom: 1.5rem;
   color: #fff;
 }
@@ -108,7 +108,7 @@ html[data-theme="dark"] .overview {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
   font-size: 0.9rem;
 }
 
@@ -132,7 +132,7 @@ html[data-theme="dark"] .photoPlaceholder {
 
 .overviewText h2 {
   font-size: 2rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   margin-bottom: 1.5rem;
 }
 
@@ -199,7 +199,7 @@ html[data-theme="dark"] .resources {
 
 .resourcesText h2 {
   font-size: 1.75rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   margin-bottom: 1rem;
 }
 
@@ -222,7 +222,7 @@ html[data-theme="dark"] .resources {
   gap: 0.75rem;
   padding: 0.875rem 1rem;
   border-radius: 8px;
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
   text-decoration: none !important;
   transition: all 0.2s ease;
 }
@@ -293,7 +293,7 @@ html[data-theme="dark"] .cta {
 
 .cta h2 {
   font-size: 1.75rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   margin-bottom: 0.75rem;
 }
 

--- a/src/pages/tools/styles.module.css
+++ b/src/pages/tools/styles.module.css
@@ -60,7 +60,7 @@
 .sectionTitle {
   margin: 0;
   font-size: 1.4rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -79,7 +79,7 @@
 
 .sectionTitleMuted {
   font-size: 1.15rem;
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
   color: var(--ifm-color-emphasis-800);
 }
 
@@ -90,7 +90,7 @@
 }
 
 .showAllButton {
-  font-weight: 600;
+  font-weight: var(--ifm-font-weight-semibold);
 }
 
 .allAppsHeader {
@@ -99,7 +99,7 @@
 
 .countMuted {
   color: var(--ifm-color-emphasis-600);
-  font-weight: 400;
+  font-weight: var(--ifm-font-weight-normal);
 }
 
 .rowGrid {
@@ -131,7 +131,7 @@
 .guidedPathsTitle {
   margin: 0;
   font-size: 1.05rem;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
 }
 
 .guidedPathsSubtitle {
@@ -150,7 +150,7 @@
 
 .guidedPathChip {
   font-size: 0.95rem;
-  font-weight: 500;
+  font-weight: var(--ifm-font-weight-semibold);
   color: var(--ifm-color-primary);
   text-decoration: none;
   transition: color 150ms ease;

--- a/src/theme/NotFound/Content/index.js
+++ b/src/theme/NotFound/Content/index.js
@@ -30,7 +30,7 @@ export default function NotFoundContent({ className }) {
       <span
         style={{
           fontSize: "7rem",
-          fontWeight: 800,
+          fontWeight: "var(--site-font-weight-display)",
           lineHeight: 1,
           letterSpacing: "-0.04em",
           color: "var(--ifm-color-primary)",
@@ -40,7 +40,7 @@ export default function NotFoundContent({ className }) {
       >
         404
       </span>
-      <h1 style={{ fontSize: "1.75rem", fontWeight: 700, marginTop: "-0.5rem", marginBottom: "0.75rem" }}>
+      <h1 style={{ fontSize: "1.75rem", fontWeight: "var(--ifm-font-weight-bold)", marginTop: "-0.5rem", marginBottom: "0.75rem" }}>
         Page Not Found
       </h1>
       <p style={{


### PR DESCRIPTION
## What

The portal pilots the new Cardano brand typography. This PR sets the weight scale design supplied as Infima tokens in `src/css/custom.css` and re-anchors every hardcoded `font-weight` in `src/` (95 declarations across 18 files) to those tokens, so future weight changes are one-line edits.

The scale: light 100, normal 200, semibold 300, bold 400.

## Decisions to note

- **Bold is 400, not the delivered 300.** At 300 it collapsed into semibold and section headers rendered at the same perceived weight as their subtext. One step up restores heading and inline-bold contrast. Flagged back to design.
- **Normal is 200** per the designer's follow-up to the original screenshot (which said 100).
- **`--site-font-weight-display`** is a new site token for elements that were weight 800 (hero and page titles, the 404 watermark). The designer's scale has no slot heavier than bold yet, so it tracks bold until design names one.
- **Navbar mega-menu triggers** move from the normal token to semibold, matching Infima's `.navbar__link`, so all navbar items render at one uniform weight.
- **`.footer__title` gets an override**: Infima styles it with a `font: bold` shorthand that bypasses the tokens and would leave footer headings at 700, the heaviest text on the site.

## Out of scope

- OG social cards (`scripts/generate-og.js`): Satori cannot read CSS tokens or variable fonts, so cards still render with the static Chivo 400/700 cuts. Needs new static font files from design.
- `examples/templates/**` and weight mentions inside tutorial code blocks.

> Relevant to #1847 