### PR TITLE
Promote the Builder Tools colours to tokens and trim the navbar

### DIFF
--- a/src/components/AppFilterPanel/styles.module.css
+++ b/src/components/AppFilterPanel/styles.module.css
@@ -1,12 +1,11 @@
 /* Persistent facet rail as the template's Menu panel: an outlined Clarity
    card like the tool tiles, so the whole browse area shares one treatment.
-   The border is the sheet's "Light Grey (WEB)", a literal until a shared
-   token exists. */
+   "Light Grey (WEB)" border. */
 .rail {
   /* The template's Menu insets: 20 left, 12 right, which is also what keeps
      the longest category label on one line. */
   padding: 25px 12px 25px 20px;
-  border: 1px solid #E5E2E2;
+  border: 1px solid var(--site-color-light-grey);
   border-radius: 12px;
   background: var(--site-color-cream);
   align-self: start;
@@ -32,7 +31,7 @@ html[data-theme="dark"] .rail {
   gap: 23px;
   margin-bottom: 10px;
   padding-bottom: 10px;
-  border-bottom: 1px solid #06187D;
+  border-bottom: 1px solid var(--site-color-blue-deep);
 }
 
 html[data-theme="dark"] .groupHead {

--- a/src/components/AppRow/styles.module.css
+++ b/src/components/AppRow/styles.module.css
@@ -110,7 +110,7 @@ html[data-theme="dark"] .row:focus-visible {
   font-size: 0.78rem;
   font-weight: var(--ifm-font-weight-normal);
   line-height: 1.25;
-  background: #06187D;
+  background: var(--site-color-blue-deep);
   color: var(--site-color-cream);
   padding: 2px 10px;
   border-radius: 999px;

--- a/src/components/AppTile/styles.module.css
+++ b/src/components/AppTile/styles.module.css
@@ -1,11 +1,11 @@
-/* The template's tool card: an outlined Clarity panel. The border is the
-   sheet's "Light Grey (WEB)", a literal until a shared token exists. */
+/* The template's tool card: an outlined Clarity panel. "Light Grey (WEB)"
+   border. */
 .tile {
   display: flex;
   flex-direction: column;
   gap: 10px;
   padding: 1.875rem 2.5rem;
-  border: 1px solid #E5E2E2;
+  border: 1px solid var(--site-color-light-grey);
   border-radius: 12px;
   background: var(--site-color-cream);
   min-height: 295px;
@@ -47,16 +47,15 @@ html[data-theme="dark"] .tile:focus-visible {
   margin-bottom: 1rem;
 }
 
-/* The template's NEW badge: a Deep Blue capsule in the text face — the
-   colour sheet's first secondary with a consumer. Cream on it is 13:1, so
-   it holds in both themes. */
+/* The template's NEW badge: a Deep Blue capsule in the text face. Cream
+   on it is 13:1, so it holds in both themes. */
 .newBadge {
   font-size: 1rem;
   font-weight: var(--ifm-font-weight-normal);
   line-height: 1.25;
   padding: 3px 13px;
   border-radius: 999px;
-  background: #06187D;
+  background: var(--site-color-blue-deep);
   color: var(--site-color-cream);
 }
 
@@ -98,7 +97,7 @@ html[data-theme="dark"] .tile:focus-visible {
   border-radius: 999px;
   line-height: 1.25;
   font-size: 1rem;
-  background: #B8BBCD;
+  background: var(--site-color-chip-grey);
   color: var(--site-color-navy);
 }
 

--- a/src/components/CategoryPanelsCarousel/styles.module.css
+++ b/src/components/CategoryPanelsCarousel/styles.module.css
@@ -85,7 +85,7 @@ html[data-theme="dark"] .panel {
   gap: 1rem;
   padding-bottom: 10px;
   margin-bottom: 1.25rem;
-  border-bottom: 1px solid #06187D;
+  border-bottom: 1px solid var(--site-color-blue-deep);
 }
 
 html[data-theme="dark"] .panelHeader {

--- a/src/components/showcase/ShowcaseSort/styles.module.css
+++ b/src/components/showcase/ShowcaseSort/styles.module.css
@@ -25,7 +25,7 @@ html[data-theme="dark"] .sortLabelText {
      background-image, and `background:` would drop it silently. */
   background-color: var(--site-color-cream);
   /* "Light Grey (WEB)", shared with the search field beside it */
-  border: 1px solid #E5E2E2;
+  border: 1px solid var(--site-color-light-grey);
   color: var(--site-color-ink-muted);
   height: clamp(60px, 5vw, 86px);
   padding: 0 3rem 0 30px;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -38,10 +38,11 @@
 
 /* You can override the default Infima variables here. */
 
-/* The template's nav bar is 102px tall; mobile keeps Infima's height. */
+/* Deliberately below the template's 102px bar; mobile keeps Infima's
+   height. */
 @media (min-width: 997px) {
   :root {
-    --ifm-navbar-height: 102px;
+    --ifm-navbar-height: 84px;
   }
 }
 
@@ -110,8 +111,15 @@
      raised-surface pair carries. */
   --site-color-gray-light-hover: #E8E6E1;
   /* "Light Grey (WEB)" on the design sheet: hairlines and outlines on light
-     surfaces (submenu item cards, the navbar search pill). */
+     surfaces (submenu item cards, the navbar search pill, the Builder
+     Tools cards and fields). */
   --site-color-light-grey: #E5E2E2;
+  /* "Deep Blue" on the design sheet: the NEW badge and the panel header
+     rules on the Builder Tools page. */
+  --site-color-blue-deep: #06187D;
+  /* The template's grey-lavender chip fill on the tool cards. Off-sheet,
+     from the Figma frames. */
+  --site-color-chip-grey: #B8BBCD;
   --site-color-ink: #111425;
   --site-color-ink-muted: #5F6B85;
   /* Muted text that follows the page background (ink on cream, white on navy) */

--- a/src/pages/tools/styles.module.css
+++ b/src/pages/tools/styles.module.css
@@ -42,14 +42,13 @@
 }
 
 /* The template's search field: a tall outlined Clarity bar with the
-   placeholder in Slate. The border is the sheet's "Light Grey (WEB)", a
-   literal until a shared token exists. */
+   placeholder in Slate, "Light Grey (WEB)" border. */
 .searchInput {
   width: 100%;
   height: clamp(60px, 5vw, 86px);
   padding: 0 31px;
   border-radius: 12px;
-  border: 1px solid #E5E2E2;
+  border: 1px solid var(--site-color-light-grey);
   background: var(--site-color-cream);
   font-size: 1rem;
 }

--- a/static/img/brand/README.md
+++ b/static/img/brand/README.md
@@ -19,8 +19,8 @@ Secondary:
 
 | Colour | Hex | Pantone | Use on the portal |
 | --- | --- | --- | --- |
-| Deep Blue | `#06187D` | 2575 C | Not used yet |
-| Neutral Grey | `#ACA6A6` | Cool Gray 4 | Artwork accent |
+| Deep Blue | `#06187D` | 2575 C | NEW badge and panel header rules on Builder Tools |
+| Neutral Grey | `#ACA6A6` | Cool Gray 4 | Artwork accent; count capsules and dormant controls on Builder Tools |
 | Slate | `#5F6B85` | 7545 C | Muted text |
 | Teal | `#2FB7A8` | 3262 C | Not used yet |
 | Pedal | `#C7C2E6` | 7443 C | Artwork accent |


### PR DESCRIPTION
The Builder Tools restyle shipped three colours as commented hex literals because their tokens could not land while the navbar PR was open. Deep Blue and the grey-lavender chip fill now join the palette as --site-color-blue-deep and --site-color-chip-grey, all six stylesheets read tokens instead of literals, and the brand README's secondary table records where Deep Blue and Neutral Grey actually appear on the portal.

The desktop navbar also drops from the template's 102px to 84px: the full template height read as too heavy in use, and 84px keeps the airier bar without the bulk. No other visual change.

Related to #1847