### PR TITLE
2026 rebrand round 6: docs reading experience

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,49 +8,53 @@ const isAnnouncementActive = true;
 // There are various equivalent ways to declare the Docusaurus config.
 // See: https://docusaurus.io/docs/api/docusaurus-config
 
-// One Light palette
+// 2026 brand code themes. Token shades are tuned for AA contrast against
+// their code background; interface colors stay in src/css/custom.css.
+// Light: warm paper panel, slightly deeper than the cream page, with ink
+// text and brand-blue keywords.
 const prismLightTheme = {
   plain: {
-    color: '#383a42',
-    backgroundColor: '#fafafa',
+    color: '#111425',
+    backgroundColor: '#F6F0E6',
   },
   styles: [
-    { types: ['comment', 'prolog', 'cdata'], style: { color: '#a0a1a7', fontStyle: 'italic' } },
-    { types: ['keyword', 'operator'], style: { color: '#a626a4' } },
-    { types: ['string', 'char', 'regex', 'attr-value'], style: { color: '#50a14f' } },
-    { types: ['number'], style: { color: '#986801' } },
-    { types: ['boolean', 'constant'], style: { color: '#986801' } },
-    { types: ['class-name'], style: { color: '#c18401' } },
-    { types: ['function'], style: { color: '#4078f2' } },
-    { types: ['tag', 'deleted'], style: { color: '#e45649' } },
-    { types: ['attr-name'], style: { color: '#986801' } },
-    { types: ['namespace'], style: { color: '#383a42' } },
-    { types: ['punctuation'], style: { color: '#383a42' } },
-    { types: ['inserted'], style: { color: '#50a14f' } },
-    { types: ['builtin'], style: { color: '#4078f2' } },
+    { types: ['comment', 'prolog', 'cdata'], style: { color: '#5F6B85', fontStyle: 'italic' } },
+    { types: ['keyword', 'operator'], style: { color: '#0033AD' } },
+    { types: ['string', 'char', 'regex', 'attr-value'], style: { color: '#2E7D32' } },
+    { types: ['number'], style: { color: '#8A5D00' } },
+    { types: ['boolean', 'constant'], style: { color: '#8A5D00' } },
+    { types: ['class-name'], style: { color: '#8F6100' } },
+    { types: ['function'], style: { color: '#6D5FA8' } },
+    { types: ['tag', 'deleted'], style: { color: '#B3362B' } },
+    { types: ['attr-name'], style: { color: '#8A5D00' } },
+    { types: ['namespace'], style: { color: '#111425' } },
+    { types: ['punctuation'], style: { color: '#3F4762' } },
+    { types: ['inserted'], style: { color: '#2E7D32' } },
+    { types: ['builtin'], style: { color: '#6D5FA8' } },
   ],
 };
 
-// One Dark palette
+// Dark: code blocks join the navy chrome (navbar, footer, cards), with
+// warm off-white text and the periwinkle/amber/lavender accent set.
 const prismDarkTheme = {
   plain: {
-    color: '#abb2bf',
-    backgroundColor: '#282c34',
+    color: '#E8E4DC',
+    backgroundColor: '#000629',
   },
   styles: [
-    { types: ['comment', 'prolog', 'cdata'], style: { color: '#5c6370', fontStyle: 'italic' } },
-    { types: ['keyword', 'operator'], style: { color: '#c678dd' } },
-    { types: ['string', 'char', 'regex', 'attr-value'], style: { color: '#98c379' } },
-    { types: ['number'], style: { color: '#d19a66' } },
-    { types: ['boolean', 'constant'], style: { color: '#d19a66' } },
-    { types: ['class-name'], style: { color: '#e6c07b' } },
-    { types: ['function'], style: { color: '#61aeee' } },
-    { types: ['tag', 'deleted'], style: { color: '#e06c75' } },
-    { types: ['attr-name'], style: { color: '#d19a66' } },
-    { types: ['namespace'], style: { color: '#abb2bf' } },
-    { types: ['punctuation'], style: { color: '#abb2bf' } },
-    { types: ['inserted'], style: { color: '#98c379' } },
-    { types: ['builtin'], style: { color: '#61aeee' } },
+    { types: ['comment', 'prolog', 'cdata'], style: { color: 'rgba(232, 228, 220, 0.55)', fontStyle: 'italic' } },
+    { types: ['keyword', 'operator'], style: { color: '#7E97D7' } },
+    { types: ['string', 'char', 'regex', 'attr-value'], style: { color: '#86C994' } },
+    { types: ['number'], style: { color: '#FFB122' } },
+    { types: ['boolean', 'constant'], style: { color: '#FFB122' } },
+    { types: ['class-name'], style: { color: '#FFCF87' } },
+    { types: ['function'], style: { color: '#C7C2E6' } },
+    { types: ['tag', 'deleted'], style: { color: '#E0776F' } },
+    { types: ['attr-name'], style: { color: '#FFB122' } },
+    { types: ['namespace'], style: { color: '#E8E4DC' } },
+    { types: ['punctuation'], style: { color: 'rgba(232, 228, 220, 0.7)' } },
+    { types: ['inserted'], style: { color: '#86C994' } },
+    { types: ['builtin'], style: { color: '#C7C2E6' } },
   ],
 };
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -834,6 +834,59 @@ html[data-theme="dark"] .tabs__item:focus-visible,
   outline-color: var(--site-color-amber);
 }
 
+/* Admonitions on the brand palette: warning and caution ride amber, info
+   and its important alias ride brand blue, note goes neutral; tip and
+   danger keep Infima's
+   conventional green and red. Only background and border move: foreground
+   and icon stay on Infima's contrast sets, which already adapt per theme.
+   The .alert prefix out-specifies Infima's .alert--type blocks instead of
+   relying on stylesheet order. <details> is named explicitly because it
+   renders as alert--info without a theme-admonition class; its summary
+   arrow follows the border color. */
+.alert.theme-admonition-warning,
+.alert.theme-admonition-caution {
+  --ifm-alert-background-color: rgb(var(--site-color-amber-rgb) / 0.12);
+  --ifm-alert-border-color: var(--site-color-amber);
+}
+
+.alert.theme-admonition-info,
+.alert.theme-admonition-important,
+details.alert--info {
+  --ifm-alert-background-color: rgb(var(--site-color-brand-blue-rgb) / 0.07);
+  --ifm-alert-border-color: var(--site-color-brand-blue);
+}
+
+.alert.theme-admonition-note {
+  --ifm-alert-background-color: rgb(var(--site-color-navy-rgb) / 0.04);
+  --ifm-alert-border-color: rgb(var(--site-color-navy-rgb) / 0.35);
+}
+
+html[data-theme="dark"] .alert.theme-admonition-warning,
+html[data-theme="dark"] .alert.theme-admonition-caution {
+  --ifm-alert-background-color: rgb(var(--site-color-amber-rgb) / 0.15);
+}
+
+html[data-theme="dark"] .alert.theme-admonition-info,
+html[data-theme="dark"] .alert.theme-admonition-important,
+html[data-theme="dark"] details.alert--info {
+  --ifm-alert-background-color: rgba(255, 255, 255, 0.05);
+  --ifm-alert-border-color: var(--ifm-color-primary);
+}
+
+html[data-theme="dark"] .alert.theme-admonition-note {
+  --ifm-alert-background-color: rgba(255, 255, 255, 0.04);
+  --ifm-alert-border-color: var(--site-color-card-border);
+}
+
+/* Uppercase admonition titles read spindly at the Light 300 heading
+   weight. The heading div carries only a hashed class, so it is reached
+   structurally; :not(:only-child) restricts the rule to admonitions that
+   render both heading and content, since a lone div could be a title-less
+   body that must not turn bold. */
+.theme-admonition > div:first-child:not(:only-child) {
+  font-weight: var(--ifm-font-weight-semibold);
+}
+
 /* "Copy page" dropdown in the docs breadcrumb row
  * (rendered by src/theme/DocBreadcrumbs via src/components/CopyMarkdownActions) */
 .docbreadcrumbs-with-actions {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -112,7 +112,7 @@
   --ifm-navbar-link-color: #ffffff;
   /* The logo sits ~52px in from the edge on wide screens (3vw, clamped) */
   --ifm-navbar-padding-horizontal: clamp(1rem, 3vw, 52px);
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --docusaurus-highlighted-code-line-bg: rgb(var(--site-color-navy-rgb) / 0.08);
   /* Docs chrome (sidebar, TOC, breadcrumbs, tables, blockquotes). Infima
      adapts these vars in dark mode through its emphasis scale or its own
      dark block; a direct override detaches from both, so every var set
@@ -148,7 +148,7 @@ html[data-theme="dark"] {
      specificity and wins on load order, so dark mode must re-declare it. */
   --ifm-font-color-base: #e3e3e3;
   --site-color-text-muted: rgba(255, 255, 255, 0.65);
-  --docusaurus-highlighted-code-line-bg: rgb(72, 77, 91);
+  --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.09);
   /* Docs chrome, dark half: the :root overrides above detach these vars
      from Infima's own dark adaptation, so each one is restated here. */
   --ifm-menu-color: rgb(var(--site-color-cream-rgb) / 0.7);
@@ -885,6 +885,26 @@ html[data-theme="dark"] .alert.theme-admonition-note {
    body that must not turn bold. */
 .theme-admonition > div:first-child:not(:only-child) {
   font-weight: var(--ifm-font-weight-semibold);
+}
+
+/* Code block chrome. The title bar and buttons carry only hashed module
+   classes, so they are reached through the stable .theme-code-block
+   ancestor (upstream keys button visibility off the same class). The
+   title-bar div only renders when a block sets a title. */
+.theme-code-block > div:first-child:not(:only-child) {
+  border-bottom: 1px solid rgb(var(--site-color-navy-rgb) / 0.12);
+}
+
+.theme-code-block .clean-btn {
+  border: 1px solid rgb(var(--site-color-navy-rgb) / 0.15);
+}
+
+html[data-theme="dark"] .theme-code-block > div:first-child:not(:only-child) {
+  border-bottom-color: var(--site-color-card-border);
+}
+
+html[data-theme="dark"] .theme-code-block .clean-btn {
+  border-color: var(--site-color-card-border);
 }
 
 /* "Copy page" dropdown in the docs breadcrumb row

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -113,6 +113,20 @@
   /* The logo sits ~52px in from the edge on wide screens (3vw, clamped) */
   --ifm-navbar-padding-horizontal: clamp(1rem, 3vw, 52px);
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  /* Docs chrome (sidebar, TOC, breadcrumbs, tables, blockquotes). Infima
+     adapts these vars in dark mode through its emphasis scale or its own
+     dark block; a direct override detaches from both, so every var set
+     here is re-declared in the dark block below. */
+  --ifm-menu-color: var(--site-color-ink-muted);
+  --ifm-menu-color-active: var(--site-color-brand-blue);
+  --ifm-menu-color-background-active: rgb(var(--site-color-navy-rgb) / 0.05);
+  --ifm-menu-color-background-hover: rgb(var(--site-color-navy-rgb) / 0.05);
+  --ifm-toc-border-color: rgb(var(--site-color-navy-rgb) / 0.12);
+  --ifm-toc-link-color: var(--site-color-text-muted);
+  --ifm-breadcrumb-item-background-active: rgb(var(--site-color-navy-rgb) / 0.05);
+  --ifm-breadcrumb-border-radius: 999px;
+  --ifm-table-border-color: rgb(var(--site-color-navy-rgb) / 0.12);
+  --ifm-blockquote-border-color: rgb(var(--site-color-brand-blue-rgb) / 0.35);
 }
 
 html[data-theme="dark"] {
@@ -135,6 +149,16 @@ html[data-theme="dark"] {
   --ifm-font-color-base: #e3e3e3;
   --site-color-text-muted: rgba(255, 255, 255, 0.65);
   --docusaurus-highlighted-code-line-bg: rgb(72, 77, 91);
+  /* Docs chrome, dark half: the :root overrides above detach these vars
+     from Infima's own dark adaptation, so each one is restated here. */
+  --ifm-menu-color: rgb(var(--site-color-cream-rgb) / 0.7);
+  --ifm-menu-color-active: var(--ifm-color-primary);
+  --ifm-menu-color-background-active: rgba(255, 255, 255, 0.06);
+  --ifm-menu-color-background-hover: rgba(255, 255, 255, 0.06);
+  --ifm-toc-border-color: var(--site-color-card-border);
+  --ifm-breadcrumb-item-background-active: rgba(255, 255, 255, 0.06);
+  --ifm-table-border-color: var(--site-color-card-border);
+  --ifm-blockquote-border-color: var(--ifm-color-primary-darker);
 }
 
 /* Form controls do not inherit font-family: the browser's own stylesheet sets
@@ -652,6 +676,162 @@ html[data-theme="dark"] body {
 .megaMenuFeatured:focus-visible {
   outline: 2px solid var(--site-color-amber);
   outline-offset: -2px;
+}
+
+/* --- Docs reading experience ---
+   The docs area on the 2026 brand: variables and CSS on Docusaurus' stable
+   theme-* / Infima classes only. No doc component is swizzled, so theme
+   upgrades keep their markup and accessibility. The matching color tokens
+   live in the :root and dark blocks at the top of this file. */
+
+/* Sidebar: a quiet rail on the page background, scoped to the docs tree
+   (the desktop rail and the drawer's docs pane) so the drawer's primary
+   nav and the blog sidebar keep their own type. Infima sets the whole
+   menu semibold, so the tree resets to normal first and only the
+   top-level category labels carry weight, giving two tiers. Collapsible
+   category rows paint their hover on the list item, so the chip radius
+   goes there as well. */
+.theme-doc-sidebar-menu {
+  font-weight: var(--ifm-font-weight-normal);
+}
+
+.theme-doc-sidebar-menu .menu__link {
+  border-radius: 8px;
+  font-size: 0.9rem;
+}
+
+.theme-doc-sidebar-menu .menu__list-item-collapsible {
+  border-radius: 8px;
+}
+
+.theme-doc-sidebar-item-category-level-1
+  > .menu__list-item-collapsible
+  > .menu__link {
+  font-weight: var(--ifm-font-weight-semibold);
+}
+
+/* The mobile drawer sits on the navy navbar surface in both themes, so its
+   menu rides the drawer's palette instead of the page rail's. The caret
+   filter borrows Infima's own dark-mode inversion, which light mode never
+   applies on its own. */
+.navbar-sidebar {
+  --ifm-menu-color: rgb(var(--site-color-cream-rgb) / 0.7);
+  --ifm-menu-color-active: #ffffff;
+  --ifm-menu-color-background-active: rgba(255, 255, 255, 0.06);
+  --ifm-menu-color-background-hover: rgba(255, 255, 255, 0.06);
+  --ifm-menu-link-sublist-icon-filter: invert(100%) sepia(94%) saturate(17%)
+    hue-rotate(223deg) brightness(104%) contrast(98%);
+}
+
+/* TOC: Infima hardcodes the active color to primary with no variable for
+   it, so the active state needs a rule; the code descendant mirrors
+   upstream's own selector list. Idle links ride --ifm-toc-link-color. */
+.table-of-contents__link--active,
+.table-of-contents__link--active code {
+  color: var(--ifm-color-primary);
+  font-weight: var(--ifm-font-weight-semibold);
+}
+
+/* Breadcrumbs: upstream has no variable for the idle link color. The
+   active crumb keeps its own color through the breadcrumb tokens. */
+.breadcrumbs__link {
+  color: var(--site-color-text-muted);
+}
+
+/* Prev/next: Infima hardcodes the border color (no variable exists), and
+   the guillemets are pseudo-content, so both are replaced here. */
+.pagination-nav__link {
+  border: 1px solid rgb(var(--site-color-navy-rgb) / 0.15);
+  border-radius: 12px;
+}
+
+.pagination-nav__link:hover {
+  border-color: var(--site-color-brand-blue);
+  background: rgb(var(--site-color-navy-rgb) / 0.03);
+  text-decoration: none;
+}
+
+.pagination-nav__sublabel {
+  color: var(--site-color-text-muted);
+}
+
+.pagination-nav__link--prev .pagination-nav__label::before {
+  content: "← ";
+}
+
+.pagination-nav__link--next .pagination-nav__label::after {
+  content: " →";
+}
+
+html[data-theme="dark"] .pagination-nav__link {
+  border-color: var(--site-color-card-border);
+}
+
+html[data-theme="dark"] .pagination-nav__link:hover {
+  border-color: var(--ifm-color-primary);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+/* Category-index cards. Scoped to the docs card class: the global .card
+   also serves the landing page and must not change. */
+.theme-doc-card-container {
+  border: 1px solid rgb(var(--site-color-navy-rgb) / 0.12);
+  border-radius: 12px;
+}
+
+.theme-doc-card-container:hover {
+  border-color: var(--site-color-brand-blue);
+}
+
+html[data-theme="dark"] .theme-doc-card-container {
+  border-color: var(--site-color-card-border);
+}
+
+html[data-theme="dark"] .theme-doc-card-container:hover {
+  border-color: var(--ifm-color-primary);
+}
+
+/* Tabs: the active underline already rides --ifm-tabs-color-active, which
+   resolves to primary in both themes. Rounded top corners and a hover wash
+   bring the row into the chip family. */
+.tabs__item {
+  border-radius: 8px 8px 0 0;
+}
+
+.tabs__item:hover {
+  background: rgb(var(--site-color-navy-rgb) / 0.05);
+}
+
+html[data-theme="dark"] .tabs__item:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+/* Doc footer meta row */
+.theme-last-updated {
+  color: var(--site-color-text-muted);
+}
+
+/* Surface-aware focus rings for the docs chrome, following the site rule:
+   navy ring on light page surfaces, amber on dark ones, amber inside the
+   navy drawer in both themes. */
+.menu__link:focus-visible,
+.breadcrumbs__link:focus-visible,
+.table-of-contents__link:focus-visible,
+.pagination-nav__link:focus-visible,
+.theme-doc-card-container:focus-visible,
+.tabs__item:focus-visible {
+  outline: 2px solid var(--site-color-navy);
+  outline-offset: 2px;
+}
+
+html[data-theme="dark"] .menu__link:focus-visible,
+html[data-theme="dark"] .breadcrumbs__link:focus-visible,
+html[data-theme="dark"] .table-of-contents__link:focus-visible,
+html[data-theme="dark"] .pagination-nav__link:focus-visible,
+html[data-theme="dark"] .theme-doc-card-container:focus-visible,
+html[data-theme="dark"] .tabs__item:focus-visible,
+.navbar-sidebar .menu__link:focus-visible {
+  outline-color: var(--site-color-amber);
 }
 
 /* "Copy page" dropdown in the docs breadcrumb row


### PR DESCRIPTION
## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/cardano-foundation/developer-portal/blob/staging/CONTRIBUTING.md).
- [x] I have run `yarn build` after adding my changes **without getting any errors**.
- [x] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://github.com/cardano-foundation/developer-portal/blob/staging/CONTRIBUTING.md#faq)).

## Updating documentation or Bugfix

Round 6 of the 2026 rebrand: the docs reading experience, in three commits.

## What

- The docs sidebar becomes a quiet brand rail: chip-shaped rows, a two-tier hierarchy with weighted top-level categories, and brand-blue active states. The mobile drawer, which is navy in both themes, gets its own legible palette and a visible caret in light mode.
- The table of contents, breadcrumbs, tables, blockquotes, pagination, and category cards move onto the brand tokens: muted idle states, brand-blue actives and hovers, hairline borders, and arrow glyphs instead of guillemets on prev and next.
- Admonitions map onto the palette: warning and caution ride amber, info and its important alias ride brand blue, note goes neutral. Tip and danger keep their conventional green and red. Collapsible details blocks follow the info treatment.
- Code blocks get brand themes: a warm paper panel with ink text and brand-blue keywords in light mode, and the navy chrome with cream text in dark mode. Every token color clears the 4.5:1 contrast bar on its background.

> Relevant to #1847
