### PR TITLE
Fix nine small UI defects

### DIFF
--- a/src/components/TemplatesBrowser/ChipRow.js
+++ b/src/components/TemplatesBrowser/ChipRow.js
@@ -5,7 +5,7 @@ import styles from "./browser.module.css";
 // A labeled row of taxonomy chips on a card (e.g. "Framework: Vite + React").
 // `ids` are resolved to their display label via `taxonomy`; renders nothing for
 // an empty list. Shared by the app-starter and contracts cards.
-export default function ChipRow({ label, ids, taxonomy }) {
+export default function ChipRow({ label, ids = [], taxonomy }) {
   if (!ids.length) return null;
   return (
     <div className={styles.chipGroup}>

--- a/src/components/showcase/IntentChips/styles.module.css
+++ b/src/components/showcase/IntentChips/styles.module.css
@@ -108,7 +108,10 @@ html[data-theme="dark"] .intentChip.intentChipActive:hover {
 }
 
 @media (max-width: 600px) {
+  /* The base list is a grid, where flex-wrap is inert; the strip needs flex
+     for nowrap + horizontal scroll to actually happen. */
   .intentList {
+    display: flex;
     overflow-x: auto;
     flex-wrap: nowrap;
     padding-bottom: 0.5rem;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1089,7 +1089,10 @@ html[data-theme="dark"] .breadcrumbs__link:focus-visible,
 html[data-theme="dark"] .table-of-contents__link:focus-visible,
 html[data-theme="dark"] .pagination-nav__link:focus-visible,
 html[data-theme="dark"] .theme-doc-card-container:focus-visible,
-html[data-theme="dark"] .tabs__item:focus-visible,
+html[data-theme="dark"] .tabs__item:focus-visible {
+  outline-color: var(--site-color-amber);
+}
+
 /* GitHub/Discord/theme buttons sit in circular chips on hover, the
    template's toggle treatment. */
 .navbar .header-github-link,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -211,6 +211,7 @@ function QuickstartCard({ badge, text, command, prompt, docHref, docLabel, docEx
   React.useEffect(() => () => clearTimeout(timeoutRef.current), []);
 
   const copyCommand = () => {
+    if (!navigator.clipboard) return;
     navigator.clipboard
       .writeText(command)
       .then(() => {
@@ -238,6 +239,7 @@ function QuickstartCard({ badge, text, command, prompt, docHref, docLabel, docEx
           {prompt && <span className={styles.cliPrompt}>$</span>}
           <code>{command}</code>
           <button
+            type="button"
             className={styles.copyBtn}
             onClick={copyCommand}
             aria-label="Copy command"
@@ -488,7 +490,7 @@ function SmartContractsSection() {
           <div className={styles.prodCard}>
             <img
               src={useBaseUrl("img/home/rebrand/prod-smart-contracts.webp")}
-              alt="Smart contract design patterns and security"
+              alt=""
               className={styles.scLearnImage}
             />
             <div className={styles.prodCardOverlay} />
@@ -517,7 +519,7 @@ function SmartContractsSection() {
           >
             <img
               src={useBaseUrl("img/home/rebrand/prod-asteria.webp")}
-              alt="Asteria space game for learning eUTxO development"
+              alt=""
               className={styles.asteriaImage}
             />
             <div className={styles.prodCardOverlay} />
@@ -537,7 +539,7 @@ function SmartContractsSection() {
           >
             <img
               src={useBaseUrl("img/home/rebrand/prod-ctf.webp")}
-              alt="Cardano Capture The Flag security challenge"
+              alt=""
               className={styles.scCTFImage}
             />
             <div className={styles.prodCardOverlay} />
@@ -645,16 +647,8 @@ function CTASection() {
 function OfficeHoursArt() {
   return (
     <div className={styles.officeHoursArt} aria-hidden="true">
-      <img
-        src={useBaseUrl("img/home/rebrand/office-hours-dots-light.webp")}
-        alt=""
-        className={styles.officeHoursArtLight}
-      />
-      <img
-        src={useBaseUrl("img/home/rebrand/office-hours-dots-dark.webp")}
-        alt=""
-        className={styles.officeHoursArtDark}
-      />
+      <div className={styles.officeHoursArtLight} />
+      <div className={styles.officeHoursArtDark} />
     </div>
   );
 }

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -1199,27 +1199,35 @@ html[data-theme="dark"] .officeHoursContent p {
 /* Bleeds to the right edge like the template. Sized by width, not height:
    at full banner width this equals full height (the export is the banner's
    right 52% at the same aspect), and at narrower widths it shrinks with the
-   banner instead of sliding under the copy. */
-.officeHoursArt img {
+   banner instead of sliding under the copy. CSS backgrounds instead of <img>
+   so a visit downloads only its own theme's file; a background in an
+   unmatched theme selector is never fetched. */
+.officeHoursArtLight,
+.officeHoursArtDark {
   position: absolute;
   top: 50%;
   right: 0;
   transform: translateY(-50%);
   width: 52%;
-  height: auto;
-  display: block;
+  aspect-ratio: 1592 / 856;
+  background: center / contain no-repeat;
 }
 
-.officeHoursArt .officeHoursArtDark {
+.officeHoursArtLight {
+  background-image: url("/img/home/rebrand/office-hours-dots-light.webp");
+}
+
+html[data-theme="dark"] .officeHoursArtLight {
   display: none;
 }
 
-html[data-theme="dark"] .officeHoursArt .officeHoursArtLight {
+.officeHoursArtDark {
   display: none;
 }
 
-html[data-theme="dark"] .officeHoursArt .officeHoursArtDark {
+html[data-theme="dark"] .officeHoursArtDark {
   display: block;
+  background-image: url("/img/home/rebrand/office-hours-dots-dark.webp");
 }
 
 /* Below this width the artwork would crowd the copy, so the banner reads as

--- a/src/pages/tools/index.js
+++ b/src/pages/tools/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useEffect } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import Layout from "@theme/Layout";
 import { PageMetadata } from "@docusaurus/theme-common";
 import ogCards from "@site/static/img/og/pages/manifest.json";
@@ -50,7 +50,9 @@ function restoreUserState(userState) {
 const maintainerPicks = SortedShowcases.filter((t) => t.maintainerPick);
 
 const isProminentCategory = (c) => Categories[c]?.prominent === true;
-const isCompactCategory = (c) => Categories[c]?.prominent === false;
+// Everything not prominent is compact, so a category missing the flag still
+// shows up instead of silently falling out of both carousels.
+const isCompactCategory = (c) => !isProminentCategory(c);
 
 // Category order is derived by how many tools sit in each category (desc).
 function deriveCategoryOrder(predicate) {
@@ -192,16 +194,20 @@ function SearchBar() {
     }
   }, [location]);
 
-  const debouncedHistoryPush = useCallback(
-    _debounce((newSearchString) => {
-      history.push({
-        ...location,
-        search: newSearchString,
-        state: { isSearch: true },
-      });
-    }, 300),
-    [history, location]
+  // Stable across keystrokes (reading the current path off `history` itself),
+  // so pending pushes are debounced for real and cancelled on unmount.
+  const debouncedHistoryPush = useMemo(
+    () =>
+      _debounce((newSearchString) => {
+        history.push({
+          pathname: history.location.pathname,
+          search: newSearchString,
+          state: { isSearch: true },
+        });
+      }, 300),
+    [history]
   );
+  useEffect(() => () => debouncedHistoryPush.cancel(), [debouncedHistoryPush]);
 
   const handleInput = (e) => {
     const currentInputValue = e.currentTarget.value;
@@ -406,7 +412,7 @@ function AllToolsReveal() {
         apps={null}
         sortOption={SORT_IDS.ALPHABETICAL}
         isUnfiltered={true}
-        heading={`All ${SortedShowcases.length} tools, A to Z`}
+        heading="All tools, A to Z"
       />
     );
   }


### PR DESCRIPTION
A batch of small defects across the docs chrome, the tools page, and the landing page, fixed in one pass with no architecture changes. Everything here is either user-visible or a latent crash.

What changes:

- Dark-mode keyboard focus: sidebar links, breadcrumbs, table of contents, pagination, doc cards, and tabs now show the amber ring the rest of the site already uses. Their rule lost its body in the #1978 navbar restyle, leaving a near-invisible navy ring plus a small layout jump on focus.
- The "All tools, A to Z" reveal showed the tool count twice in one heading; it now shows once, muted like every other section.
- The tools search debounce was rebuilt on every keystroke and could still fire after leaving the page; it is now stable and cancelled on unmount.
- The Office Hours banner downloaded both theme images on every visit; each theme now fetches only its own file. Geometry is unchanged.
- The landing copy button guards clipboard access, so it cannot crash where the clipboard API is unavailable, and carries type="button".
- The mobile intent-chip strip never actually scrolled (flex-wrap on a grid container); it scrolls now.
- Decorative card images no longer announce alt text that repeats the text beside them.
- A tool category missing its prominence flag silently vanished from both category carousels; compact is now simply everything not prominent.
- Template card chip rows default their id list, so an absent field in the data cannot crash the card.

Related to #1847