### PR TITLE
Point readers at the registries instead of naming products

### DIFF
--- a/docs/community/funding.md
+++ b/docs/community/funding.md
@@ -19,7 +19,7 @@ Good fit for new ideas, prototypes, and community-facing projects that can rally
 
 Cardano's treasury is governed on-chain under [CIP-1694](https://cips.cardano.org/cip/CIP-1694). Anyone can submit a treasury withdrawal as a governance action, which [DReps](https://cardano.org/governance) and the Constitutional Committee then vote on. This is the route for larger, ecosystem-level work with clear community benefit.
 
-Draft and submit an action with [GovTool](https://gov.tools), and see [staking and governance](/docs/developers/curriculum/staking-governance/governance) for how the process works under the hood. Organizations like [Intersect](https://www.intersectmbo.org/) and [PRAGMA](https://pragma.builders) often help coordinate due diligence and disbursement for approved proposals.
+Draft and submit an action with a [governance app](https://cardano.org/apps/?tags=governance), and see [staking and governance](/docs/developers/curriculum/staking-governance/governance) for how the process works under the hood. Organizations like [Intersect](https://www.intersectmbo.org/) and [PRAGMA](https://pragma.builders) often help coordinate due diligence and disbursement for approved proposals.
 
 Good fit for mature projects, shared infrastructure, and protocol-level improvements.
 

--- a/docs/developers/cardano-for-ethereum-developers.md
+++ b/docs/developers/cardano-for-ethereum-developers.md
@@ -558,7 +558,7 @@ Ready to start building? Here's the tooling landscape.
 
 Ethereum developers primarily use Solidity. On Cardano, currently the [most popular language](https://cardano-foundation.github.io/state-of-the-developer-ecosystem/2025/#what-do-you-use-or-plan-to-use-for-writing-plutus-script-validators-smart-contracts) is **Aiken**: a purpose-built language with Rust-like syntax, strong static typing, and its own toolchain (compiler, test framework, formatter, LSP). Aiken compiles directly to UPLC (Untyped Plutus Core), Cardano's native bytecode.
 
-Alternatives include [OpShin](https://opshin.dev) (Python syntax), [Scalus](https://scalus.org) (Scala), [Pebble](https://pluts.harmoniclabs.tech/) (TypeScript DSL). See the [Smart Contracts overview](/docs/developers/curriculum/smart-contracts/overview) for the full list.
+Other languages target the same bytecode, with Python, Scala, and TypeScript-flavoured options among them. See the [Smart Contracts overview](/docs/developers/curriculum/smart-contracts/overview) for the comparison and [Builder Tools](/tools/?tags=smart-contracts) for the current set.
 
 ### Tools
 
@@ -566,9 +566,9 @@ Alternatives include [OpShin](https://opshin.dev) (Python syntax), [Scalus](http
 |----------|---------|
 | Hardhat | [Aiken CLI](https://aiken-lang.org/installation-instructions) (`aiken build`, `aiken check`) |
 | Remix | [Aiken Playground](https://play.aiken-lang.org) |
-| Web3.js, ethers.js | [Client SDKs](/docs/developers/curriculum/start-building/choose-your-tools) like **Mesh SDK** (TypeScript) |
-| Ganache, Foundry | [Local devnets](/docs/developers/curriculum/start-building/local-testing#local-devnets) like [Yaci DevKit](https://devkit.yaci.xyz/) |
-| Infura, Alchemy | [Query APIs](/docs/developers/curriculum/production/connecting-to-the-chain#query-apis) like [Blockfrost](https://blockfrost.dev/), [Maestro](https://www.gomaestro.org/), [Koios](https://koios.rest/) |
+| Web3.js, ethers.js | [Client SDKs](/docs/developers/curriculum/start-building/choose-your-tools) |
+| Ganache, Foundry | [Local devnets](/docs/developers/curriculum/start-building/local-testing#local-devnets) |
+| Infura, Alchemy | [Query APIs](/docs/developers/curriculum/production/connecting-to-the-chain#query-apis), listed in [Builder Tools](/tools/?tags=api) |
 | Etherscan | [Explorers](https://explorer.cardano.org/) |
 | MetaMask | [Wallets](https://cardano.org/apps/?tags=wallet) |
 
@@ -579,10 +579,10 @@ Client SDKs handle transaction building, wallet integration, UTxO selection, and
 | Language | SDK |
 |----------|-----|
 | TypeScript | [Typescript SDKs](/docs/developers/curriculum/start-building/choose-your-tools)|
-| Python | [PyCardano](/tools/?tags=sdk) |
-| Rust | [Pallas](/tools/?tags=sdk) |
-| Go | [Apollo](/tools/?tags=sdk) |
-| C# | [Chrysalis](/tools/?tags=sdk) |
+| Python | [Python SDKs](/tools/?tags=sdk&tags=python) |
+| Rust | [Rust SDKs](/tools/?tags=sdk&tags=rust) |
+| Go | [Go SDKs](/tools/?tags=sdk&tags=golang) |
+| C# | [C# SDKs](/tools/?tags=sdk&tags=net) |
 
 ### Development Workflow
 

--- a/docs/developers/curriculum/dapps/connect-a-wallet.md
+++ b/docs/developers/curriculum/dapps/connect-a-wallet.md
@@ -212,7 +212,7 @@ The extension adds `getPubDRepKey()` for the user's DRep key, and `getRegistered
 
 ## No browser extension? Wallet as a Service
 
-Not every user has a browser wallet installed. **Wallet-as-a-Service (WaaS)** lets users create a non-custodial wallet via social login, removing the install step entirely (keys are split with Shamir's Secret Sharing and reconstructed only on the user's device at signing time). See [UTXOS Web3 Services](/docs/developers/curriculum/dapps/wallet-authentication#hosted-sign-in-as-a-service), which also supports [transaction sponsorship](https://docs.utxos.dev/sponsor) so users can transact without holding ADA for fees first.
+Not every user has a browser wallet installed. **Wallet-as-a-Service (WaaS)** lets users create a non-custodial wallet via social login, removing the install step entirely (keys are split with Shamir's Secret Sharing and reconstructed only on the user's device at signing time). See [hosted sign-in as a service](/docs/developers/curriculum/dapps/wallet-authentication#hosted-sign-in-as-a-service), and pair it with [sponsored transactions](/docs/developers/curriculum/dapps/sponsored-transactions) so users can transact without holding ADA for fees first.
 
 ## Framework integration (React & Svelte)
 

--- a/docs/developers/curriculum/fundamentals/core-concepts/wallets-and-keys.md
+++ b/docs/developers/curriculum/fundamentals/core-concepts/wallets-and-keys.md
@@ -91,12 +91,14 @@ The last two levels are not hardened, which has a practical payoff: you can give
 
 A wallet is software that stores your keys, scans the chain for UTXOs at your addresses, computes your balance, and builds and signs transactions. Your funds live on-chain as UTXOs; they are not "inside" the app.
 
-| Wallet type | Examples | Trade-off |
+| Wallet type | Form | Trade-off |
 |---|---|---|
-| **Full-node** | Daedalus | Maximum trustlessness; downloads the whole chain |
+| **Full-node** | Desktop wallets that run their own node | Maximum trustlessness; downloads the whole chain |
 | **Light** | Browser and mobile wallets | Fast; relies on a backend for chain data (signing stays local) |
-| **Hardware** | Ledger, Trezor | Keys never leave a secure device; strongest theft protection |
+| **Hardware** | Signing devices used through a companion app | Keys never leave a secure device; strongest theft protection |
 | **Browser extension** | (implements CIP-30) | The standard way dApps connect to users |
+
+[cardano.org/apps](https://cardano.org/apps/?tags=wallet) lists the current wallets.
 
 ## How dApps connect: CIP-30
 

--- a/docs/developers/curriculum/production/connecting-to-the-chain.md
+++ b/docs/developers/curriculum/production/connecting-to-the-chain.md
@@ -71,7 +71,7 @@ Transaction submission options:
 
 ### Indexers
 
-**db-sync, Kupo, Oura, Adder, Yaci Store.** The node holds the whole chain, but not in a form an application can query: there is no "UTXOs at this address" lookup inside cardano-node. An **indexer** follows the chain and stores what it sees in a queryable shape. The shapes differ, and picking by shape is the whole game: a full SQL copy (db-sync), a filtered UTXO set (Kupo), an event stream (Oura, Adder), or modular per-table stores (Yaci Store). What they share is the hard part, which is that the chain can take blocks back, so an index has to be able to unwind. [Custom indexing & analytics](/docs/developers/curriculum/production/indexing-and-analytics) covers the shapes, that problem, and builds one out.
+**db-sync, Kupo, Oura, Adder, Yaci Store.** The node holds the whole chain, but not in a form an application can query: there is no "UTXOs at this address" lookup inside cardano-node. An **indexer** follows the chain and stores what it sees in a queryable shape. The shapes differ, and picking by shape is the whole game: a full SQL copy (db-sync), a filtered UTXO set (Kupo), an event stream (Oura, Adder), or modular per-table stores (Yaci Store). What they share is the hard part, which is that the chain can take blocks back, so an index has to be able to unwind. [Custom indexing & analytics](/docs/developers/curriculum/production/indexing-and-analytics) covers the shapes, that problem, and builds one out. [Builder Tools](/tools/?tags=indexer) has the full set.
 
 ### The full node
 

--- a/docs/developers/curriculum/production/going-to-production.md
+++ b/docs/developers/curriculum/production/going-to-production.md
@@ -117,7 +117,7 @@ Decide how your dApp will read and submit to the chain: a hosted query API (fast
 Production also means users who may not have a wallet or any ADA. Lower the barrier:
 
 - **Wallet-as-a-Service**: let users create a non-custodial wallet with social login ([connect a wallet](/docs/developers/curriculum/dapps/connect-a-wallet#no-browser-extension-wallet-as-a-service)).
-- **Transaction sponsorship**: pay fees on behalf of users so they can transact before holding ADA ([sponsorship](https://docs.utxos.dev/sponsor)).
+- **Transaction sponsorship**: pay fees on behalf of users so they can transact before holding ADA ([sponsored transactions](/docs/developers/curriculum/dapps/sponsored-transactions)).
 
 ## Checklist
 

--- a/docs/developers/curriculum/production/use-a-provider.md
+++ b/docs/developers/curriculum/production/use-a-provider.md
@@ -258,3 +258,4 @@ One hosted API is a single point of failure, and chatty code hits rate limits. B
 
 - [Self-hosting](/docs/developers/curriculum/production/self-hosting): the same two workflows served from infrastructure you run
 - [Going to production](/docs/developers/curriculum/production/going-to-production): the pre-mainnet checklist, including provider hardening
+- [Builder Tools](/tools/?tags=api): the hosted providers in full, beyond the four set up here

--- a/docs/developers/curriculum/start-building/choose-your-tools.md
+++ b/docs/developers/curriculum/start-building/choose-your-tools.md
@@ -24,7 +24,7 @@ An SDK handles the parts of Cardano you do not want to reimplement: assembling a
 
 The code tabs across this curriculum use **Evolution** and **Mesh**, both TypeScript. That is the only reason they appear here: with one of them installed, every example on the site runs as written. Nothing you learn depends on either one.
 
-Cardano has SDKs in Python (PyCardano), Rust (Whisky), Go (Apollo), C# (Chrysalis), Java, Swift, and more, alongside lower-level serialization libraries. [Builder Tools](/tools/?tags=sdk) lists them by language and by what each one covers.
+Cardano has SDKs in Python, Rust, Go, C#, Java, Swift, and more, alongside lower-level serialization libraries. [Builder Tools](/tools/?tags=sdk) lists them by language and by what each one covers.
 
 ## Install it
 

--- a/docs/developers/exchange-integrations.md
+++ b/docs/developers/exchange-integrations.md
@@ -26,7 +26,7 @@ Cardano uses the **Extended UTXO (eUTXO)** model: value lives in discrete unspen
 
 :::note
 Rosetta specification does not include transaction signing capabilities. This is done  in a separate offline service for best security practices using any signing libraries available. See example using [CSL](https://github.com/Emurgo/cardano-serialization-lib/blob/master/doc/getting-started/singing_rosetta_tx.ts).  
-For creating addresses, [cardano-addresses](https://github.com/IntersectMBO/cardano-addresses) provides mnemonic (backup phrase) creation, and conversion of a mnemonic to seed for wallet restoration, and address derivation functionalities. This can also be achieved using other libraries like [cardano-serialization-lib](https://github.com/Emurgo/cardano-serialization-lib)
+For creating addresses, [cardano-addresses](https://github.com/IntersectMBO/cardano-addresses) provides mnemonic (backup phrase) creation, and conversion of a mnemonic to seed for wallet restoration, and address derivation functionalities. This can also be achieved with any of the [SDKs and serialization libraries](/tools/?tags=sdk)
 :::
 
 - [**cardano-graphql**](https://github.com/cardano-foundation/cardano-graphql): GraphQL API for querying blockchain data.
@@ -82,7 +82,7 @@ Cardano offers multiple tools for transaction creation and submission, each desi
 | [`cardano-submit-api`](https://github.com/IntersectMBO/cardano-node/tree/master/cardano-submit-api) | ❌ | ❌ | ✅ | Lightweight API for submitting signed transactions to a Cardano node. |
 
 :::tip
-The best practice for exchanges is to use `cardano-rosetta` for transaction construction and submission, and sign the transaction using signing libraries of their choice such as `cardano-serialization-lib`.
+The best practice for exchanges is to use `cardano-rosetta` for transaction construction and submission, and sign the transaction using a signing library of their choice ([SDKs and serialization libraries](/tools/?tags=sdk)).
 :::
 
 ### Fee Calculation
@@ -269,7 +269,7 @@ Exchange debited:
 
 1. **Dynamic Calculation (Recommended)**
 
-- Use libraries like [`cardano-serialization-lib`](https://github.com/Emurgo/cardano-serialization-lib) for dynamic calculation
+- Use an [SDK](/tools/?tags=sdk) for dynamic calculation
 
 2. **Fixed Allocation (Simpler but less efficient)**
 

--- a/docs/operators/block-producer/register-stake-pool.md
+++ b/docs/operators/block-producer/register-stake-pool.md
@@ -55,7 +55,7 @@ cat poolMetaDataHash.txt
 Both hashes must be identical. If they differ, re-upload the file (extra whitespace or encoding differences are common causes).
 
 :::tip SPO identity — Calidus keys
-After registering your pool, consider registering a [Calidus key](/docs/operators/operator-tools/calidus-keys). It lets explorers (Cardanoscan, Cexplorer, AdaStat), governance tools, and APIs verify your SPO identity with a hot key — without ever touching your cold key again.
+After registering your pool, consider registering a [Calidus key](/docs/operators/operator-tools/calidus-keys). It lets [explorers](https://cardano.org/apps/?tags=explorer), governance tools, and APIs verify your SPO identity with a hot key — without ever touching your cold key again.
 :::
 
 ## Generate the pool registration certificate

--- a/docs/operators/governance/spo-governance.md
+++ b/docs/operators/governance/spo-governance.md
@@ -47,7 +47,7 @@ For a full governance state dump (includes vote tallies):
 cardano-cli conway query gov-state
 ```
 
-You can also browse active proposals on [Cardano GovTool](https://gov.tools), [CardanoScan](https://cardanoscan.io/govActions), [Adastat](https://adastat.net/governances) or [CGOV](https://app.cgov.io/).
+You can also browse active proposals in any of the [governance apps](https://cardano.org/apps/?tags=governance).
 
 :::tip Check every action you can vote on before you start
 If several proposals requiring SPO votes are live at the same time, you can vote on all of them in a **single transaction** — one trip to the air-gapped machine, one cold key signature. Take stock of the full list here, so you only unlock your cold key once.
@@ -262,4 +262,4 @@ See [Calidus Keys](../../operator-tools/calidus-keys) for setup instructions.
 - [Submitting votes (cardano-cli full reference)](/docs/developers/curriculum/staking-governance/vote-and-propose#vote-on-an-action)
 - [Governance queries](/docs/developers/curriculum/staking-governance/governance-operations#query-governance-state)
 - [CIP-1694 specification](https://cips.cardano.org/cip/CIP-1694)
-- [Cardano GovTool](https://gov.tools)
+- [Governance apps](https://cardano.org/apps/?tags=governance)

--- a/docs/operators/operator-tools/calidus-keys.md
+++ b/docs/operators/operator-tools/calidus-keys.md
@@ -50,8 +50,8 @@ Then submit the registration metadata in a transaction from your online machine.
 The Calidus key acts as a hot key for:
 
 - **Governance tool authentication** — prove your SPO identity on governance platforms and voting interfaces
-- **Explorer profiles** — update pool metadata and interact with Cardanoscan, Cexplorer, AdaStat
-- **API authentication** — authenticate with Koios, Blockfrost, and other SPO-aware APIs
+- **Explorer profiles** — update pool metadata and interact with [explorers](https://cardano.org/apps/?tags=explorer)
+- **API authentication** — authenticate with SPO-aware [query APIs](/tools/?tags=api)
 - **dApp signing** — compatible with CIP-30 light wallets and CIP-8 message signing, so hardware wallets and browser wallets can be used
 
 Keep `calidus.skey` secure — it represents your pool's online identity. Unlike your cold key, it can be kept on a relatively secured hot machine, but it should still be treated as sensitive. If compromised, rotate it by submitting a new registration with a higher nonce.


### PR DESCRIPTION
Several pages pointed readers at hand-picked products where the only intent was to say that a category exists: governance sites to browse proposals on, explorers to look a pool up in, providers "like Blockfrost, Maestro, Koios", one SDK per language, the same serialization library three times. Those names carry no reason to be there, drift out of date, and quietly rank the ecosystem.

Related to #1839