### PR TITLE
Rebrand round 8: the tool detail page

### DIFF
--- a/src/components/AppIcon/index.js
+++ b/src/components/AppIcon/index.js
@@ -4,10 +4,17 @@ import clsx from "clsx";
 
 import styles from "./styles.module.css";
 
+const SIZE_CLASS = {
+  tile: styles.appIconTile,
+  row: styles.appIconRow,
+  detail: styles.appIconDetail,
+};
+
 // Render a tool's icon. Primary path: <img src={app.icon}> via useBaseUrl.
 // Fallback when icon is missing OR fails to load: a neutral letter avatar,
 // the tool's first letter on a navy tile.
-// This UX pass ships without tool icons, so the fallback is what renders.
+// Sizes: "tile" on the card grid, "row" in list rows, "detail" on the tool page.
+// Only the detail icon loads eagerly, since it is above the fold on its page.
 export default function AppIcon({ app, size = "tile", className }) {
   const iconHref = useBaseUrl(app.icon || "");
   const [errored, setErrored] = useState(false);
@@ -18,7 +25,7 @@ export default function AppIcon({ app, size = "tile", className }) {
     <span
       className={clsx(
         styles.appIcon,
-        size === "row" ? styles.appIconRow : styles.appIconTile,
+        SIZE_CLASS[size] ?? SIZE_CLASS.tile,
         className
       )}
       aria-hidden
@@ -30,7 +37,7 @@ export default function AppIcon({ app, size = "tile", className }) {
           src={iconHref}
           alt=""
           className={styles.image}
-          loading="lazy"
+          loading={size === "detail" ? "eager" : "lazy"}
           onError={() => setErrored(true)}
         />
       )}

--- a/src/components/AppIcon/styles.module.css
+++ b/src/components/AppIcon/styles.module.css
@@ -26,6 +26,12 @@ html[data-theme="dark"] .appIcon {
   padding: 4px;
 }
 
+.appIconDetail {
+  width: 120px;
+  height: 120px;
+  padding: 8px;
+}
+
 .image {
   width: 100%;
   height: 100%;
@@ -53,7 +59,22 @@ html[data-theme="dark"] .appIcon {
   font-size: 1.05rem;
 }
 
+.appIconDetail .fallback {
+  font-size: 3rem;
+}
+
 /* The navy tile blends into the dark page without an edge */
 html[data-theme="dark"] .fallback {
   border-color: var(--site-color-card-border);
+}
+
+@media (max-width: 600px) {
+  .appIconDetail {
+    width: 88px;
+    height: 88px;
+  }
+
+  .appIconDetail .fallback {
+    font-size: 2.2rem;
+  }
 }

--- a/src/components/ToolDetail/index.js
+++ b/src/components/ToolDetail/index.js
@@ -3,7 +3,6 @@ import Layout from "@theme/Layout";
 import Head from "@docusaurus/Head";
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
-import useBaseUrl from "@docusaurus/useBaseUrl";
 import clsx from "clsx";
 
 import {
@@ -11,6 +10,7 @@ import {
   Properties,
   Showcases,
 } from "@site/src/data/builder-tools/showcase";
+import AppIcon from "@site/src/components/AppIcon";
 import AppTile from "@site/src/components/AppTile";
 import Tooltip from "@site/src/components/showcase/ShowcaseTooltip/index";
 import InfoDot from "@site/src/components/showcase/InfoDot";
@@ -209,18 +209,7 @@ export default function ToolDetail({ slug }) {
         )}
 
         <header className={styles.header}>
-          {tool.icon ? (
-            <img
-              className={styles.iconImage}
-              src={useBaseUrl(tool.icon)}
-              alt=""
-              aria-hidden
-            />
-          ) : (
-            <div className={styles.iconFallback} aria-hidden>
-              {tool.title.charAt(0).toUpperCase()}
-            </div>
-          )}
+          <AppIcon app={tool} size="detail" />
           <div className={styles.headerText}>
             <h1 className={styles.title}>{tool.title}</h1>
           </div>

--- a/src/components/ToolDetail/index.js
+++ b/src/components/ToolDetail/index.js
@@ -12,6 +12,7 @@ import {
 } from "@site/src/data/builder-tools/showcase";
 import AppIcon from "@site/src/components/AppIcon";
 import AppTile from "@site/src/components/AppTile";
+import PageCTA from "@site/src/components/PageCTA";
 import Tooltip from "@site/src/components/showcase/ShowcaseTooltip/index";
 import InfoDot from "@site/src/components/showcase/InfoDot";
 
@@ -136,12 +137,16 @@ function ShareButton({ title }) {
 function NotFound() {
   return (
     <Layout title="Tool not found">
-      <main className={clsx("container", styles.detail)}>
-        <h1>Tool not found</h1>
-        <p>
-          This tool may have been renamed or removed.{" "}
-          <Link to="/tools">Back to Builder Tools</Link>.
+      <main className={clsx("container", styles.detail, styles.notFoundPad)}>
+        <h1 className={styles.title}>Tool not found</h1>
+        <p className={styles.description}>
+          This tool may have been renamed or removed.
         </p>
+        <div className={styles.actions}>
+          <Link to="/tools" className={styles.visitButton}>
+            Back to Builder Tools
+          </Link>
+        </div>
       </main>
     </Layout>
   );
@@ -177,122 +182,112 @@ export default function ToolDetail({ slug }) {
           {buildJsonLd(tool, categoryDef?.label)}
         </script>
       </Head>
-      <main className={clsx("container", styles.detail)}>
-        <nav className={styles.breadcrumb} aria-label="breadcrumb">
-          <Link to="/tools">Builder Tools</Link>
-          {categoryDef && (
-            <>
-              <span className={styles.crumbSep} aria-hidden>
-                /
-              </span>
-              <Link to={`/tools?tags=${tool.category}`}>{categoryDef.label}</Link>
-            </>
-          )}
-          <span className={styles.crumbSep} aria-hidden>
-            /
-          </span>
-          <span className={styles.crumbCurrent}>{tool.title}</span>
-        </nav>
-
-        <header className={styles.header}>
-          <AppIcon app={tool} size="detail" />
-          <div className={styles.headerText}>
-            <h1 className={styles.title}>{tool.title}</h1>
-          </div>
-        </header>
-
-        <div className={styles.tagRow}>
-          {tool.maintainerPick && (
-            <span className={styles.pickBadge}>
-              <svg viewBox="0 0 24 24" width="12" height="12" aria-hidden focusable="false">
-                <path
-                  fill="currentColor"
-                  d="M12 2.5l2.9 6.5 7.1.8-5.3 4.9 1.5 7-6.2-3.6L5.8 21.7l1.5-7L2 9.8l7.1-.8z"
-                />
-              </svg>
-              Maintainer pick
+      {/* The CTA band brings its own container, so the page body carries one of
+          its own rather than main. Both stay inside the main landmark. */}
+      <main className={styles.detail}>
+        <div className="container">
+          <nav className={styles.breadcrumb} aria-label="breadcrumb">
+            <Link to="/tools">Builder Tools</Link>
+            {categoryDef && (
+              <>
+                <span className={styles.crumbSep} aria-hidden>
+                  /
+                </span>
+                <Link to={`/tools?tags=${tool.category}`}>{categoryDef.label}</Link>
+              </>
+            )}
+            <span className={styles.crumbSep} aria-hidden>
+              /
             </span>
-          )}
-          {tool.repository && <span className={styles.osBadge}>Open Source</span>}
-          <TagPill tag={tool.category} def={categoryDef} info />
-          {tool.properties.map((p) => (
-            <TagPill key={p} tag={p} def={Properties[p]} />
-          ))}
-        </div>
+            <span className={styles.crumbCurrent}>{tool.title}</span>
+          </nav>
 
-        <p className={styles.description}>{tool.description}</p>
+          <header className={styles.header}>
+            <AppIcon app={tool} size="detail" />
+            <div className={styles.headerText}>
+              <h1 className={styles.title}>{tool.title}</h1>
+            </div>
+          </header>
 
-        <div className={styles.actions}>
-          {tool.repository ? (
-            <Link href={tool.repository} className={styles.visitButton}>
-              <GitHubIcon size={18} />
-              View on GitHub
-            </Link>
-          ) : (
-            <Link href={tool.website} className={styles.visitButton}>
-              {`Visit ${tool.title}`}
-              <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden focusable="false">
-                <path
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M7 17L17 7M9 7h8v8"
-                />
-              </svg>
-            </Link>
-          )}
-          {tool.repository && tool.website && tool.website !== tool.repository && (
-            <Link href={tool.website} className={styles.secondaryButton}>
-              Visit website
-            </Link>
-          )}
-          {tool.docs && (
-            <Link href={tool.docs} className={styles.secondaryButton}>
-              Get Started
-            </Link>
-          )}
-          <ShareButton title={tool.title} />
-        </div>
-
-        {relatedTools.length > 0 && (
-          <section className={styles.related}>
-            <h2 className={styles.sectionHeading}>More in this category</h2>
-            <ul className={styles.relatedGrid}>
-              {relatedTools.map((related) => (
-                <li key={related.slug}>
-                  <AppTile app={related} />
-                </li>
-              ))}
-            </ul>
-            <Link className={styles.relatedMore} to={`/tools?tags=${tool.category}`}>
-              {`View all ${categoryDef?.label ?? tool.category} tools`}
-            </Link>
-          </section>
-        )}
-
-        <aside className={styles.improve}>
-          <div className={styles.improveIcon} aria-hidden>
-            <svg viewBox="0 0 24 24" width="28" height="28" focusable="false">
-              <path
-                fill="currentColor"
-                d="M12 3 2 8l10 5 10-5-10-5zm-8 9.5L12 17l8-4.5 2 1L12 19 2 13.5l2-1zm0 4L12 21l8-4.5 2 1L12 23 2 17.5l2-1z"
-              />
-            </svg>
+          <div className={styles.tagRow}>
+            {tool.maintainerPick && (
+              <span className={styles.pickBadge}>
+                <svg viewBox="0 0 24 24" width="12" height="12" aria-hidden focusable="false">
+                  <path
+                    fill="currentColor"
+                    d="M12 2.5l2.9 6.5 7.1.8-5.3 4.9 1.5 7-6.2-3.6L5.8 21.7l1.5-7L2 9.8l7.1-.8z"
+                  />
+                </svg>
+                Maintainer pick
+              </span>
+            )}
+            {tool.repository && <span className={styles.osBadge}>Open Source</span>}
+            <TagPill tag={tool.category} def={categoryDef} info />
+            {tool.properties.map((p) => (
+              <TagPill key={p} tag={p} def={Properties[p]} />
+            ))}
           </div>
-          <h2 className={styles.improveHeading}>Spotted something off?</h2>
-          <p className={styles.improveCopy}>
-            This directory is open source. Open a pull request to update or correct
-            this entry.
-          </p>
-          {editUrl && (
-            <Link href={editUrl} className={styles.improveButton}>
-              <GitHubIcon />
-              {`Edit ${tool.title} on GitHub`}
-            </Link>
+
+          <p className={styles.description}>{tool.description}</p>
+
+          <div className={styles.actions}>
+            {tool.repository ? (
+              <Link href={tool.repository} className={styles.visitButton}>
+                <GitHubIcon size={18} />
+                View on GitHub
+              </Link>
+            ) : (
+              <Link href={tool.website} className={styles.visitButton}>
+                {`Visit ${tool.title}`}
+                <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden focusable="false">
+                  <path
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M7 17L17 7M9 7h8v8"
+                  />
+                </svg>
+              </Link>
+            )}
+            {tool.repository && tool.website && tool.website !== tool.repository && (
+              <Link href={tool.website} className={styles.secondaryButton}>
+                Visit website
+              </Link>
+            )}
+            {tool.docs && (
+              <Link href={tool.docs} className={styles.secondaryButton}>
+                Get Started
+              </Link>
+            )}
+            <ShareButton title={tool.title} />
+          </div>
+
+          {relatedTools.length > 0 && (
+            <section className={styles.related}>
+              <h2 className={styles.sectionHeading}>More in this category</h2>
+              <ul className={styles.relatedGrid}>
+                {relatedTools.map((related) => (
+                  <li key={related.slug}>
+                    <AppTile app={related} />
+                  </li>
+                ))}
+              </ul>
+              <Link className={styles.relatedMore} to={`/tools?tags=${tool.category}`}>
+                {`View all ${categoryDef?.label ?? tool.category} tools`}
+              </Link>
+            </section>
           )}
-        </aside>
+        </div>
+        {editUrl && (
+          <PageCTA
+            title="Spotted something off?"
+            description="This directory is open source. Open a pull request to update or correct this entry."
+            href={editUrl}
+            buttonText={`Edit ${tool.title} on GitHub`}
+          />
+        )}
       </main>
     </Layout>
   );

--- a/src/components/ToolDetail/index.js
+++ b/src/components/ToolDetail/index.js
@@ -194,20 +194,6 @@ export default function ToolDetail({ slug }) {
           <span className={styles.crumbCurrent}>{tool.title}</span>
         </nav>
 
-        {tool.maintainerPick && (
-          <div className={styles.pickBadgeRow}>
-            <span className={styles.pickBadge}>
-              <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden focusable="false">
-                <path
-                  fill="currentColor"
-                  d="M12 2.5l2.9 6.5 7.1.8-5.3 4.9 1.5 7-6.2-3.6L5.8 21.7l1.5-7L2 9.8l7.1-.8z"
-                />
-              </svg>
-              Maintainer pick
-            </span>
-          </div>
-        )}
-
         <header className={styles.header}>
           <AppIcon app={tool} size="detail" />
           <div className={styles.headerText}>
@@ -216,6 +202,17 @@ export default function ToolDetail({ slug }) {
         </header>
 
         <div className={styles.tagRow}>
+          {tool.maintainerPick && (
+            <span className={styles.pickBadge}>
+              <svg viewBox="0 0 24 24" width="12" height="12" aria-hidden focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M12 2.5l2.9 6.5 7.1.8-5.3 4.9 1.5 7-6.2-3.6L5.8 21.7l1.5-7L2 9.8l7.1-.8z"
+                />
+              </svg>
+              Maintainer pick
+            </span>
+          )}
           {tool.repository && <span className={styles.osBadge}>Open Source</span>}
           <TagPill tag={tool.category} def={categoryDef} info />
           {tool.properties.map((p) => (

--- a/src/components/ToolDetail/styles.module.css
+++ b/src/components/ToolDetail/styles.module.css
@@ -175,56 +175,63 @@ html[data-theme="dark"] .categoryPill:focus-visible {
   margin-top: 0.5rem;
 }
 
+/* Filled brand pill, the page's one primary action. The fill is identical in
+   both themes: the dark primary under white text falls below the contrast
+   floor, so it is not used here. Motion is in lockstep by hand with the 404
+   chips (src/theme/NotFound/Content/styles.module.css). The padding is trimmed
+   by the border width, and the base border is transparent, so the dark edge
+   below cannot change the button's size. */
 .visitButton {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.85rem 1.6rem;
+  padding: calc(0.85rem - 1px) calc(1.6rem - 1px);
+  border: 1px solid transparent;
   border-radius: 999px;
-  background: #0a1f5e;
-  color: #fff;
+  background: var(--site-color-brand-blue);
+  color: #ffffff;
   font-size: 1rem;
   font-weight: var(--ifm-font-weight-semibold);
   text-decoration: none;
-  transition: background 0.15s ease, transform 0.15s ease;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+/* Brand blue is close to the dark page in luminance, so the fill alone does not
+   mark the button's edge. The hairline carries the boundary, the same way the
+   pick badge and the letter avatar do. */
+html[data-theme="dark"] .visitButton {
+  border-color: var(--ifm-color-primary);
 }
 
 .visitButton:hover {
-  background: #122a78;
-  color: #fff;
+  color: #ffffff;
   text-decoration: none;
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 30px rgb(var(--site-color-brand-blue-rgb) / 0.25);
 }
 
-[data-theme="dark"] .visitButton {
-  background: var(--ifm-color-primary);
+.visitButton:focus-visible {
+  outline: 2px solid var(--site-color-navy);
+  outline-offset: 2px;
 }
 
-[data-theme="dark"] .visitButton:hover {
-  background: var(--ifm-color-primary-dark);
+html[data-theme="dark"] .visitButton:focus-visible {
+  outline-color: var(--site-color-amber);
 }
 
+/* Ghost controls, in lockstep by hand with the intent chips
+   (src/components/showcase/IntentChips/styles.module.css). The two share
+   grouped selectors so the controls sitting in one row cannot drift; only the
+   metrics differ. */
 .secondaryButton {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
   padding: 0.85rem 1.4rem;
   border-radius: 999px;
-  border: 1px solid var(--ifm-color-emphasis-400);
-  background: transparent;
-  color: var(--ifm-color-emphasis-900);
   font-size: 1rem;
   font-weight: var(--ifm-font-weight-semibold);
   text-decoration: none;
-  transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
-}
-
-.secondaryButton:hover {
-  border-color: var(--ifm-color-emphasis-700);
-  background: var(--ifm-color-emphasis-100);
-  color: var(--ifm-color-emphasis-900);
-  text-decoration: none;
-  transform: translateY(-1px);
 }
 
 .iconButton {
@@ -234,22 +241,54 @@ html[data-theme="dark"] .categoryPill:focus-visible {
   width: 3rem;
   height: 3rem;
   border-radius: 50%;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  background: transparent;
-  color: var(--ifm-color-emphasis-900);
   cursor: pointer;
   padding: 0;
-  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
 }
 
+.secondaryButton,
+.iconButton {
+  background: transparent;
+  border: 1px solid rgb(var(--site-color-navy-rgb) / 0.2);
+  color: var(--ifm-font-color-base);
+  transition: background-color 150ms ease, border-color 150ms ease,
+    color 150ms ease;
+}
+
+html[data-theme="dark"] .secondaryButton,
+html[data-theme="dark"] .iconButton {
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.secondaryButton:hover,
 .iconButton:hover {
-  background: var(--ifm-color-emphasis-100);
-  border-color: var(--ifm-color-emphasis-500);
-  color: var(--ifm-color-emphasis-900);
+  background: rgb(var(--site-color-navy-rgb) / 0.05);
+  border-color: var(--site-color-brand-blue);
+  color: var(--site-color-brand-blue);
   text-decoration: none;
-  transform: translateY(-1px);
 }
 
+/* The hover wash lightens the surface under the label, which drops plain
+   primary to 4.3:1. The next step up clears the text floor. */
+html[data-theme="dark"] .secondaryButton:hover,
+html[data-theme="dark"] .iconButton:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--ifm-color-primary-light);
+  color: var(--ifm-color-primary-light);
+}
+
+.secondaryButton:focus-visible,
+.iconButton:focus-visible {
+  outline: 2px solid var(--site-color-navy);
+  outline-offset: 2px;
+}
+
+html[data-theme="dark"] .secondaryButton:focus-visible,
+html[data-theme="dark"] .iconButton:focus-visible {
+  outline-color: var(--site-color-amber);
+}
+
+/* Matches `.sectionTitle` on the browse page; the inherited heading weight is
+   light and reads thin above the card grid */
 .sectionHeading {
   font-size: 1.4rem;
   font-weight: var(--ifm-font-weight-bold);

--- a/src/components/ToolDetail/styles.module.css
+++ b/src/components/ToolDetail/styles.module.css
@@ -1,6 +1,16 @@
+/* The closing CTA band owns the bottom rhythm, so the page body carries no
+   bottom padding of its own. `.notFoundPad` restores it for the defensive
+   not-found branch, which renders no band. */
 .detail {
   padding-top: 2.5rem;
+}
+
+.notFoundPad {
   padding-bottom: 4rem;
+}
+
+.notFoundPad .description {
+  margin-top: 1rem;
 }
 
 .breadcrumb {
@@ -321,66 +331,6 @@ html[data-theme="dark"] .iconButton:focus-visible {
 
 html[data-theme="dark"] .relatedMore:focus-visible {
   outline-color: var(--site-color-amber);
-}
-
-.improve {
-  margin-top: 4rem;
-  padding: 3rem 1.5rem;
-  border-top: 1px solid var(--ifm-color-emphasis-200);
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.improveIcon {
-  width: 56px;
-  height: 56px;
-  border-radius: 14px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--ifm-color-emphasis-100);
-  color: var(--ifm-color-emphasis-900);
-  margin-bottom: 1.5rem;
-}
-
-.improveHeading {
-  margin: 0 0 0.6rem;
-  font-size: clamp(1.4rem, 3vw, 1.85rem);
-  font-weight: var(--site-font-weight-display);
-  letter-spacing: -0.01em;
-}
-
-.improveCopy {
-  margin: 0 0 1.75rem;
-  max-width: 480px;
-  font-size: 1rem;
-  line-height: 1.55;
-  color: var(--ifm-color-emphasis-700);
-}
-
-.improveButton {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.55rem;
-  padding: 0.75rem 1.4rem;
-  border-radius: 999px;
-  border: 1px solid var(--ifm-color-emphasis-400);
-  background: transparent;
-  color: var(--ifm-color-emphasis-900);
-  font-size: 0.95rem;
-  font-weight: var(--ifm-font-weight-semibold);
-  text-decoration: none;
-  transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
-}
-
-.improveButton:hover {
-  border-color: var(--ifm-color-emphasis-700);
-  background: var(--ifm-color-emphasis-100);
-  color: var(--ifm-color-emphasis-900);
-  text-decoration: none;
-  transform: translateY(-1px);
 }
 
 @media (max-width: 600px) {

--- a/src/components/ToolDetail/styles.module.css
+++ b/src/components/ToolDetail/styles.module.css
@@ -10,50 +10,42 @@
   gap: 0.5rem;
   font-size: 0.95rem;
   margin-bottom: 1.5rem;
-  color: var(--ifm-color-emphasis-600);
+  color: var(--site-color-text-muted);
 }
 
 .breadcrumb a {
-  color: var(--ifm-color-emphasis-700);
+  color: inherit;
   text-decoration: none;
 }
 
 .breadcrumb a:hover {
+  color: var(--site-color-brand-blue);
+}
+
+html[data-theme="dark"] .breadcrumb a:hover {
   color: var(--ifm-color-primary);
 }
 
+/* Surface-aware rings: the breadcrumb sits on the page background */
+.breadcrumb a:focus-visible {
+  outline: 2px solid var(--site-color-navy);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+html[data-theme="dark"] .breadcrumb a:focus-visible {
+  outline-color: var(--site-color-amber);
+}
+
+/* Fades the inherited muted token rather than naming a second color, so the
+   separator needs no dark counterpart */
 .crumbSep {
-  color: var(--ifm-color-emphasis-400);
+  opacity: 0.5;
 }
 
 .crumbCurrent {
-  color: var(--ifm-color-emphasis-900);
+  color: var(--ifm-font-color-base);
   font-weight: var(--ifm-font-weight-semibold);
-}
-
-.pickBadgeRow {
-  margin-bottom: 1.5rem;
-}
-
-.pickBadge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  background: var(--ifm-color-emphasis-1000, #0b0d10);
-  color: #fff;
-  padding: 0.45rem 0.95rem;
-  border-radius: 999px;
-  font-size: 0.85rem;
-  font-weight: var(--ifm-font-weight-semibold);
-}
-
-.pickBadge svg {
-  color: var(--site-color-amber);
-}
-
-[data-theme="dark"] .pickBadge {
-  background: #1c1f24;
-  border: 1px solid var(--ifm-color-emphasis-300);
 }
 
 .header {
@@ -84,17 +76,48 @@
   margin-bottom: 1.75rem;
 }
 
+/* One chip row, three weights: the maintainer pick is filled, the category is
+   washed, and the attributes are outlined. The two bordered chips
+   trim their padding by the border width so every chip in the row is the same
+   height. */
+.pickBadge,
 .osBadge {
   display: inline-flex;
   align-items: center;
-  padding: 0.45rem 0.9rem;
+  padding: calc(0.45rem - 1px) calc(0.9rem - 1px);
   border-radius: 999px;
   font-size: 0.78rem;
   font-weight: var(--ifm-font-weight-bold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  background: color-mix(in srgb, #2ea043 16%, transparent);
-  color: color-mix(in srgb, #2ea043 88%, black);
+}
+
+.pickBadge {
+  gap: 0.4rem;
+  background: var(--site-color-navy);
+  color: var(--site-color-cream);
+  /* Transparent in the base so the dark hairline below cannot shift layout */
+  border: 1px solid transparent;
+}
+
+.pickBadge svg {
+  color: var(--site-color-amber);
+}
+
+/* The navy chip blends into the dark page without an edge */
+html[data-theme="dark"] .pickBadge {
+  border-color: var(--site-color-card-border);
+}
+
+/* Outlined chip, in lockstep with AppTile's `.property` */
+.osBadge {
+  background: transparent;
+  border: 1px solid rgb(var(--site-color-navy-rgb) / 0.2);
+  color: var(--site-color-text-muted);
+}
+
+html[data-theme="dark"] .osBadge {
+  border-color: rgba(255, 255, 255, 0.25);
 }
 
 .categoryPill {
@@ -128,10 +151,19 @@ html[data-theme="dark"] .categoryPill:hover {
   background: rgba(255, 255, 255, 0.1);
 }
 
+.categoryPill:focus-visible {
+  outline: 2px solid var(--site-color-navy);
+  outline-offset: 2px;
+}
+
+html[data-theme="dark"] .categoryPill:focus-visible {
+  outline-color: var(--site-color-amber);
+}
+
 .description {
   font-size: 1.2rem;
   line-height: 1.6;
-  color: var(--ifm-color-emphasis-800);
+  color: var(--site-color-text-muted);
   margin-bottom: 1.5rem;
 }
 
@@ -220,6 +252,7 @@ html[data-theme="dark"] .categoryPill:hover {
 
 .sectionHeading {
   font-size: 1.4rem;
+  font-weight: var(--ifm-font-weight-bold);
   margin-top: 2.5rem;
   margin-bottom: 1rem;
 }
@@ -239,6 +272,16 @@ html[data-theme="dark"] .categoryPill:hover {
 
 .relatedMore {
   font-size: 0.95rem;
+}
+
+.relatedMore:focus-visible {
+  outline: 2px solid var(--site-color-navy);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+html[data-theme="dark"] .relatedMore:focus-visible {
+  outline-color: var(--site-color-amber);
 }
 
 .improve {

--- a/src/components/ToolDetail/styles.module.css
+++ b/src/components/ToolDetail/styles.module.css
@@ -63,36 +63,6 @@
   margin-bottom: 1.25rem;
 }
 
-.iconFallback {
-  width: 120px;
-  height: 120px;
-  border-radius: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--site-color-navy);
-  color: var(--site-color-cream);
-  font-size: 3rem;
-  font-weight: var(--ifm-font-weight-bold);
-  flex-shrink: 0;
-  text-transform: uppercase;
-}
-
-/* The navy tile blends into the dark page without an edge */
-html[data-theme="dark"] .iconFallback {
-  border: 1px solid var(--site-color-card-border);
-}
-
-.iconImage {
-  width: 120px;
-  height: 120px;
-  border-radius: 24px;
-  object-fit: contain;
-  background: var(--ifm-color-emphasis-100);
-  padding: 8px;
-  flex-shrink: 0;
-}
-
 .headerText {
   flex: 1 1 auto;
   min-width: 0;
@@ -332,19 +302,6 @@ html[data-theme="dark"] .categoryPill:hover {
 }
 
 @media (max-width: 600px) {
-  .iconFallback {
-    width: 88px;
-    height: 88px;
-    border-radius: 20px;
-    font-size: 2.2rem;
-  }
-
-  .iconImage {
-    width: 88px;
-    height: 88px;
-    border-radius: 20px;
-  }
-
   .visitButton {
     flex: 1 1 auto;
     justify-content: center;

--- a/src/components/showcase/IntentChips/styles.module.css
+++ b/src/components/showcase/IntentChips/styles.module.css
@@ -49,10 +49,12 @@ html[data-theme="dark"] .intentChip {
   color: var(--site-color-brand-blue);
 }
 
+/* The hover wash lightens the surface under the label, which drops plain
+   primary to 4.3:1. The next step up clears the text floor. */
 html[data-theme="dark"] .intentChip:hover {
   background: rgba(255, 255, 255, 0.06);
-  border-color: var(--ifm-color-primary);
-  color: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary-light);
+  color: var(--ifm-color-primary-light);
 }
 
 /* Surface-aware rings: the chips sit on the page background */

--- a/src/data/builder-tools/showcase.js
+++ b/src/data/builder-tools/showcase.js
@@ -3,8 +3,8 @@
 // ============================================================================
 // Reads the explicit `category` / `properties` / `maintainerPick` now carried by
 // each tools.js entry (no more derivation) and shapes them for the app-store
-// components: adds a `slug` and re-exports the taxonomy. Icons are not sourced
-// yet, so `icon` is null and AppIcon renders a letter-avatar fallback.
+// components: adds a `slug` and re-exports the taxonomy. Most entries carry an
+// `icon`; where it is null AppIcon renders a letter-avatar fallback instead.
 // ============================================================================
 
 import {


### PR DESCRIPTION
## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/cardano-foundation/developer-portal/blob/staging/CONTRIBUTING.md).
- [x] I have run `yarn build` after adding my changes **without getting any errors**.
- [x] I have not committed any changes to `yarn.lock` (or have [removed these changes](https://github.com/cardano-foundation/developer-portal/blob/staging/CONTRIBUTING.md#faq)).

## Updating documentation or Bugfix

Round 8 of the 2026 rebrand: the tool detail page, in four commits. Round 7 rebranded the tools grid, which left its 94 detail pages on the stock gray ramp. This closes that seam.

## What

- The detail page reuses the shared icon component instead of its own copy. That also picks up the missing-image fallback the detail page never had, so a broken icon path now renders the letter avatar instead of a broken image.
- The page chrome moves onto brand tokens: breadcrumb, maintainer pick badge, description, and section headings. The pick badge becomes navy with cream text, matching the letter avatar, and moves down into the tag row instead of sitting on a line of its own above the title.
- The "Open Source" badge loses its GitHub green and becomes the same outlined chip the tool cards use. The brand has no green, and the label already carries the meaning.
- The action row is rebranded. The primary button becomes the brand blue pill used across the site, the secondary and share buttons become ghost controls, and all three gain focus rings. The page previously had none.

> Relevant to #1847
