### PR TITLE
Add node101 to Builder Tools as a Cardano API provider

### DIFF
--- a/src/data/builder-tools/tools.js
+++ b/src/data/builder-tools/tools.js
@@ -1023,6 +1023,15 @@ export const BuilderTools = [
     category: "operations",
     properties: ["javascript", "rust"],
   },
+  {
+    title: "node101",
+    description: "Paid managed Cardano node services with REST and gRPC access, distributed request handling, monitoring, and 24/7 support. Testnet access, archive nodes, and dedicated deployments in Türkiye, Europe, and the United States are available on request.",
+    category: "api",
+    properties: ["rest", "grpc"],
+    website: "https://node101.io/en/rpc/cardano",
+    repository: null,
+    docs: null,
+  },
   // ============================================================================
   // ADD YOUR BUILDER TOOL ABOVE THIS LINE
   // Copy the template from the top of this file


### PR DESCRIPTION
## Checklist

- [x] I have read the Contributing Guidelines.
- [x] I have read the Builder Tool Requirements.
- [x] I have run `yarn build` after adding my changes without getting any errors.
- [x] I have not committed any changes to `yarn.lock`.

## Builder Tool addition

* Title: node101
* Description: Paid managed Cardano node services with REST and gRPC access, distributed request handling, monitoring, and 24/7 support. Testnet access, archive nodes, and dedicated deployments in Türkiye, Europe, and the United States are available on request.
* Category: api
* Properties: rest, grpc
* Website: https://node101.io/en/rpc/cardano
* Repository: null
* Docs: null

## Scope

Adds one entry to the end of the BuilderTools array. This is a paid hosted service with no free public RPC. The linked product page provides plans and onboarding; no public source repository or public technical documentation is claimed.

Validation: `yarn build` and `git diff --check` passed locally on 12 September 2026. No changes to `yarn.lock`.